### PR TITLE
페이코 채널 연동 문서에 정기결제 표시 추가

### DIFF
--- a/src/content/docs/ko/ready/2-pg/pg/payco.mdx
+++ b/src/content/docs/ko/ready/2-pg/pg/payco.mdx
@@ -25,7 +25,7 @@ import Tab from "~/components/gitbook/tabs/Tab.astro";
 #### 테스트 환경 구성방법
 
 1. [포트원 관리자 콘솔 로그인](https://admin.portone.io/integration)
-2. 결제연동 탭 클릭
+2. 결제 연동 탭 클릭
 3. 결제 대행사 설정에 테스트 → 페이코 → 페이코 선택 후 오른쪽 **추가** 버튼 클릭
 
 import image1 from "./_assets/payco/payco-channel-guide-1.png";
@@ -35,8 +35,8 @@ import image1 from "./_assets/payco/payco-channel-guide-1.png";
 4. 아래 MID확인 후 저장
 
 - **페이코 간편결제 결제창** 테스트 PARTNERTEST
-- **페이코 간편결제 정기결제 결제창** 테스트 AUTOPAY (정기결제)
-- 결제채널 이름 속성은 원하시는 이름으로 한글/영문 관계 없이 작성하시면 됩니다.
+- **페이코 간편결제 정기결제 결제창** 테스트 AUTOPAY
+- 결제 채널 이름 속성은 원하시는 이름으로 한글/영문 관계없이 작성하시면 됩니다.
 - 과세구분(부가세신고자료용) 설정은 정산 서비스 이용 시 설정이 필요합니다.
 
 import image2 from "./_assets/payco/payco-channel-guide-2.png";
@@ -48,7 +48,7 @@ import image2 from "./_assets/payco/payco-channel-guide-2.png";
 <Tab title="실 결제">
 #### 실 환경 구성방법
 1. [포트원 관리자 콘솔 로그인](https://admin.portone.io/integration)
-2. 결제연동 탭 클릭
+2. 결제 연동 탭 클릭
 3. 결제 대행사 설정에 실 연동 → 페이코 → 페이코 선택 후 오른쪽 **추가** 버튼 클릭
 
 import image3 from "./_assets/payco/payco-channel-guide-3.png";
@@ -57,8 +57,8 @@ import image3 from "./_assets/payco/payco-channel-guide-3.png";
 
 4. 카드사 심사 완료 후 페이코에서 발급받은 실상점 정보를 설정합니다.
 
-- 결제채널 이름 속성은 원하시는 이름으로 한글/영문 관계 없이 작성하시면 됩니다.
-- 과세구분(부가세신고자료용) 설정은 정산 서비스 이용 시 설정이 필요합니다.
+- 결제 채널 이름 속성은 원하시는 이름으로 한글/영문 관계없이 작성하시면 됩니다.
+- 과세 구분(부가세 신고자료용) 설정은 정산 서비스 이용 시 설정이 필요합니다.
 
 import image4 from "./_assets/payco/payco-channel-guide-4.png";
 

--- a/src/content/docs/ko/ready/2-pg/pg/payco.mdx
+++ b/src/content/docs/ko/ready/2-pg/pg/payco.mdx
@@ -18,7 +18,7 @@ import Tab from "~/components/gitbook/tabs/Tab.astro";
 > - 로그인(ID/PW) : payco / payco1234
 > - 경로 : 메인화면 > 화면 좌측 \[다운로드] 클릭 > \[PAYCO APP (개발용)] 클릭 > 해당 OS 다운로드
 
-## 인증결제
+## 일반결제 및 정기결제
 
 <Tabs>
 <Tab title="테스트 결제">


### PR DESCRIPTION
페이코에서 정기결제 또한 지원하지만, 제목 태그에 인증결제라고만 나와 있어 코멘트를 "일반결제 및 정기결제"로 변경하였습니다