### PR TITLE
docs: `POST /subscribe/payments/schedule`의 `schedule_at`이 세컨드임을 명시

### DIFF
--- a/src/content/docs/en/api/subscription-payment-api/schedule-payment-api.mdx
+++ b/src/content/docs/en/api/subscription-payment-api/schedule-payment-api.mdx
@@ -158,19 +158,19 @@ A non-zero code includes a message like 'Invalid payment info'.
 
 **`schedule_at`**  <mark style="color:red;">**\***</mark>  <mark style="color:blue;">**UNIX timestamp**</mark>
 
-**Payment scheduled at**
+**Payment scheduled at (UNIX timestamp in seconds)**
 
 
 
 **`executed_at`** <mark style="color:red;">**\***</mark>  <mark style="color:blue;">**UNIX timestamp**</mark>
 
-**Payment started at**
+**Payment started at (UNIX timestamp in seconds)**
 
 
 
 **`revoked_at`** <mark style="color:red;">**\***</mark>  <mark style="color:blue;">**UNIX timestamp**</mark>
 
-**Payment cancelled at**
+**Payment cancelled at (UNIX timestamp in seconds)**
 
 
 
@@ -273,7 +273,7 @@ A non-zero code includes a message like 'Invalid payment info'.
 > <mark style="color:red;">**\[ Required ]**</mark>
 >
 > * `merchant_uid` : Merchant order ID (Must be unique for each request)
-> * `schedule_at` : Scheduled time (UNIX timestamp)
+> * `schedule_at` : Scheduled time (UNIX timestamp in seconds)
 > * `currency` : Currency code (Example: KRW, USD, ... )
 > * `amount` : Amount
 >
