### PR TITLE
페이팔 RT 링크가 잘못 연결된 텍스트 수정

### DIFF
--- a/src/content/docs/ko/pg/payment-gateway/rt.mdx
+++ b/src/content/docs/ko/pg/payment-gateway/rt.mdx
@@ -191,7 +191,7 @@ attribute가 `paypal-rt`인 elemente도 2개 이상인 경우, “동일한 data
 
 아래 링크로 반드시 유의사항을 숙지하셔야 합니다.
 
-[https://app.gitbook.com/o/nad6nqI7LNE1TGdY19Od/s/wWX2hlvRZLZrXeH1aacF/pg/payment-gateway/rt/warning](RT/warning)
+[파라미터 유의사항](../../pg/payment-gateway/rt/warning)
 
 </Hint>
 


### PR DESCRIPTION
- 페이팔 RT 유의사항 텍스트 링크가 잘못 걸려 있어 수정한 PR입니다.