### PR TITLE
Update paymentwall.mdx

### DIFF
--- a/src/content/docs/ko/pg/payment-gateway/paymentwall.mdx
+++ b/src/content/docs/ko/pg/payment-gateway/paymentwall.mdx
@@ -131,7 +131,7 @@ IMP.request_pay(
     pay_method: "card", // 빌링키 결제는 오직 신용카드만 가능합니다.
     merchant_uid: "order_monthly_0001", // 상점에서 관리하는 주문 번호
     name: "최초인증결제",
-    amount: 20, // 결제창에 표시될 금액. 실제 승인이 이뤄지지는 않습니다.
+    amount: 20, // 빌링키 발급과 함께 최초 승인이 같이 이루어집니다.
     currency: "USD", // 필수 파라미터
     customer_uid: "your-customer-unique-id", // 필수 입력
     buyer_email: "test@portone.io", // 빌링키 발급시 기재한 주소와 빌링키 결제할때 기재한 주소가 동일해야 합니다.


### PR DESCRIPTION
페이먼트월의 비인증결제의 경우 최초 승인이 같이 이루어 지는데, 화면표시용이라고 잘못 안내 되어 있어 이를 수정합니다.