### PR TITLE
api 문서에서 format 필드가 있는 속성 문서를 좀 더 친절하게 보여줌

### DIFF
--- a/src/layouts/rest-api/category/type-def.tsx
+++ b/src/layouts/rest-api/category/type-def.tsx
@@ -234,7 +234,7 @@ export function ReqPropertiesDoc({
                 bgColor="white"
               />
             )),
-            <hr />
+            <hr />,
           )
         : null}
     </div>
@@ -262,7 +262,11 @@ function PropertyDoc({
     "";
   const deprecated = Boolean(property.deprecated);
   return (
-    <div class={`text-14px flex flex-col gap-2 p-2 ${deprecated ? "opacity-50" : ""}`}>
+    <div
+      class={`text-14px flex flex-col gap-2 p-2 ${
+        deprecated ? "opacity-50" : ""
+      }`}
+    >
       <div class="flex items-center justify-between gap-4">
         <div>
           <div class="mr-4 inline-block font-mono font-bold leading-tight">
@@ -292,7 +296,34 @@ function TypeReprDoc({ basepath, def }: TypeReprDocProps) {
   const typeRepr = repr(def);
   const isUserType = typeRepr[0]?.toUpperCase() === typeRepr[0];
   if (!isUserType) {
-    return <span class="text-green-6 font-bold">{typeRepr}</span>;
+    if (typeof def !== "string" && "format" in def) {
+      const format = (() => {
+        switch (def.format) {
+          case "int32":
+            return "(32 bit)";
+          case "int64":
+            return "(64 bit)";
+          case "date-time":
+            return (
+              <a
+                class="underline-offset-4 hover:underline"
+                target="_blank"
+                href="https://ko.wikipedia.org/wiki/ISO_8601"
+              >
+                (ISO 8601)
+              </a>
+            );
+          default:
+            return "";
+        }
+      })();
+      return (
+        <span class="inline-block text-green-6 font-bold">
+          {typeRepr} <span class="font-normal">{format}</span>
+        </span>
+      );
+    }
+    return <span class="inline-block text-green-6 font-bold">{typeRepr}</span>;
   }
   const typeName = typeRepr.replace("[]", "");
   const href = `${basepath}/type-def#${typeName}`;

--- a/src/layouts/rest-api/schema-utils/type-def.ts
+++ b/src/layouts/rest-api/schema-utils/type-def.ts
@@ -36,6 +36,7 @@ export interface Property {
   summary?: string | undefined;
   description?: string | undefined;
   type?: string | undefined;
+  format?: string | undefined;
   items?: string | TypeDef | undefined;
   deprecated?: boolean | undefined;
   /**
@@ -73,7 +74,7 @@ export function bakeProperties(schema: any, typeDef: TypeDef): BakedProperty[] {
 
 export function resolveTypeDef(
   schema: any,
-  typeDef: TypeDef | Property
+  typeDef: TypeDef | Property,
 ): TypeDef {
   return mergeAllOf(schema, followRef(schema, typeDef));
 }
@@ -121,7 +122,7 @@ export function repr(def: string | TypeDef | Property | Parameter): string {
 
 export function crawlRefs(
   schema: any,
-  endpointGroups: CategoryEndpointsPair[]
+  endpointGroups: CategoryEndpointsPair[],
 ): string[] {
   const result = new Set<string>();
   const rootPropertyRefsCrawler: Visitor = {


### PR DESCRIPTION
| before | after |
| --- | --- |
| ![image](https://github.com/portone-io/developers.portone.io/assets/690661/74525fa8-8326-45f1-b9f9-5125a477769d) | ![image](https://github.com/portone-io/developers.portone.io/assets/690661/af6dc645-69c5-4f1d-9652-e41d47b0cfb4) |