### PR TITLE
토스 구모듈 허브형지원 이후 outdated된 내용 삭제

### DIFF
--- a/src/content/docs/ko/pg/payment-gateway/toss.mdx
+++ b/src/content/docs/ko/pg/payment-gateway/toss.mdx
@@ -96,11 +96,3 @@ IMP.request_pay(
 **에스크로 설정여부**
 
 <Codepen user="chaiport" slug="qBxbGXy" caption="토스페이먼츠 결제창 예제" />
-
-<Hint style="info">
-
-**허브형 간편결제**
-
-토스페이먼츠 결제창을 통한 간편결제(카카오,네이버페이 등)는 미 지원 되고 있습니다.
-
-</Hint>


### PR DESCRIPTION
토스 구모듈 허브형 지원하게 됨에 따라 하단에 outdated된 허브형을 지원하지 않는 다는 문구를 삭제