### PR TITLE
docs: V2 본인인증 연동하기 문서의 예제 코드에서 오타 수정

### DIFF
--- a/src/content/docs/ko/v2-payment/identity-verification/4.mdx
+++ b/src/content/docs/ko/v2-payment/identity-verification/4.mdx
@@ -33,14 +33,14 @@ app.use(bodyParser.json());
           apiKey: PORTONE_API_KEY, // 포트원 API Key
         },
       });
-      const { access_token } = signinResponse.data;
+      const { accessToken } = signinResponse.data;
 
       // 2. 포트원 본인인증 내역 단건조회 API 호출
       const verificationResponse = await axios({
-        url: `https://api.portone.io/identity-verifications/${identityVerificationId}?storeId=${storeId}`,
+        url: `https://api.portone.io/identity-verifications/${identityVerificationId}?store_id=${storeId}`,
         method: "get",
         // 1번에서 발급받은 액세스 토큰을 Bearer 형식에 맞게 넣어주세요.
-        headers: { "Authorization": "Bearer " + access_token },
+        headers: { "Authorization": "Bearer " + accessToken },
       });
       const identityVerification = verificationResponse.data;
       if (identityVerification.status !== "VERIFIED") {


### PR DESCRIPTION
[V2 본인인증 연동하기 4. 인증정보 조회 및 활용하기](https://developers.portone.io/docs/ko/v2-payment/identity-verification/4) 문서의 예제 코드에서 오타를 수정합니다.

- access_token > `accessToken`
  - refer: [인증 관련 API](https://developers.portone.io/docs/ko/api-v2/authorization)
- storeId > `store_id`
  - refer: [본인인증 관련 API](https://developers.portone.io/docs/ko/api-v2/identity-verification)