@@ -300,26 +300,26 @@ A non-zero code includes a message like 'Invalid payment info'.
 [
     {
         "merchant_uid": "your_merchant_uid1",
-	"schedule_at": 1478150985,
-	"currency": "KRW",
-	"amount": 1004,
-	"name": "order name",
-	"buyer_name": "customer name",
-	"buyer_email": "customer email",
-	"buyer_tel": "customer phone number",
-	"buyer_addr": "customer address",
-	"buyer_postcode": "customer zip code"
-},
+        "schedule_at": 1478150985,
+        "currency": "KRW",
+        "amount": 1004,
+        "name": "order name",
+        "buyer_name": "customer name",
+        "buyer_email": "customer email",
+        "buyer_tel": "customer phone number",
+        "buyer_addr": "customer address",
+        "buyer_postcode": "customer zip code"
+    },
     {
         "merchant_uid": "your_merchant_uid2",
         "schedule_at": 1478150985,
-	"amount": 1004,
-	"name": "order name",
-	"buyer_name": "customer name",
-	"buyer_email": "customer email",
-	"buyer_tel": "customer phone number",
-	"buyer_addr": "customer address",
-	"buyer_postcode": "customer zip code"
+        "amount": 1004,
+        "name": "order name",
+        "buyer_name": "customer name",
+        "buyer_email": "customer email",
+        "buyer_tel": "customer phone number",
+        "buyer_addr": "customer address",
+        "buyer_postcode": "customer zip code"
     }
 ]
 ```
@@ -381,9 +381,9 @@ A non-zero code includes a message like 'Invalid payment info'.
       "customer_uid": "string",
       "merchant_uid": "string",
       "imp_uid": "string",
-      "schedule_at": "0",
-      "executed_at": "0",
-      "revoked_at": "0",
+      "schedule_at": 0,
+      "executed_at": 0,
+      "revoked_at": 0,
       "amount": 0,
       "name": "string",
       "buyer_name": "string",

--- a/src/content/docs/ko/api/subscription-payment-api/schedule-payment-api.mdx
+++ b/src/content/docs/ko/api/subscription-payment-api/schedule-payment-api.mdx
@@ -126,17 +126,17 @@ code값이 0이 아닐 때, '존재하지 않는 결제정보입니다'와 같�
 
 **포트원 결제 고유 UID**
 
-**`schedule_at`** <mark style="color:green;">**string**</mark>
+**`schedule_at`** <mark style="color:green;">**UNIX timestamp**</mark>
 
-**예약결제 실행 예정 시각 (UNIX timestamp)**
+**예약결제 실행 예정 시각(초) (UNIX timestamp in seconds)**
 
-**`executed_at`** <mark style="color:green;">**string**</mark>
+**`executed_at`** <mark style="color:green;">**UNIX timestamp**</mark>
 
-**예약결제가 실행된 시각 (UNIX timestamp)**
+**예약결제가 실행된 시각(초) (UNIX timestamp in seconds)**
 
-**`revoked_at`** <mark style="color:green;">**string**</mark>
+**`revoked_at`** <mark style="color:green;">**UNIX timestamp**</mark>
 
-**예약결제 실행을 철회한 시각 (UNIX timestamp)**
+**예약결제 실행을 철회한 시각(초) (UNIX timestamp in seconds)**
 
 **`amount`** <mark style="color:purple;">**integer**</mark>
 
@@ -218,7 +218,7 @@ code값이 0이 아닐 때, '존재하지 않는 결제정보입니다'와 같�
 > <mark style="color:red;">**\[ 필수항목 ]**</mark>
 >
 > * `merchant_uid` : 가맹점 주문번호(동일한 주문번호로 중복결제 불가) (스마트로-신모듈의 경우, 특수문자 포함이 불가능합니다.)
-> * `schedule_at` : 결제요청 예약시각 (UNIX timestamp)
+> * `schedule_at` : 결제요청 예약시각(초) (UNIX timestamp in seconds)
 > * `currency` : 결제통화 e.g.) KRW, USD, ... (단, (신) 페이팔의 경우 KRW 결제가 불가능하므로 반드시 유효한 값을 필수로 입력해야합니다.)
 > * `amount` : 결제금액
 >
@@ -247,26 +247,26 @@ code값이 0이 아닐 때, '존재하지 않는 결제정보입니다'와 같�
 [
     {
         "merchant_uid": "your_merchant_uid1",
-	"schedule_at": 1478150985,
-	"currency": "KRW",
-	"amount": 1004,
-	"name": "주문명",
-	"buyer_name": "주문자명",
-	"buyer_email": "주문자 Email주소",
-	"buyer_tel": "주문자 전화번호",
-	"buyer_addr": "주문자 주소",
-	"buyer_postcode": "주문자 우편번호"
+        "schedule_at": 1478150985,
+        "currency": "KRW",
+        "amount": 1004,
+        "name": "주문명",
+        "buyer_name": "주문자명",
+        "buyer_email": "주문자 Email주소",
+        "buyer_tel": "주문자 전화번호",
+        "buyer_addr": "주문자 주소",
+        "buyer_postcode": "주문자 우편번호"
     },
     {
         "merchant_uid": "your_merchant_uid2",
         "schedule_at": 1478150985,
-	"amount": 1004,
-	"name": "주문명",
-	"buyer_name": "주문자명",
-	"buyer_email": "주문자 Email주소",
-	"buyer_tel": "주문자 전화번호",
-	"buyer_addr": "주문자 주소",
-	"buyer_postcode": "주문자 우편번호"
+        "amount": 1004,
+        "name": "주문명",
+        "buyer_name": "주문자명",
+        "buyer_email": "주문자 Email주소",
+        "buyer_tel": "주문자 전화번호",
+        "buyer_addr": "주문자 주소",
+        "buyer_postcode": "주문자 우편번호"
     }
 ]
 ```
@@ -333,9 +333,9 @@ schedules의 상세정보
       "customer_uid": "string",
       "merchant_uid": "string",
       "imp_uid": "string",
-      "schedule_at": "0",
-      "executed_at": "0",
-      "revoked_at": "0",
+      "schedule_at": 0,
+      "executed_at": 0,
+      "revoked_at": 0,
       "amount": 0,
       "name": "string",
       "buyer_name": "string",


### PR DESCRIPTION
[정기결제 현황에 보이지 않는다](https://chai-finance.slack.com/archives/C021YGZEGS2/p1693969477110569)는 이슈가 들어와서 확인해 보니 `schedule_at`을 밀리세컨드로 요청해서 시간 변환이 잘못되어 예약이 정상적으로 이뤄지지 않은 것으로 확인됐습니다. 

```log
php > print_r(date('Y-m-d H:i:s', 1757385657224));
57659-05-03 03:33:44

php > print_r(date('Y-m-d H:i:s', 1757385657));
2025-09-09 11:40:57
```

예제에는 unix timestamp가 초 단위의 unix 타임스탬프로 나와 있지만, 사양에 세컨드인지 밀리세컨드인지 명시되어 있지 않아서, 세컨드임을 명시했습니다.

- api-iamport 스웨거 수정: https://github.com/iamport/api-iamport/pull/595