### PR TITLE
V2 채널 불러오기 API 문서 탭 정리

### DIFF
--- a/src/content/docs/ko/api-v2/channel.mdx
+++ b/src/content/docs/ko/api-v2/channel.mdx
@@ -115,6 +115,17 @@ PG 상점 ID
 
 </Tab>
 
+<Tab title="TossPaymentsCredential">
+**`secret_key`** <mark style="color:green;">**string**</mark>
+
+***
+
+**`client_key`** <mark style="color:green;">**string**</mark>
+
+***
+
+</Tab>
+
 <Tab title="KsnetCredential">
 **`api_key`** <mark style="color:green;">**string**</mark>
 
@@ -151,19 +162,6 @@ PG 상점 ID
 ***
 
 **`api_key`** <mark style="color:green;">**string**</mark>
-
-***
-
-</Tab>
-</Tabs>
-
-<Tabs>
-<Tab title="TossPaymentsCredential">
-**`secret_key`** <mark style="color:green;">**string**</mark>
-
-***
-
-**`client_key`** <mark style="color:green;">**string**</mark>
 
 ***
 


### PR DESCRIPTION
토스만 아래에 빠져나와있어서 다른 PG사처럼 탭으로 변경함