### PR TITLE
fix: typo (웹훅 재발송)

### DIFF
--- a/src/content/docs/ko/console/guide/list.mdx
+++ b/src/content/docs/ko/console/guide/list.mdx
@@ -143,6 +143,6 @@ description: 결제가 이루어진 거래내역을 조회할 수 있는 메뉴�
   * 환불계좌 계좌번호
   * 환불계좌 예금주
 
-## 웹훅 재발
+## 웹훅 재발송
 
 ![](</gitbook-assets/ko/Screen Shot 2022-06-20 at 8.44.01 PM.png>)


### PR DESCRIPTION
기술 지원 > 관리자 콘솔 > 결제 내역 에서 `웹훅 재발`으로 오타가 있어 `웹훅 재발송` 으로 수정합니다.

<img width="714" alt="image" src="https://github.com/portone-io/developers.portone.io/assets/20654188/4050cd19-bbc0-4d0f-997a-9774f9461031">
