### PR TITLE
본인인증 문서 오타 수정

### DIFF
--- a/src/content/docs/ko/v2-payment/identity-verification/4.mdx
+++ b/src/content/docs/ko/v2-payment/identity-verification/4.mdx
@@ -33,14 +33,14 @@ app.use(bodyParser.json());
           apiKey: PORTONE_API_KEY, // 포트원 API Key
         },
       });
-      const { access_token } = signinResponse.data;
+      const { accessToken } = signinResponse.data;
 
       // 2. 포트원 본인인증 내역 단건조회 API 호출
       const verificationResponse = await axios({
         url: `https://api.portone.io/identity-verifications/${identityVerificationId}?storeId=${storeId}`,
         method: "get",
         // 1번에서 발급받은 액세스 토큰을 Bearer 형식에 맞게 넣어주세요.
-        headers: { "Authorization": "Bearer " + access_token },
+        headers: { "Authorization": "Bearer " + accessToken },
       });
       const identityVerification = verificationResponse.data;
       if (identityVerification.status !== "VERIFIED") {


### PR DESCRIPTION
본인인증 연동 문서에서 access_token -> accessToken 으로 오타를 수정합니다.

참조)
아래 PR에서 수정된 부분이며, 잘못 수정된 부분이 있어서 빠르게 해당 부분만 수정한 PR을 다시 생성하였으며 아래 PR은 Close 예정입니다. 
https://github.com/portone-io/developers.portone.io/pull/202