### PR TITLE
사파리에서 <details> 못생기게 보이는 문제 수정

### DIFF
--- a/src/layouts/ArticleStyle.astro
+++ b/src/layouts/ArticleStyle.astro
@@ -40,6 +40,9 @@
     margin-bottom: 1em;
     color: rgba(156, 163, 175); /* text-gray */
   }
+  article details summary::-webkit-details-marker {
+    display: none;
+  }
   article table {
     margin-top: 0.5rem; /* my-2 */
     margin-bottom: 0.5rem; /* my-2 */


### PR DESCRIPTION
### before
<img width="322" alt="before" src="https://github.com/portone-io/developers.portone.io/assets/690661/99dd7de0-6bfe-4031-a0d5-93c4681e346e">

### after
<img width="299" alt="after" src="https://github.com/portone-io/developers.portone.io/assets/690661/bfe6034b-d7b3-4b10-b34a-6a154ed3ca7e">
