### PR TITLE
Update spb.mdx

### DIFF
--- a/src/content/docs/ko/pg/payment-gateway/spb.mdx
+++ b/src/content/docs/ko/pg/payment-gateway/spb.mdx
@@ -175,7 +175,7 @@ attribute가 `paypal-spb`인 elemente도 2개 이상인 경우, “동일한 dat
     // 5. 결제 요청 금액이 변경되면 가맹점이 선언한 onChangeAmount 함수가 호출됩니다.
     // IMP.updateLoadUIRequest에 최종적으로 변경 된 결제 요청 데이터를 전달합니다.
     requestData.amount = document.getElementById('amount').value
-    IMP.updateLoadUIRequest(requestData)
+    IMP.updateLoadUIRequest('paypal-spb',requestData)
   }
 </script>
 ```


### PR DESCRIPTION
페이팔 연동가이드중 금액 변경시 호출되는 updateLoadUIRequest 함수 첫번째 파라미터 정의가 누락되어 있어 수정