### PR TITLE
`X-Content-Type-Options: nosniff` 헤더 추가

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [{ "key": "X-Content-Type-Options", "value": "nosniff" }]
+    }
+  ]
+}


### PR DESCRIPTION
mime sniff 취약점 방지를 위해 vercel 헤더설정에 `X-Content-Type-Options: nosniff` 를 추가합니다.

context: https://chai-finance.slack.com/archives/C02MEQHGG4E/p1693544481944109