### PR TITLE
docs: KCP 카드사 다이렉트 경우 카드사 포인트 사용 및 할부 사용 문서 추가

### DIFF
--- a/src/content/docs/en/payment-integration-by-pg/payment-gateways/nhh-kcp.mdx
+++ b/src/content/docs/en/payment-integration-by-pg/payment-gateways/nhh-kcp.mdx
@@ -256,6 +256,11 @@ card: {
      direct: {
         code: "367",
         quota: 3
+        // When want to use points of credit card
+        // quota: 80 = 80(Hyundai Card Point installment) + 0(pay all at once)
+        // quota: 93 = 80(Hyundai Card Point installment) + 13(number of installments)
+        // quota: 60 = 60(Other Card Point installment) + 0(pay all at once)
+        // quota: 63 = 60(Other Card Point installment) + 3(number of installments)
     }
 }
 ```
@@ -263,7 +268,103 @@ card: {
 **Parameters**
 
 - **code**: [<mark style="color:red;">**Credit card code**</mark>](https://chaifinance.notion.site/53589280bbc94fab938d93257d452216?v=eb405baf52134b3f90d438e3bf763630) (**string**)
-- **quota**: Installment plan. For immediate, set to 0. (**integer**)
+- **quota**: Installment plan. For immediate, set to 0. If you want to use points of credit card, you need to add the point installment per credit card<sup style="cursor: pointer; color: red;">[1]</sup> to number of installments (**integer**)
+  <details>
+    <summary><sup style="color:red;">[1]</sup> point installment per credit card</summary>
+
+    <table border="0" cellspacing="0" cellpadding="0" width="330">
+      <tbody>
+      <tr style="height:27.0pt">
+        <td style="background:#f2f5f9;">
+          <p align="center"><b><span>Point of Credit Card<span></span></span></b></p>
+        </td>
+        <td style="background:#f2f5f9;">
+          <p align="center"><b><span>Point Installment<span></span></span></b></p>
+        </td>
+      </tr>
+      <tr style="height:13.5pt">
+        <td>
+          <p align="center"><span>Hyundai <span>M</span></span></p>
+        </td>
+        <td>
+          <p align="center"><span>+80</span></p>
+        </td>
+      </tr>
+      <tr style="height:13.5pt">
+        <td>
+          <p align="center"><span>Kookmin<span></span></span></p>
+        </td>
+        <td>
+          <p align="center"><span>+60</span></p>
+        </td>
+      </tr>
+      <tr style="height:13.5pt">
+        <td>
+          <p align="center"><span>BC<span></span></span></p>
+        </td>
+        <td>
+          <p align="center"><span>+60</span></p>
+        </td>
+      </tr>
+      <tr style="height:13.5pt">
+        <td>
+          <p align="center"><span>Samsung<span></span></span></p>
+        </td>
+        <td>
+          <p align="center"><span>+60</span></p>
+        </td>
+      </tr>
+      <tr style="height:13.5pt">
+        <td>
+          <p align="center"><span>Hana<span>/</span>KEB<span></span></span></p>
+        </td>
+        <td>
+          <p align="center"><span>+60</span></p>
+        </td>
+      </tr>
+      <tr style="height:13.5pt">
+        <td>
+          <p align="center"><span>Lotte<span></span></span></p>
+        </td>
+        <td>
+          <p align="center"><span>+60</span></p>
+        </td>
+      </tr>
+      <tr style="height:13.5pt">
+        <td>
+          <p align="center"><span>Shinhan<span></span></span></p>
+        </td>
+        <td>
+          <p align="center"><span>+60</span></p>
+        </td>
+      </tr>
+      <tr style="height:13.5pt">
+        <td>
+          <p align="center"><span>NongHyup<span></span></span></p>
+        </td>
+        <td>
+          <p align="center"><span>+60</span></p>
+        </td>
+      </tr>
+      <tr style="height:13.5pt">
+        <td>
+          <p align="center"><span>Citi<span></span></span></p>
+        </td>
+        <td>
+          <p align="center"><span>+60</span></p>
+        </td>
+      </tr>
+      <tr style="height:13.5pt">
+        <td>
+          <p align="center"><span>Woori<span></span></span></p>
+        </td>
+        <td>
+          <p align="center"><span>+60</span></p>
+        </td>
+      </tr>
+      </tbody>
+    </table>
+  </details>
 
 <Hint style="danger">
 **Precautions**

--- a/src/content/docs/ko/pg/payment-gateway/nhn-kcp.mdx
+++ b/src/content/docs/ko/pg/payment-gateway/nhn-kcp.mdx
@@ -261,6 +261,11 @@ display: {
     direct: {
       code: "367",
       quota: 3
+      // 카드사 포인트 사용 경우
+      // quota: 80 = 80(현대카드 포인트 할부개월) + 0(일시불)
+      // quota: 93 = 80(현대카드 포인트 할부개월) + 13개월 할부
+      // quota: 60 = 60(기타카드 포인트 할부개월) + 0(일시불)
+      // quota: 63 = 60(기타카드 포인트 할부개월) + 3개월 할부
     }
   },
   company: "가맹점", // 해당 파라미터를 설정하지 않으면  카드사 모듈 창에 import 로 표기
@@ -270,7 +275,103 @@ display: {
 **파라미터 설명**
 
 - **code**: 카드사 금융결제원 표준 코드. [<mark style="color:red;">**링크**</mark>](https://faq.portone.io/6503bcb4-4a61-4cf3-afd8-5d913b1385a6) 참조 (**string**)
-- **quota**: 할부 개월 수. 일시불일 시 0 으로 지정. (**integer**)
+- **quota**: 할부 개월 수. 일시불일 시 0 으로 지정. 만약, 신용 카드사 포인트를 사용할 경우 카드사별 포인트 할부개월<sup style="cursor: pointer; color: red;">[1]</sup>을 할부 개월 수에 더해줘야 합니다. (**integer**)
+  <details>
+    <summary><sup style="color:red;">[1]</sup> 카드사별 포인트 할부개월</summary>
+
+    <table border="0" cellspacing="0" cellpadding="0" width="237">
+      <tbody>
+      <tr style="height:27.0pt">
+        <td width="114" style="background:#f2f5f9;">
+          <p align="center"><b><span>카드사 포인트<span></span></span></b></p>
+        </td>
+        <td width="123" style="background:#f2f5f9;">
+          <p align="center"><b><span>포인트 할부개월<span></span></span></b></p>
+        </td>
+      </tr>
+      <tr style="height:13.5pt">
+        <td width="114">
+          <p align="center"><span>현대<span>M</span></span></p>
+        </td>
+        <td width="123">
+          <p align="center"><span>+80</span></p>
+        </td>
+      </tr>
+      <tr style="height:13.5pt">
+        <td width="114">
+          <p align="center"><span>국민<span></span></span></p>
+        </td>
+        <td width="123">
+          <p align="center"><span>+60</span></p>
+        </td>
+      </tr>
+      <tr style="height:13.5pt">
+        <td width="114">
+          <p align="center"><span>비씨<span></span></span></p>
+        </td>
+        <td width="123">
+          <p align="center"><span>+60</span></p>
+        </td>
+      </tr>
+      <tr style="height:13.5pt">
+        <td width="114">
+          <p align="center"><span>삼성<span></span></span></p>
+        </td>
+        <td width="123">
+          <p align="center"><span>+60</span></p>
+        </td>
+      </tr>
+      <tr style="height:13.5pt">
+        <td width="114">
+          <p align="center"><span>하나<span>/</span>외환<span></span></span></p>
+        </td>
+        <td width="123">
+          <p align="center"><span>+60</span></p>
+        </td>
+      </tr>
+      <tr style="height:13.5pt">
+        <td width="114">
+          <p align="center"><span>롯데<span></span></span></p>
+        </td>
+        <td width="123">
+          <p align="center"><span>+60</span></p>
+        </td>
+      </tr>
+      <tr style="height:13.5pt">
+        <td width="114">
+          <p align="center"><span>신한<span></span></span></p>
+        </td>
+        <td width="123">
+          <p align="center"><span>+60</span></p>
+        </td>
+      </tr>
+      <tr style="height:13.5pt">
+        <td width="114">
+          <p align="center"><span>농협<span></span></span></p>
+        </td>
+        <td width="123">
+          <p align="center"><span>+60</span></p>
+        </td>
+      </tr>
+      <tr style="height:13.5pt">
+        <td width="114">
+          <p align="center"><span>씨티<span></span></span></p>
+        </td>
+        <td width="123">
+          <p align="center"><span>+60</span></p>
+        </td>
+      </tr>
+      <tr style="height:13.5pt">
+        <td width="114">
+          <p align="center"><span>우리<span></span></span></p>
+        </td>
+        <td width="123">
+          <p align="center"><span>+60</span></p>
+        </td>
+      </tr>
+      </tbody>
+    </table>
+  </details>
 
 <Hint style="danger">
 **주의사항**


### PR DESCRIPTION
KCP 다이렉트 경우 카드사 포인트 사용시 `카드사 포인트할부`라는 값을 `할부 개월수`에 더해서 요청을 해야 해서, 해당 내용을 문서에 추가했습니다. 

아래는 참고 캡처입니다.

### 한국어 

<img width="721" alt="image" src="https://github.com/portone-io/developers.portone.io/assets/28570432/48e1dc6c-95eb-4f84-b3bd-452a77dd6993">

<img width="712" alt="image" src="https://github.com/portone-io/developers.portone.io/assets/28570432/c06c67a1-8c36-467a-8c5c-943b439c46fd">

### 영문

<img width="735" alt="image" src="https://github.com/portone-io/developers.portone.io/assets/28570432/a1e3c7dc-ebdf-4882-bd99-0e60d985e0ff">

<img width="695" alt="image" src="https://github.com/portone-io/developers.portone.io/assets/28570432/748356c3-e281-456e-ab1f-7b9ec990e909">
