### PR TITLE
docs: 헥토파이낸셜 빌링키 발급 API 추가로 인한 문서 업데이트

### DIFF
--- a/src/content/docs/ko/pg/payment-gateway/settle/readme.mdx
+++ b/src/content/docs/ko/pg/payment-gateway/settle/readme.mdx
@@ -109,6 +109,21 @@ curl -H "Content-Type: application/json" \
      https://api.iamport.kr/subscribe/payments/onetime
 ```
 
+**빌링키 발급 요청하기**
+
+REST [**API POST /subscribe/customers/\{customer_uid}**](../../api/api-2/api-1)를 호출하여 빌링키 발급을 요청합니다.
+
+```sh
+curl -H "Content-Type: application/json" \
+     -X POST -d '{"card_number":"1234-1234-1234-1234", "expiry":"2025-12", "birth":"820213", "pwd_2digit":"00"}' \
+     https://api.iamport.kr/subscribe/customers/your-customer-unique-id
+```
+
+<Hint style="info">
+**세틀뱅크** [**빌링키 단독 발급 API**](../../../api/api-2/api-1)**는 별도 계약 후 사용가능합니다..**
+
+</Hint>
+
 **빌링키 발급 및 최초 결제 요청하기**
 
 REST [**API POST /subscribe/payments/onetime**](../../../api/api-4/api-1)을 호출하여 빌링키 발급과 최초 결제를 요청합니다.
@@ -130,11 +145,6 @@ curl -H "Content-Type: application/json" \
      -X POST -d '{"customer_uid":"your-customer-unique-id", "merchant_uid":"order_id_8237352", "amount":3000}' \
      https://api.iamport.kr/subscribe/payments/again
 ```
-
-<Hint style="info">
-**세틀뱅크는** [**빌링키 단독 발급 API**](../../../api/api-2/api-1)**가 지원되지 않습니다.**
-
-</Hint>
 
 **자세한 비 인증 결제 가이드는 아래 링크를 참조하세요**
 


### PR DESCRIPTION
기존에 헥토파이낸셜은 결제와 동시에 빌링키 발급만 가능했으나 빌링키만 단독으로 발급하는 API를 신규 연동함에 따라 이에 대한 내용을 추가 및 수정한 PR 입니다. ( v1 연동에만 해당됩니다. )

