### PR TITLE
docs: x-portone-summary를 x-portone-description 으로 일괄 치환

### DIFF
--- a/src/schema/v1.openapi.json
+++ b/src/schema/v1.openapi.json
@@ -39,8 +39,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "REST API KEY",
-            "x-portone-summary": "<p>REST API 키로 포트원 관리자 페이지의 <code>상점 ・ 계정 관리</code> -&gt; <code>내 식별코드 ・ API Keys</code>에서 확인하실 수 있습니다 : <a href=\"https://admin.portone.io\" rel=\"noopener noreferrer\">https://admin.portone.io</a></p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>REST API 키로 포트원 관리자 페이지의 <code>상점 ・ 계정 관리</code> -&gt; <code>내 식별코드 ・ API Keys</code>에서 확인하실 수 있습니다 : <a href=\"https://admin.portone.io\" rel=\"noopener noreferrer\">https://admin.portone.io</a></p>\n"
           },
           {
             "name": "imp_secret",
@@ -49,8 +48,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "REST API SECRET",
-            "x-portone-summary": "<p>REST API Secret으로 포트원 관리자 페이지의 <code>상점 ・ 계정 관리</code> -&gt; <code>내 식별코드 ・ API Keys</code>에서 확인하실 수 있습니다 : <a href=\"https://admin.portone.io\" rel=\"noopener noreferrer\">https://admin.portone.io</a></p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>REST API Secret으로 포트원 관리자 페이지의 <code>상점 ・ 계정 관리</code> -&gt; <code>내 식별코드 ・ API Keys</code>에서 확인하실 수 있습니다 : <a href=\"https://admin.portone.io\" rel=\"noopener noreferrer\">https://admin.portone.io</a></p>\n"
           }
         ],
         "responses": {
@@ -90,8 +88,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "계정 아이디",
-            "x-portone-summary": "<p>베네피아 계정 아이디</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>베네피아 계정 아이디</p>\n"
           },
           {
             "name": "benepia_password",
@@ -100,8 +97,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "계정 비밀번호",
-            "x-portone-summary": "<p>베네피아 계정 비밀번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>베네피아 계정 비밀번호</p>\n"
           },
           {
             "name": "pg",
@@ -110,8 +106,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "PG 구분코드",
-            "x-portone-summary": "<p>사용하고자 하는 PG사 구분코드</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>사용하고자 하는 PG사 구분코드</p>\n"
           }
         ],
         "responses": {
@@ -157,8 +152,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "계정 아이디",
-            "x-portone-summary": "<p>베네피아 계정 아이디</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>베네피아 계정 아이디</p>\n"
           },
           {
             "name": "benepia_password",
@@ -167,8 +161,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "계정 비밀번호",
-            "x-portone-summary": "<p>베네피아 계정 비밀번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>베네피아 계정 비밀번호</p>\n"
           },
           {
             "name": "merchant_uid",
@@ -188,8 +181,7 @@
             "required": true,
             "type": "number",
             "x-portone-name": "결제요청금액",
-            "x-portone-summary": "<p>결제 요청하고자 하는 금액</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>결제 요청하고자 하는 금액</p>\n"
           },
           {
             "name": "name",
@@ -199,8 +191,7 @@
             "type": "string",
             "maxLength": 40,
             "x-portone-name": "주문명",
-            "x-portone-summary": "<p>주문명</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>주문명</p>\n"
           },
           {
             "name": "buyer_name",
@@ -210,8 +201,7 @@
             "type": "string",
             "maxLength": 16,
             "x-portone-name": "주문자명",
-            "x-portone-summary": "<p>주문자명</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>주문자명</p>\n"
           },
           {
             "name": "buyer_email",
@@ -221,8 +211,7 @@
             "type": "string",
             "maxLength": 64,
             "x-portone-name": "주문자 Email 주소",
-            "x-portone-summary": "<p>주문자 Email주소</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>주문자 Email주소</p>\n"
           },
           {
             "name": "buyer_tel",
@@ -232,8 +221,7 @@
             "type": "string",
             "maxLength": 16,
             "x-portone-name": "주문자 전화번호",
-            "x-portone-summary": "<p>주문자 전화번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>주문자 전화번호</p>\n"
           },
           {
             "name": "buyer_addr",
@@ -243,8 +231,7 @@
             "type": "string",
             "maxLength": 128,
             "x-portone-name": "주문자 주소",
-            "x-portone-summary": "<p>주문자 주소</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>주문자 주소</p>\n"
           },
           {
             "name": "buyer_postcode",
@@ -254,8 +241,7 @@
             "type": "string",
             "maxLength": 8,
             "x-portone-name": "주문자 우편번호",
-            "x-portone-summary": "<p>주문자 우편번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>주문자 우편번호</p>\n"
           },
           {
             "name": "pg",
@@ -264,7 +250,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "PG 구분코드",
-            "x-portone-summary": "<p>사용하고자 하는 PG사 구분코드</p>\n"
+            "x-portone-description": "<p>사용하고자 하는 PG사 구분코드</p>\n"
           },
           {
             "name": "notice_url",
@@ -273,7 +259,7 @@
             "required": false,
             "type": "array",
             "x-portone-name": "Notification URL(Webhook URL)",
-            "x-portone-summary": "<p>웹훅을 수신하고자 하는 URL</p>\n"
+            "x-portone-description": "<p>웹훅을 수신하고자 하는 URL</p>\n"
           },
           {
             "name": "custom_data",
@@ -329,8 +315,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "포트원 인증 고유번호",
-            "x-portone-summary": "<p>본인인증 결과로 리턴 받은 포트원 인증 고유번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>본인인증 결과로 리턴 받은 포트원 인증 고유번호</p>\n"
           }
         ],
         "responses": {
@@ -376,8 +361,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "포트원 인증 고유번호",
-            "x-portone-summary": "<p>본인인증 결과로 리턴받은 포트원 인증 고유번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>본인인증 결과로 리턴받은 포트원 인증 고유번호</p>\n"
           }
         ],
         "responses": {
@@ -428,8 +412,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "성명",
-            "x-portone-summary": "<p>본인인증 대상자 성명</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>본인인증 대상자 성명</p>\n"
           },
           {
             "name": "phone",
@@ -484,8 +467,7 @@
             "type": "boolean",
             "default": "false",
             "x-portone-name": "알뜰폰 사용 여부",
-            "x-portone-summary": "<p>본인인증 대상자 알뜰폰 사용 여부</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>본인인증 대상자 알뜰폰 사용 여부</p>\n"
           },
           {
             "name": "company",
@@ -504,8 +486,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "가맹점 주문번호",
-            "x-portone-summary": "<p>본인인증 요청건을 식별하기 위한 가맹점 주문번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>본인인증 요청건을 식별하기 위한 가맹점 주문번호</p>\n"
           },
           {
             "name": "pg",
@@ -564,8 +545,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "포트원 인증 고유번호",
-            "x-portone-summary": "<p>본인인증 요청 API 요청 후 응답된 인증 고유번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>본인인증 요청 API 요청 후 응답된 인증 고유번호</p>\n"
           },
           {
             "name": "otp",
@@ -574,8 +554,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "본인인증 번호",
-            "x-portone-summary": "<p>SMS로 전송된 본인인증 번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>SMS로 전송된 본인인증 번호</p>\n"
           }
         ],
         "responses": {
@@ -632,8 +611,7 @@
             "collectionFormat": "multi",
             "default": "customer_1234",
             "x-portone-name": "구매자의 결제 수단 식별 고유번호",
-            "x-portone-summary": "<p>빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n"
           }
         ],
         "responses": {
@@ -715,8 +693,7 @@
             "type": "string",
             "default": "customer_1234",
             "x-portone-name": "구매자의 결제 수단 식별 고유번호",
-            "x-portone-summary": "<p>빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n"
           }
         ],
         "responses": {
@@ -792,8 +769,7 @@
             "default": "customer_1234",
             "maxLength": 80,
             "x-portone-name": "구매자의 결제 수단 식별 고유번호",
-            "x-portone-summary": "<p>빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n"
           },
           {
             "name": "pg",
@@ -803,7 +779,7 @@
             "type": "string",
             "maxLength": 80,
             "x-portone-name": "PG 구분코드",
-            "x-portone-summary": "<p>빌링키 발급을 받고자 하는 PG사 구분코드</p>\n"
+            "x-portone-description": "<p>빌링키 발급을 받고자 하는 PG사 구분코드</p>\n"
           },
           {
             "name": "customer_id",
@@ -812,8 +788,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "구매자 ID",
-            "x-portone-summary": "<p>구매자 식별 고유 번호</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>구매자 식별 고유 번호</p>\n",
             "x-portone-per-pg": {
               "tosspayments": {
                 "required": true,
@@ -828,8 +803,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "카드번호",
-            "x-portone-summary": "<p>빌링키 발급 하고자 하는 카드의 번호(<code>dddd-dddd-dddd-dddd</code>)</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>빌링키 발급 하고자 하는 카드의 번호(<code>dddd-dddd-dddd-dddd</code>)</p>\n"
           },
           {
             "name": "expiry",
@@ -838,8 +812,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "카드 유효기간",
-            "x-portone-summary": "<p>빌링키 발급 하고자 하는 카드 유효기간(<code>YYYY-MM</code>)</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>빌링키 발급 하고자 하는 카드 유효기간(<code>YYYY-MM</code>)</p>\n"
           },
           {
             "name": "birth",
@@ -878,8 +851,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "카드 인증번호",
-            "x-portone-summary": "<p>빌링키 발급 받고자 하는 카드 카드 뒷면 3자리, AMEX의 경우 4자리</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>빌링키 발급 받고자 하는 카드 카드 뒷면 3자리, AMEX의 경우 4자리</p>\n",
             "x-portone-supported-pgs": [
               "paymentwall"
             ],
@@ -897,8 +869,7 @@
             "type": "string",
             "maxLength": 20,
             "x-portone-name": "카드소유자명",
-            "x-portone-summary": "<p>고객(카드소지자) 관리용 성함</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>고객(카드소지자) 관리용 성함</p>\n",
             "x-portone-per-pg": {
               "welcome": {
                 "required": true
@@ -913,8 +884,7 @@
             "type": "string",
             "maxLength": 20,
             "x-portone-name": "카드소유자 연락처",
-            "x-portone-summary": "<p>고객(카드소지자) 전화번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>고객(카드소지자) 전화번호</p>\n"
           },
           {
             "name": "customer_email",
@@ -924,8 +894,7 @@
             "type": "string",
             "maxLength": 200,
             "x-portone-name": "카드소유자 이메일주소",
-            "x-portone-summary": "<p>고객(카드소지자) Email</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>고객(카드소지자) Email</p>\n"
           },
           {
             "name": "customer_addr",
@@ -935,8 +904,7 @@
             "type": "string",
             "maxLength": 200,
             "x-portone-name": "카드소유자 주소",
-            "x-portone-summary": "<p>고객(카드소지자) 주소</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>고객(카드소지자) 주소</p>\n"
           },
           {
             "name": "customer_postcode",
@@ -946,8 +914,7 @@
             "type": "string",
             "maxLength": 8,
             "x-portone-name": "카드소유자 우편번호",
-            "x-portone-summary": "<p>고객(카드소지자) 우편번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>고객(카드소지자) 우편번호</p>\n"
           }
         ],
         "responses": {
@@ -997,8 +964,7 @@
             "type": "string",
             "default": "customer_1234",
             "x-portone-name": "구매자의 결제 수단 식별 고유번호",
-            "x-portone-summary": "<p>빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n"
           },
           {
             "name": "reason",
@@ -1007,8 +973,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "삭제 사유",
-            "x-portone-summary": "<p>빌링키를 삭제하려는 사유</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>빌링키를 삭제하려는 사유</p>\n"
           },
           {
             "name": "extra[requester]",
@@ -1018,8 +983,7 @@
             "type": "string",
             "default": "admin",
             "x-portone-name": "삭제 요청자",
-            "x-portone-summary": "<p>빌링키 삭제 요청자</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>빌링키 삭제 요청자</p>\n",
             "x-portone-supported-pgs": [
               "naverpay"
             ]
@@ -1094,8 +1058,7 @@
             "type": "string",
             "default": "customer_1234",
             "x-portone-name": "구매자의 결제 수단 식별 고유번호",
-            "x-portone-summary": "<p>빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n"
           },
           {
             "name": "page",
@@ -1105,8 +1068,7 @@
             "type": "integer",
             "default": "1",
             "x-portone-name": "조회목록 페이징",
-            "x-portone-summary": "<p>조회목록 페이징으로 기본값은 1입니다.</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>조회목록 페이징으로 기본값은 1입니다.</p>\n"
           }
         ],
         "responses": {
@@ -1177,8 +1139,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "구매자의 결제 수단 식별 고유번호",
-            "x-portone-summary": "<p>결제예약에 사용된 구매자의 결제 수단 식별 고유번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>결제예약에 사용된 구매자의 결제 수단 식별 고유번호</p>\n"
           },
           {
             "name": "page",
@@ -1187,8 +1148,7 @@
             "required": false,
             "type": "integer",
             "x-portone-name": "조회목록 페이징",
-            "x-portone-summary": "<p>조회목록 페이징으로 기본값은 1입니다.</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>조회목록 페이징으로 기본값은 1입니다.</p>\n"
           },
           {
             "name": "from",
@@ -1197,8 +1157,7 @@
             "required": true,
             "type": "integer",
             "x-portone-name": "조회 시작시각",
-            "x-portone-summary": "<p>unix timestamp(결제예약건의 '예약시각'기준으로 조회합니다. from &lt;= '예약시각')</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>unix timestamp(결제예약건의 '예약시각'기준으로 조회합니다. from &lt;= '예약시각')</p>\n"
           },
           {
             "name": "to",
@@ -1207,8 +1166,7 @@
             "required": true,
             "type": "integer",
             "x-portone-name": "조회 종료시각",
-            "x-portone-summary": "<p>unix timestamp(결제예약건의 '예약시각'기준으로 조회합니다. '예약시각' &lt; to)</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>unix timestamp(결제예약건의 '예약시각'기준으로 조회합니다. '예약시각' &lt; to)</p>\n"
           },
           {
             "name": "schedule-status",
@@ -1222,7 +1180,7 @@
               "revoked"
             ],
             "x-portone-name": "예약상태",
-            "x-portone-summary": "<p>조회 하고자 하는 예약 상태</p>\n"
+            "x-portone-description": "<p>조회 하고자 하는 예약 상태</p>\n"
           }
         ],
         "responses": {
@@ -1304,8 +1262,7 @@
             "required": true,
             "type": "number",
             "x-portone-name": "결제금액",
-            "x-portone-summary": "<p>결제하고자 하는 금액</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>결제하고자 하는 금액</p>\n"
           },
           {
             "name": "barcode",
@@ -1314,8 +1271,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "바코드",
-            "x-portone-summary": "<p>가맹점에서 직접 생성, 관리하는 바코드(barcode)번호가 있는 경우, 갤럭시아컴즈로부터 신규 수납번호(barcode)를 발급요청하지 않고 가맹점에서 관리하는 바코드(barcode)번호를 등록하여 수납번호로 활용할 수 있습니다.</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>가맹점에서 직접 생성, 관리하는 바코드(barcode)번호가 있는 경우, 갤럭시아컴즈로부터 신규 수납번호(barcode)를 발급요청하지 않고 가맹점에서 관리하는 바코드(barcode)번호를 등록하여 수납번호로 활용할 수 있습니다.</p>\n"
           },
           {
             "name": "expired_at",
@@ -1324,8 +1280,7 @@
             "required": false,
             "type": "integer",
             "x-portone-name": "편의점 수납가능한 결제기한",
-            "x-portone-summary": "<p>편의점 수납가능한 결제기한(Unix Timestamp). 정의하지 않으면 갤럭시아컴즈와 계약시 협의한 기본값이 적용됩니다.</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>편의점 수납가능한 결제기한(Unix Timestamp). 정의하지 않으면 갤럭시아컴즈와 계약시 협의한 기본값이 적용됩니다.</p>\n"
           },
           {
             "name": "name",
@@ -1335,8 +1290,7 @@
             "type": "string",
             "maxLength": 40,
             "x-portone-name": "주문명",
-            "x-portone-summary": "<p>주문명</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>주문명</p>\n"
           },
           {
             "name": "buyer_name",
@@ -1346,8 +1300,7 @@
             "type": "string",
             "maxLength": 16,
             "x-portone-name": "주문자명",
-            "x-portone-summary": "<p>주문자의 이름</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>주문자의 이름</p>\n"
           },
           {
             "name": "buyer_email",
@@ -1357,8 +1310,7 @@
             "type": "string",
             "maxLength": 64,
             "x-portone-name": "주문자 Email 주소",
-            "x-portone-summary": "<p>주문자 Email 주소</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>주문자 Email 주소</p>\n"
           },
           {
             "name": "buyer_tel",
@@ -1368,8 +1320,7 @@
             "type": "string",
             "maxLength": 16,
             "x-portone-name": "주문자 전화번호",
-            "x-portone-summary": "<p>주문자 전화번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>주문자 전화번호</p>\n"
           },
           {
             "name": "buyer_addr",
@@ -1379,8 +1330,7 @@
             "type": "string",
             "maxLength": 128,
             "x-portone-name": "주문자 주소",
-            "x-portone-summary": "<p>주문자의 주소</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>주문자의 주소</p>\n"
           },
           {
             "name": "buyer_postcode",
@@ -1390,8 +1340,7 @@
             "type": "string",
             "maxLength": 8,
             "x-portone-name": "주문자 우편번호",
-            "x-portone-summary": "<p>주문자의 우편번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>주문자의 우편번호</p>\n"
           },
           {
             "name": "pg",
@@ -1400,7 +1349,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "PG 구분코드",
-            "x-portone-summary": "<p>결제 하고자 하는 PG사 구분코드</p>\n"
+            "x-portone-description": "<p>결제 하고자 하는 PG사 구분코드</p>\n"
           },
           {
             "name": "confirm_url",
@@ -1409,7 +1358,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "수납가능여부 체크 URL",
-            "x-portone-summary": "<p>고객이 편의점결제 수납시도 시 수납가능여부를 체크하기 위한 URL</p>\n"
+            "x-portone-description": "<p>고객이 편의점결제 수납시도 시 수납가능여부를 체크하기 위한 URL</p>\n"
           },
           {
             "name": "notice_url",
@@ -1418,7 +1367,7 @@
             "required": false,
             "type": "array",
             "x-portone-name": "Notification URL(Webhook URL)",
-            "x-portone-summary": "<p>편의점결제 수납성공 시 통지받을 URL</p>\n"
+            "x-portone-description": "<p>편의점결제 수납성공 시 통지받을 URL</p>\n"
           },
           {
             "name": "custom_data",
@@ -1427,8 +1376,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "추가정보",
-            "x-portone-summary": "<p>결제정보와 함께 저장할 custom_data. 객체로 전달되는 경우 JSON 문자열로 저장</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>결제정보와 함께 저장할 custom_data. 객체로 전달되는 경우 JSON 문자열로 저장</p>\n"
           }
         ],
         "responses": {
@@ -1470,9 +1418,8 @@
             "description": "편의점결제 수납번호(barcode) 발급/등록된 포트원 거래고유번호",
             "required": true,
             "type": "string",
-            "x-portone-summary": "<p>편의점결제 수납번호(barcode) 발급/등록된 포트원 거래고유번호</p>\n",
-            "x-portone-name": "포트원 거래고유번호",
-            "x-portone-description": ""
+            "x-portone-description": "<p>편의점결제 수납번호(barcode) 발급/등록된 포트원 거래고유번호</p>\n",
+            "x-portone-name": "포트원 거래고유번호"
           }
         ],
         "responses": {
@@ -1516,8 +1463,7 @@
             "type": "string",
             "default": "imp_12345678912",
             "x-portone-name": "포트원 거래고유번호",
-            "x-portone-summary": "<p>배송정보를 조회하고자 하는 에스크로 결제건의 포트원 거래고유번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>배송정보를 조회하고자 하는 에스크로 결제건의 포트원 거래고유번호</p>\n"
           }
         ],
         "responses": {
@@ -1577,8 +1523,7 @@
             "type": "string",
             "default": "imp_12345678912",
             "x-portone-name": "포트원 거래고유번호",
-            "x-portone-summary": "<p>배송정보를 수정하고자 하는 에스크로 결제건의 포트원 거래고유번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>배송정보를 수정하고자 하는 에스크로 결제건의 포트원 거래고유번호</p>\n"
           },
           {
             "name": "sender",
@@ -1590,8 +1535,7 @@
             },
             "type": "string",
             "x-portone-name": "발신자 정보",
-            "x-portone-summary": "<p>배송을 보내는 발신자의 정보(<strong>이름, 연락처, 주소, 우편번호, 수신자와의 관계</strong>)</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>배송을 보내는 발신자의 정보(<strong>이름, 연락처, 주소, 우편번호, 수신자와의 관계</strong>)</p>\n"
           },
           {
             "name": "receiver",
@@ -1603,8 +1547,7 @@
             },
             "type": "string",
             "x-portone-name": "수신자 정보",
-            "x-portone-summary": "<p>배송을 받는 수신자의 정보(<strong>이름, 연락처, 주소, 우편번호</strong>)</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>배송을 받는 수신자의 정보(<strong>이름, 연락처, 주소, 우편번호</strong>)</p>\n"
           },
           {
             "name": "logis",
@@ -1616,8 +1559,7 @@
             },
             "type": "string",
             "x-portone-name": "배송정보",
-            "x-portone-summary": "<p>택배사코드표는 <a href=\"https://developers.portone.io/docs/ko/tip/code\" rel=\"noopener noreferrer\">메뉴얼</a> 참조</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>택배사코드표는 <a href=\"https://developers.portone.io/docs/ko/tip/code\" rel=\"noopener noreferrer\">메뉴얼</a> 참조</p>\n"
           },
           {
             "name": "products",
@@ -1630,8 +1572,7 @@
             },
             "collectionFormat": "multi",
             "x-portone-name": "배송 상품 정보",
-            "x-portone-summary": "<p>배송 보내는 상품의 정보 <strong>(고유 아이디, 이름, 고유 코드, 통화코드, 수량, 카테고리)</strong></p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>배송 보내는 상품의 정보 <strong>(고유 아이디, 이름, 고유 코드, 통화코드, 수량, 카테고리)</strong></p>\n",
             "x-portone-supported-pgs": [
               "welcome"
             ],
@@ -1701,7 +1642,7 @@
             "type": "string",
             "default": "imp_12345678912",
             "x-portone-name": "포트원 거래고유번호",
-            "x-portone-summary": "<p>배송정보를 등록하고자 하는 에스크로 결제건의 포트원 거래고유번호</p>\n"
+            "x-portone-description": "<p>배송정보를 등록하고자 하는 에스크로 결제건의 포트원 거래고유번호</p>\n"
           },
           {
             "name": "sender",
@@ -1713,8 +1654,7 @@
             },
             "type": "string",
             "x-portone-name": "발신자 정보",
-            "x-portone-summary": "<p>배송을 보내는 발신자의 정보(<strong>이름, 연락처, 주소, 우편번호, 발신자와의 관계</strong>)</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>배송을 보내는 발신자의 정보(<strong>이름, 연락처, 주소, 우편번호, 발신자와의 관계</strong>)</p>\n"
           },
           {
             "name": "receiver",
@@ -1726,8 +1666,7 @@
             },
             "type": "string",
             "x-portone-name": "수신자 정보",
-            "x-portone-summary": "<p>배송을 받는 수신자의 정보(<strong>이름, 연락처, 주소, 우편번호</strong>)</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>배송을 받는 수신자의 정보(<strong>이름, 연락처, 주소, 우편번호</strong>)</p>\n"
           },
           {
             "name": "logis",
@@ -1739,8 +1678,7 @@
             },
             "type": "string",
             "x-portone-name": "배송정보",
-            "x-portone-summary": "<p>택배사코드표는 <a href=\"https://developers.portone.io/docs/ko/tip/code\" rel=\"noopener noreferrer\">매뉴얼</a> 참조</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>택배사코드표는 <a href=\"https://developers.portone.io/docs/ko/tip/code\" rel=\"noopener noreferrer\">매뉴얼</a> 참조</p>\n"
           },
           {
             "name": "products",
@@ -1753,8 +1691,7 @@
             },
             "collectionFormat": "multi",
             "x-portone-name": "배송 상품 정보",
-            "x-portone-summary": "<p>배송 보내는 상품의 정보(고유 아이디, 이름, 고유 코드, 통화코드, 수량, 카테고리)</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>배송 보내는 상품의 정보(고유 아이디, 이름, 고유 코드, 통화코드, 수량, 카테고리)</p>\n",
             "x-portone-supported-pgs": [
               "welcome"
             ],
@@ -1772,8 +1709,7 @@
             "type": "boolean",
             "default": true,
             "x-portone-name": "구매확정 시 Email 전송여부",
-            "x-portone-summary": "<p>에스크로 구매 확정시 결제 창에 입력했던 이메일로 해당 사실을 전송할지 여부 (기본값 : <strong>true</strong>)</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>에스크로 구매 확정시 결제 창에 입력했던 이메일로 해당 사실을 전송할지 여부 (기본값 : <strong>true</strong>)</p>\n",
             "x-portone-supported-pgs": [
               "nice_v2"
             ],
@@ -1902,8 +1838,7 @@
             "type": "string",
             "default": "memberID",
             "x-portone-name": "구매자 고유 아이디",
-            "x-portone-summary": "<p>삭제 하고자 하는 구매자 고유 아이디(memberID)</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>삭제 하고자 하는 구매자 고유 아이디(memberID)</p>\n"
           },
           {
             "name": "site_code",
@@ -1914,8 +1849,7 @@
             "default": "IX0XX",
             "maxLength": 80,
             "x-portone-name": "사이트 코드",
-            "x-portone-summary": "<p>KCP 퀵페이 등록 시 사용한 사이트 코드(SITE CD)</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>KCP 퀵페이 등록 시 사용한 사이트 코드(SITE CD)</p>\n"
           },
           {
             "name": "partner_type",
@@ -1926,8 +1860,7 @@
             "default": "IX99",
             "maxLength": 80,
             "x-portone-name": "파트너 타입",
-            "x-portone-summary": "<p>KCP 퀵페이 등록 시 사용한 파트너 타입</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>KCP 퀵페이 등록 시 사용한 파트너 타입</p>\n"
           },
           {
             "name": "partner_subtype",
@@ -1938,8 +1871,7 @@
             "default": "99IX",
             "maxLength": 80,
             "x-portone-name": "파트너 서브타입",
-            "x-portone-summary": "<p>KCP 퀵페이 등록 시 사용한 파트너 서브타입</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>KCP 퀵페이 등록 시 사용한 파트너 서브타입</p>\n"
           }
         ],
         "responses": {
@@ -1985,8 +1917,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "포트원 거래고유번호",
-            "x-portone-summary": "<p>네이버페이 환불할 거래건의 포트원 거래고유번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>네이버페이 환불할 거래건의 포트원 거래고유번호</p>\n"
           },
           {
             "name": "product_order_id",
@@ -1996,8 +1927,7 @@
             "type": "array",
             "items": "string",
             "x-portone-name": "환불할 거래건의 네이버페이 상품주문번호",
-            "x-portone-summary": "<p>네이버페이 환불할 거래건의 네이버페이 상품주문번호로 생략되면 imp_uid 에 해당되는 모든 상품주문을 환불합니다.</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>네이버페이 환불할 거래건의 네이버페이 상품주문번호로 생략되면 imp_uid 에 해당되는 모든 상품주문을 환불합니다.</p>\n"
           },
           {
             "name": "reason",
@@ -2016,7 +1946,7 @@
               "INCORRECT_INFO"
             ],
             "x-portone-name": "취소 사유 코드",
-            "x-portone-summary": "<p>취소 사유 코드로 올바르지 않은 코드인 경우 기본값(<code>PRODUCT_UNSATISFIED</code>)을 적용합니다.</p>\n"
+            "x-portone-description": "<p>취소 사유 코드로 올바르지 않은 코드인 경우 기본값(<code>PRODUCT_UNSATISFIED</code>)을 적용합니다.</p>\n"
           }
         ],
         "responses": {
@@ -2071,8 +2001,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "포트원 거래고유번호",
-            "x-portone-summary": "<p>네이버페이 환불승인할 거래건의 포트원 거래고유번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>네이버페이 환불승인할 거래건의 포트원 거래고유번호</p>\n"
           },
           {
             "name": "product_order_id",
@@ -2082,8 +2011,7 @@
             "type": "array",
             "items": "string",
             "x-portone-name": "환불승인할 거래건의 네이버페이 상품주문번호",
-            "x-portone-summary": "<p>환불승인할 거래건의 네이버페이 상품주문번호로 생략되면 imp_uid 에 해당되는 모든 상품주문을 환불승인합니다.</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>환불승인할 거래건의 네이버페이 상품주문번호로 생략되면 imp_uid 에 해당되는 모든 상품주문을 환불승인합니다.</p>\n"
           }
         ],
         "responses": {
@@ -2138,8 +2066,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "포트원 거래고유번호",
-            "x-portone-summary": "<p>네이버페이 발송처리할 거래건의 포트원 거래고유번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>네이버페이 발송처리할 거래건의 포트원 거래고유번호</p>\n"
           },
           {
             "name": "product_order_id",
@@ -2149,8 +2076,7 @@
             "type": "array",
             "items": "string",
             "x-portone-name": "발송처리할 거래건의 네이버페이 상품주문번호",
-            "x-portone-summary": "<p>발송처리할 거래건의 네이버페이 상품주문번호로 생략되면 imp_uid 에 해당되는 모든 상품주문을 발송처리합니다.</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>발송처리할 거래건의 네이버페이 상품주문번호로 생략되면 imp_uid 에 해당되는 모든 상품주문을 발송처리합니다.</p>\n"
           },
           {
             "name": "delivery_method",
@@ -2167,7 +2093,7 @@
               "NOTHING"
             ],
             "x-portone-name": "배송방법 코드",
-            "x-portone-summary": "<p>배송방법을 나타내는 코드</p>\n"
+            "x-portone-description": "<p>배송방법을 나타내는 코드</p>\n"
           },
           {
             "name": "dispatched_at",
@@ -2176,8 +2102,7 @@
             "required": true,
             "type": "integer",
             "x-portone-name": "발송일",
-            "x-portone-summary": "<p>발송일 (unix timestamp)</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>발송일 (unix timestamp)</p>\n"
           },
           {
             "name": "delivery_company",
@@ -2228,7 +2153,7 @@
               "HONAM"
             ],
             "x-portone-name": "택배사 코드",
-            "x-portone-summary": "<p>택배사 코드(delivery_method == <code>DELIVERY</code> 인 경우 필수로 입력해야하는 파라메터)</p>\n"
+            "x-portone-description": "<p>택배사 코드(delivery_method == <code>DELIVERY</code> 인 경우 필수로 입력해야하는 파라메터)</p>\n"
           },
           {
             "name": "tracking_number",
@@ -2237,8 +2162,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "송장번호",
-            "x-portone-summary": "<p>송장번호(delivery_method == <code>DELIVERY</code> 인 경우 필수 파라미터)</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>송장번호(delivery_method == <code>DELIVERY</code> 인 경우 필수 파라미터)</p>\n"
           }
         ],
         "responses": {
@@ -2296,8 +2220,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "포트원 거래고유번호",
-            "x-portone-summary": "<p>네이버페이 재발송처리할 거래건의 포트원 거래고유번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>네이버페이 재발송처리할 거래건의 포트원 거래고유번호</p>\n"
           },
           {
             "name": "product_order_id",
@@ -2307,8 +2230,7 @@
             "type": "array",
             "items": "string",
             "x-portone-name": "재발송처리할 거래건의 네이버페이 상품주문번호",
-            "x-portone-summary": "<p>재발송처리할 거래건의 네이버페이 상품주문번호로 생략되면 imp_uid 에 해당되는 모든 상품주문을 재발송처리합니다.</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>재발송처리할 거래건의 네이버페이 상품주문번호로 생략되면 imp_uid 에 해당되는 모든 상품주문을 재발송처리합니다.</p>\n"
           },
           {
             "name": "delivery_method",
@@ -2325,7 +2247,7 @@
               "NOTHING"
             ],
             "x-portone-name": "배송방법 코드",
-            "x-portone-summary": "<p>배송방법을 나타내는 코드</p>\n"
+            "x-portone-description": "<p>배송방법을 나타내는 코드</p>\n"
           },
           {
             "name": "delivery_company",
@@ -2376,7 +2298,7 @@
               "HONAM"
             ],
             "x-portone-name": "택배사 코드",
-            "x-portone-summary": "<p>택배사 코드(delivery_method == <code>DELIVERY</code> 인 경우 필수로 입력해야하는 파라메터)</p>\n"
+            "x-portone-description": "<p>택배사 코드(delivery_method == <code>DELIVERY</code> 인 경우 필수로 입력해야하는 파라메터)</p>\n"
           },
           {
             "name": "tracking_number",
@@ -2385,8 +2307,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "송장번호",
-            "x-portone-summary": "<p>송장번호(delivery_method == <code>DELIVERY</code> 인 경우 필수로 입력해야하는 파라메터)</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>송장번호(delivery_method == <code>DELIVERY</code> 인 경우 필수로 입력해야하는 파라메터)</p>\n"
           }
         ],
         "responses": {
@@ -2444,8 +2365,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "포트원 거래고유번호",
-            "x-portone-summary": "<p>네이버페이 수거완료처리 할 거래건의 포트원 거래고유번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>네이버페이 수거완료처리 할 거래건의 포트원 거래고유번호</p>\n"
           },
           {
             "name": "product_order_id",
@@ -2455,8 +2375,7 @@
             "type": "array",
             "items": "string",
             "x-portone-name": "네이버페이 상품주문번호",
-            "x-portone-summary": "<p>수거완료처리 할 거래건의 네이버페이 상품주문번호로 생략되면 imp_uid 에 해당되는 모든 상품주문을 수거완료처리합니다.</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>수거완료처리 할 거래건의 네이버페이 상품주문번호로 생략되면 imp_uid 에 해당되는 모든 상품주문을 수거완료처리합니다.</p>\n"
           }
         ],
         "responses": {
@@ -2511,8 +2430,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "포트원 거래고유번호",
-            "x-portone-summary": "<p>네이버페이 발주처리할 거래건의 포트원 거래고유번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>네이버페이 발주처리할 거래건의 포트원 거래고유번호</p>\n"
           },
           {
             "name": "product_order_id",
@@ -2522,8 +2440,7 @@
             "type": "array",
             "items": "string",
             "x-portone-name": "네이버페이 상품주문번호",
-            "x-portone-summary": "<p>네이버페이 발주처리할 거래건의 네이버페이 상품주문번호로 생략되면 imp_uid 에 해당되는 모든 상품주문을 발주처리합니다.</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>네이버페이 발주처리할 거래건의 네이버페이 상품주문번호로 생략되면 imp_uid 에 해당되는 모든 상품주문을 발주처리합니다.</p>\n"
           }
         ],
         "responses": {
@@ -2578,8 +2495,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "포트원 거래고유번호",
-            "x-portone-summary": "<p>네이버페이 반품요청할 거래건의 포트원 거래고유번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>네이버페이 반품요청할 거래건의 포트원 거래고유번호</p>\n"
           },
           {
             "name": "product_order_id",
@@ -2589,8 +2505,7 @@
             "type": "array",
             "items": "string",
             "x-portone-name": "네이버페이 상품주문번호",
-            "x-portone-summary": "<p>반품요청할 거래건의 네이버페이 상품주문번호로 생략되면 imp_uid 에 해당되는 모든 상품주문을 반품요청합니다.</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>반품요청할 거래건의 네이버페이 상품주문번호로 생략되면 imp_uid 에 해당되는 모든 상품주문을 반품요청합니다.</p>\n"
           },
           {
             "name": "reason",
@@ -2613,7 +2528,7 @@
               "WRONG_OPTION"
             ],
             "x-portone-name": "반품사유코드",
-            "x-portone-summary": "<p>반품사유코드로 올바르지 않은 사유코드인 경우 기본값(<code>INTENT_CHANGED</code>)을 적용합니다.</p>\n"
+            "x-portone-description": "<p>반품사유코드로 올바르지 않은 사유코드인 경우 기본값(<code>INTENT_CHANGED</code>)을 적용합니다.</p>\n"
           },
           {
             "name": "delivery_method",
@@ -2627,7 +2542,7 @@
               "RETURN_INDIVIDUAL"
             ],
             "x-portone-name": "배송방법 코드",
-            "x-portone-summary": "<p>반품 배송방법 코드</p>\n"
+            "x-portone-description": "<p>반품 배송방법 코드</p>\n"
           },
           {
             "name": "delivery_company",
@@ -2678,7 +2593,7 @@
               "HONAM"
             ],
             "x-portone-name": "택배사 코드",
-            "x-portone-summary": "<p>택배사 코드(delivery_method == <code>RETURN_DELIVERY</code> 인 경우 필수로 입력해야하는 파라메터)</p>\n"
+            "x-portone-description": "<p>택배사 코드(delivery_method == <code>RETURN_DELIVERY</code> 인 경우 필수로 입력해야하는 파라메터)</p>\n"
           },
           {
             "name": "tracking_number",
@@ -2687,8 +2602,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "송장번호",
-            "x-portone-summary": "<p>송장번호(delivery_method == <code>RETURN_DELIVERY</code> 인 경우 필수로 입력해야하는 파라메터)</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>송장번호(delivery_method == <code>RETURN_DELIVERY</code> 인 경우 필수로 입력해야하는 파라메터)</p>\n"
           }
         ],
         "responses": {
@@ -2746,8 +2660,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "포트원 거래고유번호",
-            "x-portone-summary": "<p>네이버페이 반품승인 처리할 거래건의 포트원 거래고유번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>네이버페이 반품승인 처리할 거래건의 포트원 거래고유번호</p>\n"
           },
           {
             "name": "product_order_id",
@@ -2757,8 +2670,7 @@
             "type": "array",
             "items": "string",
             "x-portone-name": "네이버페이 상품주문번호",
-            "x-portone-summary": "<p>반품승인 처리할 거래건의 네이버페이 상품주문번호로 생략되면 imp_uid 에 해당되는 모든 상품주문을 반품승인 처리합니다.</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>반품승인 처리할 거래건의 네이버페이 상품주문번호로 생략되면 imp_uid 에 해당되는 모든 상품주문을 반품승인 처리합니다.</p>\n"
           },
           {
             "name": "memo",
@@ -2767,8 +2679,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "메모",
-            "x-portone-summary": "<p>반품승인 후 구매자에게 전달하는 메모</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>반품승인 후 구매자에게 전달하는 메모</p>\n"
           }
         ],
         "responses": {
@@ -2823,8 +2734,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "포트원의 거래고유번호",
-            "x-portone-summary": "<p>네이버페이 반품거절 처리할 거래건의 포트원 거래고유번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>네이버페이 반품거절 처리할 거래건의 포트원 거래고유번호</p>\n"
           },
           {
             "name": "product_order_id",
@@ -2834,8 +2744,7 @@
             "type": "array",
             "items": "string",
             "x-portone-name": "네이버페이 상품주문번호",
-            "x-portone-summary": "<p>네이버페이 반품거절 처리할 거래건의 네이버페이 상품주문번호로 생략되면 imp_uid 에 해당되는 모든 상품주문을 반품거절 처리합니다.</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>네이버페이 반품거절 처리할 거래건의 네이버페이 상품주문번호로 생략되면 imp_uid 에 해당되는 모든 상품주문을 반품거절 처리합니다.</p>\n"
           },
           {
             "name": "memo",
@@ -2844,8 +2753,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "메모",
-            "x-portone-summary": "<p>반품거절 후 구매자에게 전달하는 메모</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>반품거절 후 구매자에게 전달하는 메모</p>\n"
           }
         ],
         "responses": {
@@ -2903,8 +2811,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "포트원 거래고유번호",
-            "x-portone-summary": "<p>네이버페이 반품보류 처리할 거래건의 포트원 거래고유번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>네이버페이 반품보류 처리할 거래건의 포트원 거래고유번호</p>\n"
           },
           {
             "name": "product_order_id",
@@ -2914,8 +2821,7 @@
             "type": "array",
             "items": "string",
             "x-portone-name": "네이버페이 상품주문번호",
-            "x-portone-summary": "<p>반품보류 처리할 거래건의 네이버페이 상품주문번호로 생략되면 imp_uid 에 해당되는 모든 상품주문을 반품보류 처리합니다.</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>반품보류 처리할 거래건의 네이버페이 상품주문번호로 생략되면 imp_uid 에 해당되는 모든 상품주문을 반품보류 처리합니다.</p>\n"
           },
           {
             "name": "reason",
@@ -2932,7 +2838,7 @@
               "ETC"
             ],
             "x-portone-name": "반품보류사유 코드",
-            "x-portone-summary": "<p>반품보류사유 코드로 올바르지 않은 보류사유코드인 경우 기본값(<code>ETC</code>)를 적용합니다.</p>\n"
+            "x-portone-description": "<p>반품보류사유 코드로 올바르지 않은 보류사유코드인 경우 기본값(<code>ETC</code>)를 적용합니다.</p>\n"
           },
           {
             "name": "memo",
@@ -2941,8 +2847,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "메모",
-            "x-portone-summary": "<p>반품보류에 대하여 구매자에게 전달하는 메모</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>반품보류에 대하여 구매자에게 전달하는 메모</p>\n"
           },
           {
             "name": "extra_charge",
@@ -2951,8 +2856,7 @@
             "required": false,
             "type": "integer",
             "x-portone-name": "기타 비용 청구액",
-            "x-portone-summary": "<p>기타 비용 청구액으로 기본값은 <strong>0원</strong>입니다.</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>기타 비용 청구액으로 기본값은 <strong>0원</strong>입니다.</p>\n"
           }
         ],
         "responses": {
@@ -3010,8 +2914,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "포트원 거래고유번호",
-            "x-portone-summary": "<p>네이버페이 반품보류해제 처리할 거래건의 포트원 거래고유번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>네이버페이 반품보류해제 처리할 거래건의 포트원 거래고유번호</p>\n"
           },
           {
             "name": "product_order_id",
@@ -3021,8 +2924,7 @@
             "type": "array",
             "items": "string",
             "x-portone-name": "네이버페이 상품주문번호",
-            "x-portone-summary": "<p>반품보류해제 처리할 거래건의 네이버페이 상품주문번호로 생략되면 imp_uid 에 해당되는 모든 상품주문을 반품보류해제 처리합니다.</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>반품보류해제 처리할 거래건의 네이버페이 상품주문번호로 생략되면 imp_uid 에 해당되는 모든 상품주문을 반품보류해제 처리합니다.</p>\n"
           }
         ],
         "responses": {
@@ -3077,8 +2979,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "포트원 거래고유번호",
-            "x-portone-summary": "<p>네이버페이 포인트 적립할 거래건의 포트원 거래고유번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>네이버페이 포인트 적립할 거래건의 포트원 거래고유번호</p>\n"
           }
         ],
         "responses": {
@@ -3127,8 +3028,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "포트원 거래고유번호",
-            "x-portone-summary": "<p>네이버페이 구매확정할 거래건의 포트원 거래고유번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>네이버페이 구매확정할 거래건의 포트원 거래고유번호</p>\n"
           },
           {
             "name": "requester",
@@ -3137,8 +3037,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "구매확정 요청자",
-            "x-portone-summary": "<p>구매확정 요청자 (admin : 가맹점 관리자 (기본값), customer : 구매자)</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>구매확정 요청자 (admin : 가맹점 관리자 (기본값), customer : 구매자)</p>\n"
           }
         ],
         "responses": {
@@ -3187,8 +3086,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "포트원 거래고유번호",
-            "x-portone-summary": "<p>네이버페이 상품주문 조회를 위한 포트원 거래 고유번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>네이버페이 상품주문 조회를 위한 포트원 거래 고유번호</p>\n"
           }
         ],
         "responses": {
@@ -3234,8 +3132,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "네이버페이 상품주문번호",
-            "x-portone-summary": "<p>상세 조회할 네이버페이 상품주문번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>상세 조회할 네이버페이 상품주문번호</p>\n"
           }
         ],
         "responses": {
@@ -3284,8 +3181,7 @@
             "required": true,
             "type": "integer",
             "x-portone-name": "조회기간 시작",
-            "x-portone-summary": "<p>조회기간 시작 unix timestamp</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>조회기간 시작 unix timestamp</p>\n"
           },
           {
             "name": "to",
@@ -3294,8 +3190,7 @@
             "required": true,
             "type": "integer",
             "x-portone-name": "조회기간 종료",
-            "x-portone-summary": "<p>조회기간 종료 unix timestamp</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>조회기간 종료 unix timestamp</p>\n"
           },
           {
             "name": "review_type",
@@ -3308,7 +3203,7 @@
               "premium"
             ],
             "x-portone-name": "구매평 유형",
-            "x-portone-summary": "<p>조회할 구매평의 유형</p>\n"
+            "x-portone-description": "<p>조회할 구매평의 유형</p>\n"
           }
         ],
         "responses": {
@@ -3357,8 +3252,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "포트원 거래고유번호",
-            "x-portone-summary": "<p>네이버페이 현금영수증 발급가능 금액 조회를 위한 포트원 거래 고유번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>네이버페이 현금영수증 발급가능 금액 조회를 위한 포트원 거래 고유번호</p>\n"
           }
         ],
         "responses": {
@@ -3407,8 +3301,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "포트원 거래고유번호",
-            "x-portone-summary": "<p>하위 상점 거래를 등록할 결제건의 포트원 거래고유번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>하위 상점 거래를 등록할 결제건의 포트원 거래고유번호</p>\n"
           },
           {
             "name": "data",
@@ -3421,8 +3314,7 @@
             },
             "default": "[&#13;&#09;{&#13;&#09;&#09;&quot;business_registration_number&quot;: &quot;하위 상점 사업자 등록 번호1&quot;,&#13;&#09;&#09;&quot;company_name&quot;: &quot;하위 상점 명1&quot;,&#13;&#09;&#09;&quot;amount&quot;: 1000&#13;},&#13;&#09;{&#13;&#09;&#09;&quot;business_registration_number&quot;: &quot;하위 상점 사업자 등록 번호2&quot;,&#13;&#09;&#09;&quot;company_name&quot;: &quot;하위 상점 명2&quot;,&#13;&#09;&#09;&quot;amount&quot;: 2000&#13;}&#13;]",
             "x-portone-name": "등록할 하위 상점 및 하위 상점 별 거래 금액 정보",
-            "x-portone-summary": "<p>imp_uid에 매핑되는 거래 하위를 구성하는 하위 상점 및 하위 상점 별 거래 금액 정보의 배열</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>imp_uid에 매핑되는 거래 하위를 구성하는 하위 상점 및 하위 상점 별 거래 금액 정보의 배열</p>\n"
           }
         ],
         "responses": {
@@ -3477,8 +3369,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "포트원 거래고유번호",
-            "x-portone-summary": "<p>주문상태를 변경할 결제건의 포트원 거래고유번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>주문상태를 변경할 결제건의 포트원 거래고유번호</p>\n"
           },
           {
             "name": "status",
@@ -3492,7 +3383,7 @@
               "CANCELED"
             ],
             "x-portone-name": "주문상태코드",
-            "x-portone-summary": "<p>변경될 주문상태</p>\n"
+            "x-portone-description": "<p>변경될 주문상태</p>\n"
           }
         ],
         "responses": {
@@ -3536,8 +3427,7 @@
             "type": "string",
             "default": "imp_448280090638",
             "x-portone-name": "포트원 거래고유번호",
-            "x-portone-summary": "<p>상세정보를 조회할 결제건의 포트원 거래고유번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>상세정보를 조회할 결제건의 포트원 거래고유번호</p>\n"
           }
         ],
         "responses": {
@@ -3587,8 +3477,7 @@
             "type": "string",
             "default": "imp_448280090638",
             "x-portone-name": "포트원 거래고유번호",
-            "x-portone-summary": "<p>결제내역을 확인할 결제건의 포트원 거래고유번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>결제내역을 확인할 결제건의 포트원 거래고유번호</p>\n"
           }
         ],
         "responses": {
@@ -3644,8 +3533,7 @@
             "collectionFormat": "multi",
             "default": "imp_448280090638",
             "x-portone-name": "포트원 거래고유번호",
-            "x-portone-summary": "<p>조회할 결제건의 포트원 거래고유번호 리스트</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>조회할 결제건의 포트원 거래고유번호 리스트</p>\n"
           },
           {
             "name": "merchant_uid[]",
@@ -3659,8 +3547,7 @@
             "collectionFormat": "multi",
             "default": "merchant_143434085216",
             "x-portone-name": "가맹점 주문번호",
-            "x-portone-summary": "<p>결제요청 시 가맹점에서 요청한 가맹점 주문번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>결제요청 시 가맹점에서 요청한 가맹점 주문번호</p>\n"
           }
         ],
         "responses": {
@@ -3710,8 +3597,7 @@
             "type": "string",
             "default": "merchant_1448280088556",
             "x-portone-name": "가맹점 주문번호",
-            "x-portone-summary": "<p>결제요청 시 가맹점에서 요청한 가맹점 주문번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>결제요청 시 가맹점에서 요청한 가맹점 주문번호</p>\n"
           },
           {
             "name": "payment_status",
@@ -3721,7 +3607,7 @@
             "type": "string",
             "default": "",
             "x-portone-name": "거래상태 구분코드",
-            "x-portone-summary": "<p>특정 status상태의 값만 필터링하고 싶은 경우에 사용하는 파라미터로 지정하지 않으면 <strong>모든 상태</strong>를 대상으로 조회합니다</p>\n"
+            "x-portone-description": "<p>특정 status상태의 값만 필터링하고 싶은 경우에 사용하는 파라미터로 지정하지 않으면 <strong>모든 상태</strong>를 대상으로 조회합니다</p>\n"
           },
           {
             "name": "sorting",
@@ -3739,7 +3625,7 @@
               "updated"
             ],
             "x-portone-name": "정렬구분코드",
-            "x-portone-summary": "<p>정렬 기준을 설정하는 파라미터로 기본값은 <code>-started</code>입니다.</p>\n"
+            "x-portone-description": "<p>정렬 기준을 설정하는 파라미터로 기본값은 <code>-started</code>입니다.</p>\n"
           }
         ],
         "responses": {
@@ -3783,8 +3669,7 @@
             "type": "string",
             "default": "merchant_1448280088556",
             "x-portone-name": "가맹점 주문번호",
-            "x-portone-summary": "<p>결제요청 시 가맹점에서 요청한 가맹점 주문번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>결제요청 시 가맹점에서 요청한 가맹점 주문번호</p>\n"
           },
           {
             "name": "payment_status",
@@ -3794,7 +3679,7 @@
             "type": "string",
             "default": "",
             "x-portone-name": "결제상태코드",
-            "x-portone-summary": "<p>특정 status상태의 값만 필터링하고 싶은 경우에 사용하는 파라미터로 지정하지 않으면 <strong>모든 상태</strong>를 조회합니다.</p>\n"
+            "x-portone-description": "<p>특정 status상태의 값만 필터링하고 싶은 경우에 사용하는 파라미터로 지정하지 않으면 <strong>모든 상태</strong>를 조회합니다.</p>\n"
           },
           {
             "name": "page",
@@ -3803,8 +3688,7 @@
             "required": false,
             "type": "integer",
             "x-portone-name": "페이지번호",
-            "x-portone-summary": "<p>1부터 시작하며 기본값은 1입니다.</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>1부터 시작하며 기본값은 1입니다.</p>\n"
           },
           {
             "name": "limit",
@@ -3816,8 +3700,7 @@
             "maximum": "1000",
             "minimum": "1",
             "x-portone-name": "페이지당 조회건수",
-            "x-portone-summary": "<p>한 번에 조회할 결제건수.(최대 1000건, 기본값 20건)</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>한 번에 조회할 결제건수.(최대 1000건, 기본값 20건)</p>\n"
           },
           {
             "name": "sorting",
@@ -3835,7 +3718,7 @@
               "updated"
             ],
             "x-portone-name": "정렬기준",
-            "x-portone-summary": "<p>정렬기준을 나타내는 파라미터로 기본값은 <code>-started</code>입니다.</p>\n"
+            "x-portone-description": "<p>정렬기준을 나타내는 파라미터로 기본값은 <code>-started</code>입니다.</p>\n"
           }
         ],
         "responses": {
@@ -3888,7 +3771,7 @@
               "failed"
             ],
             "x-portone-name": "결제상태코드",
-            "x-portone-summary": "<p>조회할 결제건의 결제상태 코드</p>\n"
+            "x-portone-description": "<p>조회할 결제건의 결제상태 코드</p>\n"
           },
           {
             "name": "page",
@@ -3897,8 +3780,7 @@
             "required": false,
             "type": "integer",
             "x-portone-name": "페이지번호",
-            "x-portone-summary": "<p>1부터 시작하며 기본값 1입니다.</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>1부터 시작하며 기본값 1입니다.</p>\n"
           },
           {
             "name": "limit",
@@ -3910,8 +3792,7 @@
             "maximum": "1000",
             "minimum": "1",
             "x-portone-name": "페이지 당 조회건수",
-            "x-portone-summary": "<p>한 번에 조회할 결제건수.(최대 1000건, 기본값 20건)</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>한 번에 조회할 결제건수.(최대 1000건, 기본값 20건)</p>\n"
           },
           {
             "name": "from",
@@ -3920,8 +3801,7 @@
             "required": false,
             "type": "integer",
             "x-portone-name": "검색 시작 시각",
-            "x-portone-summary": "<p>기본값은 to 파라메터 기준으로 <strong>90일</strong> 전 unix timestamp입니다. (시간별 검색 시작 시각(&gt;=) UNIX TIMESTAMP)</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>기본값은 to 파라메터 기준으로 <strong>90일</strong> 전 unix timestamp입니다. (시간별 검색 시작 시각(&gt;=) UNIX TIMESTAMP)</p>\n"
           },
           {
             "name": "to",
@@ -3930,8 +3810,7 @@
             "required": false,
             "type": "integer",
             "x-portone-name": "검색 종료 시각",
-            "x-portone-summary": "<p>기본값은 현재 unix timestamp입니다. (시간별 검색 종료 시각(&lt;=) UNIX TIMESTAMP)</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>기본값은 현재 unix timestamp입니다. (시간별 검색 종료 시각(&lt;=) UNIX TIMESTAMP)</p>\n"
           },
           {
             "name": "sorting",
@@ -3949,7 +3828,7 @@
               "updated"
             ],
             "x-portone-name": "정렬기준",
-            "x-portone-summary": "<p>정렬기준을 나타내는 파라미터로 기본값은 <code>-started</code>입니다.</p>\n"
+            "x-portone-description": "<p>정렬기준을 나타내는 파라미터로 기본값은 <code>-started</code>입니다.</p>\n"
           }
         ],
         "responses": {
@@ -3992,8 +3871,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "포트원 거래고유번호",
-            "x-portone-summary": "<p>취소할 거래의 포트원 거래고유번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>취소할 거래의 포트원 거래고유번호</p>\n"
           },
           {
             "name": "merchant_uid",
@@ -4002,8 +3880,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "가맹점 주문번호",
-            "x-portone-summary": "<p>가맹점에서 전달한 거래 고유번호로 imp_uid, merchant_uid 중 하나는 필수이어야 합니다. (두 값이 모두 넘어오면 <strong>imp_uid를 우선 적용</strong>합니다.)</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>가맹점에서 전달한 거래 고유번호로 imp_uid, merchant_uid 중 하나는 필수이어야 합니다. (두 값이 모두 넘어오면 <strong>imp_uid를 우선 적용</strong>합니다.)</p>\n"
           },
           {
             "name": "amount",
@@ -4094,8 +3971,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "취소 사유",
-            "x-portone-summary": "<p>결제건을 취소하려는 사유</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>결제건을 취소하려는 사유</p>\n",
             "x-portone-per-pg": {
               "naverpay": {
                 "required": true,
@@ -4110,8 +3986,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "환불계좌 예금주",
-            "x-portone-summary": "<p>환불받을 계좌의 예금주</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>환불받을 계좌의 예금주</p>\n",
             "x-portone-per-pg": {
               "kcp": {
                 "description": "<p>휴대폰소액결제 익월 환불시 필수입력입니다.</p>\n"
@@ -4146,8 +4021,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "환불계좌 계좌번호",
-            "x-portone-summary": "<p>환불받을 계좌번호</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>환불받을 계좌번호</p>\n",
             "x-portone-per-pg": {
               "kcp": {
                 "description": "<p>휴대폰소액결제 익월 환불시 필수입력입니다.</p>\n"
@@ -4164,8 +4038,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "환불계좌 예금주 연락처",
-            "x-portone-summary": "<p>환불받을 계좌의 예금주 연락처 (가상계좌 취소인 경우 필수)</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>환불받을 계좌의 예금주 연락처 (가상계좌 취소인 경우 필수)</p>\n",
             "x-portone-per-pg": {
               "smartro": {
                 "required": true
@@ -4182,8 +4055,7 @@
             "required": false,
             "type": "array",
             "x-portone-name": "추가 파라미터",
-            "x-portone-summary": "<p>결제 취소 요청시 필요한 추가 정보</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>결제 취소 요청시 필요한 추가 정보</p>\n",
             "x-portone-per-pg": {
               "naverpay": {
                 "required": true,
@@ -4262,8 +4134,7 @@
             "type": "string",
             "maxLength": 40,
             "x-portone-name": "가맹점 주문번호",
-            "x-portone-summary": "<p>이미 사전등록한 가맹점 주문번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>이미 사전등록한 가맹점 주문번호</p>\n"
           },
           {
             "name": "amount",
@@ -4272,8 +4143,7 @@
             "required": true,
             "type": "number",
             "x-portone-name": "결제 예정금액",
-            "x-portone-summary": "<p>수정 할 결제건의 결제예정금액</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>수정 할 결제건의 결제예정금액</p>\n"
           }
         ],
         "responses": {
@@ -4315,8 +4185,7 @@
             "type": "string",
             "maxLength": 40,
             "x-portone-name": "가맹점 주문번호",
-            "x-portone-summary": "<p>결제금액을 사전 등록할 결제건의 가맹점 주문번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>결제금액을 사전 등록할 결제건의 가맹점 주문번호</p>\n"
           },
           {
             "name": "amount",
@@ -4325,8 +4194,7 @@
             "required": true,
             "type": "number",
             "x-portone-name": "결제예정금액",
-            "x-portone-summary": "<p>사전 등록할 결제예정금액</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>사전 등록할 결제예정금액</p>\n"
           }
         ],
         "responses": {
@@ -4366,8 +4234,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "가맹점 주문번호",
-            "x-portone-summary": "<p>결제금액을 조회할 결제건의 가맹점 주문번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>결제금액을 조회할 결제건의 가맹점 주문번호</p>\n"
           }
         ],
         "responses": {
@@ -4408,8 +4275,7 @@
             "type": "string",
             "maxLength": 40,
             "x-portone-name": "포트원 거래고유번호",
-            "x-portone-summary": "<p>배송등록 할 결제건의 포트원 거래고유번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>배송등록 할 결제건의 포트원 거래고유번호</p>\n"
           },
           {
             "name": "merchant_uid",
@@ -4419,8 +4285,7 @@
             "type": "string",
             "maxLength": 40,
             "x-portone-name": "가맹점 주문번호",
-            "x-portone-summary": "<p>배송등록 할 결제건의 가맹점 주문번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>배송등록 할 결제건의 가맹점 주문번호</p>\n"
           },
           {
             "name": "type",
@@ -4434,7 +4299,7 @@
               "digital"
             ],
             "x-portone-name": "상품구분코드",
-            "x-portone-summary": "<p>배송등록 할 결제건의 상품 구분 코드</p>\n"
+            "x-portone-description": "<p>배송등록 할 결제건의 상품 구분 코드</p>\n"
           },
           {
             "name": "status",
@@ -4450,7 +4315,7 @@
               "delivered"
             ],
             "x-portone-name": "배송상태 구분코드",
-            "x-portone-summary": "<p>배송등록 할 결제건의 배송 상태코드</p>\n"
+            "x-portone-description": "<p>배송등록 할 결제건의 배송 상태코드</p>\n"
           },
           {
             "name": "carrier_tracking_id",
@@ -4459,8 +4324,7 @@
             "type": "string",
             "maxLength": 64,
             "x-portone-name": "운송장 번호",
-            "x-portone-summary": "<p>배송등록 할 결제건의 운송장 번호 (<code>physical</code> 주문인 경우 필수 파라미터)</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>배송등록 할 결제건의 운송장 번호 (<code>physical</code> 주문인 경우 필수 파라미터)</p>\n"
           },
           {
             "name": "carrier_type",
@@ -4469,8 +4333,7 @@
             "type": "string",
             "maxLength": 64,
             "x-portone-name": "운송사 이름",
-            "x-portone-summary": "<p>운송사 이름 (<code>physical</code> 주문인 경우 필수 파라미터)</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>운송사 이름 (<code>physical</code> 주문인 경우 필수 파라미터)</p>\n"
           },
           {
             "name": "estimated_delivery_datetime",
@@ -4480,8 +4343,7 @@
             "type": "integer",
             "maxLength": 64,
             "x-portone-name": "도착예상시간",
-            "x-portone-summary": "<p>도착예상시간 Unix timestamp sec (<code>digital</code>인 경우, 지금 시간을 기록해도 무방)</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>도착예상시간 Unix timestamp sec (<code>digital</code>인 경우, 지금 시간을 기록해도 무방)</p>\n"
           },
           {
             "name": "estimated_update_datetime",
@@ -4491,8 +4353,7 @@
             "type": "integer",
             "maxLength": 64,
             "x-portone-name": "배송상태 업데이트 예정시간",
-            "x-portone-summary": "<p>배송상태 업데이트 예정시간 Unix timestamp sec (<code>digital</code>인 경우, 지금 시간을 기록해도 무방)</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>배송상태 업데이트 예정시간 Unix timestamp sec (<code>digital</code>인 경우, 지금 시간을 기록해도 무방)</p>\n"
           },
           {
             "name": "reason",
@@ -4501,7 +4362,6 @@
             "type": "string",
             "maxLength": 64,
             "x-portone-name": "사유",
-            "x-portone-summary": "",
             "x-portone-description": ""
           },
           {
@@ -4516,7 +4376,7 @@
               "no"
             ],
             "x-portone-name": "환불가능여부",
-            "x-portone-summary": "<p>결제건의 환불가능여부를 나타내는 파라미터</p>\n"
+            "x-portone-description": "<p>결제건의 환불가능여부를 나타내는 파라미터</p>\n"
           },
           {
             "name": "details",
@@ -4525,7 +4385,6 @@
             "type": "string",
             "maxLength": 400,
             "x-portone-name": "상세 사항",
-            "x-portone-summary": "",
             "x-portone-description": ""
           },
           {
@@ -4536,8 +4395,7 @@
             "type": "string",
             "maxLength": 50,
             "x-portone-name": "email",
-            "x-portone-summary": "<p>수신자의 email주소</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>수신자의 email주소</p>\n"
           },
           {
             "name": "shipping_address_country",
@@ -4546,8 +4404,7 @@
             "type": "string",
             "maxLength": 40,
             "x-portone-name": "수신자 국가",
-            "x-portone-summary": "<p>수신자의 국가 (<code>physical</code> 주문인 경우 필수 파라미터)</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>수신자의 국가 (<code>physical</code> 주문인 경우 필수 파라미터)</p>\n"
           },
           {
             "name": "shipping_address_city",
@@ -4556,8 +4413,7 @@
             "type": "string",
             "maxLength": 40,
             "x-portone-name": "수신자 시",
-            "x-portone-summary": "<p>수신자 주소 중 시 (<code>physical</code> 주문인 경우 필수 파라미터)</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>수신자 주소 중 시 (<code>physical</code> 주문인 경우 필수 파라미터)</p>\n"
           },
           {
             "name": "shipping_address_zip",
@@ -4566,8 +4422,7 @@
             "type": "string",
             "maxLength": 40,
             "x-portone-name": "수신자 우편번호",
-            "x-portone-summary": "<p>수신자 우편번호 (<code>physical</code> 주문인 경우 필수 파라미터)</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>수신자 우편번호 (<code>physical</code> 주문인 경우 필수 파라미터)</p>\n"
           },
           {
             "name": "shipping_address_state",
@@ -4576,8 +4431,7 @@
             "type": "string",
             "maxLength": 40,
             "x-portone-name": "수신자 주",
-            "x-portone-summary": "<p>수신자 주소 중 주. 미국이 아닌 경우 'N/A'로 표기 (<code>physical</code> 주문인 경우 필수 파라미터)</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>수신자 주소 중 주. 미국이 아닌 경우 'N/A'로 표기 (<code>physical</code> 주문인 경우 필수 파라미터)</p>\n"
           },
           {
             "name": "shipping_address_street",
@@ -4586,8 +4440,7 @@
             "type": "string",
             "maxLength": 40,
             "x-portone-name": "수신자 거리명",
-            "x-portone-summary": "<p>수신자 거리명 (<code>physical</code> 주문인 경우 필수 파라미터)</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>수신자 거리명 (<code>physical</code> 주문인 경우 필수 파라미터)</p>\n"
           },
           {
             "name": "shipping_address_phone",
@@ -4596,8 +4449,7 @@
             "type": "string",
             "maxLength": 40,
             "x-portone-name": "수신자 전화번호",
-            "x-portone-summary": "<p>수신자 전화번호 (<code>physical</code> 주문인 경우 필수 파라미터)</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>수신자 전화번호 (<code>physical</code> 주문인 경우 필수 파라미터)</p>\n"
           },
           {
             "name": "shipping_address_firstname",
@@ -4606,8 +4458,7 @@
             "type": "string",
             "maxLength": 40,
             "x-portone-name": "수신자 이름",
-            "x-portone-summary": "<p>수신자 이름 (<code>physical</code> 주문인 경우 필수 파라미터)</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>수신자 이름 (<code>physical</code> 주문인 경우 필수 파라미터)</p>\n"
           },
           {
             "name": "shipping_address_lastname",
@@ -4616,8 +4467,7 @@
             "type": "string",
             "maxLength": 40,
             "x-portone-name": "수신자 성",
-            "x-portone-summary": "<p>수신자 성 (<code>physical</code> 주문인 경우 필수 파라미터)</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>수신자 성 (<code>physical</code> 주문인 경우 필수 파라미터)</p>\n"
           }
         ],
         "responses": {
@@ -4660,8 +4510,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "포트원 거래고유번호",
-            "x-portone-summary": "<p>현금영수증을 조회할 결제건의 포트원 거래고유번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>현금영수증을 조회할 결제건의 포트원 거래고유번호</p>\n"
           }
         ],
         "responses": {
@@ -4716,8 +4565,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "포트원 거래고유번호",
-            "x-portone-summary": "<p>현금영수증을 발급할 결제건의 포트원 거래 고유번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>현금영수증을 발급할 결제건의 포트원 거래 고유번호</p>\n"
           },
           {
             "name": "product_type",
@@ -4730,7 +4578,7 @@
               "digital"
             ],
             "x-portone-name": "주문 상품구분",
-            "x-portone-summary": "<p>현금영수증 발행 주문 상품구분</p>\n",
+            "x-portone-description": "<p>현금영수증 발행 주문 상품구분</p>\n",
             "x-portone-supported-pgs": [
               "ksnet",
               "nice_v2"
@@ -4748,8 +4596,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "식별정보",
-            "x-portone-summary": "<p>현금영수증 발행대상 식별정보로 <code>국세청현금영수증카드</code>, <code>휴대폰번호</code>, <code>주민등록번호</code>, <code>사업자등록번호</code>를 기재합니다.</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>현금영수증 발행대상 식별정보로 <code>국세청현금영수증카드</code>, <code>휴대폰번호</code>, <code>주민등록번호</code>, <code>사업자등록번호</code>를 기재합니다.</p>\n",
             "x-portone-per-pg": {
               "html5_inicis": {
                 "description": "<p>identifier을 활용하여 자동으로 타입 처리가 이루어지므로, 별도의 identifier_type 파라미터 입력은 필요하지 않습니다.</p>\n"
@@ -4778,7 +4625,7 @@
               "taxcard"
             ],
             "x-portone-name": "식별정보 구분코드",
-            "x-portone-summary": "<p>현금영수증를 발행대상의 식별정보 구분코드</p>\n",
+            "x-portone-description": "<p>현금영수증를 발행대상의 식별정보 구분코드</p>\n",
             "x-portone-supported-pgs": [
               "kicc",
               "settle",
@@ -4809,7 +4656,7 @@
               "company"
             ],
             "x-portone-name": "타입(대상)",
-            "x-portone-summary": "<p>현금영수증 발행할 대상의 타입</p>\n",
+            "x-portone-description": "<p>현금영수증 발행할 대상의 타입</p>\n",
             "x-portone-per-pg": {
               "smartro_v2": {
                 "required": true
@@ -4829,8 +4676,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "고객센터 번호",
-            "x-portone-summary": "<p>현금영수증 발행 상점 고객센터 번호</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>현금영수증 발행 상점 고객센터 번호</p>\n",
             "x-portone-supported-pgs": [
               "daou"
             ],
@@ -4847,8 +4693,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "상점 사업자 명",
-            "x-portone-summary": "<p>현금영수증 발행 상점 사업자 명</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>현금영수증 발행 상점 사업자 명</p>\n",
             "x-portone-supported-pgs": [
               "daou"
             ],
@@ -4865,8 +4710,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "상점 사업자 번호",
-            "x-portone-summary": "<p>현금영수증 발행 상점 사업자 번호</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>현금영수증 발행 상점 사업자 번호</p>\n",
             "x-portone-supported-pgs": [
               "daou",
               "welcome"
@@ -4905,8 +4749,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "구매자 Email 주소",
-            "x-portone-summary": "<p>현금영수증을 발행할 결제건의 구매자 Email 주소</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>현금영수증을 발행할 결제건의 구매자 Email 주소</p>\n"
           },
           {
             "name": "buyer_tel",
@@ -4951,8 +4794,7 @@
             "required": false,
             "type": "number",
             "x-portone-name": "부가세 지정 금액",
-            "x-portone-summary": "<p>부가세 지정 가맹점에 한해 현금영수증 발행 금액 중 부가세 금액으로 부가세를 지정할 수 있습니다.</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>부가세 지정 가맹점에 한해 현금영수증 발행 금액 중 부가세 금액으로 부가세를 지정할 수 있습니다.</p>\n"
           }
         ],
         "responses": {
@@ -5024,8 +4866,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "포트원 거래고유번호",
-            "x-portone-summary": "<p>현금영수증을 취소할 결제건의 포트원 거래고유번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>현금영수증을 취소할 결제건의 포트원 거래고유번호</p>\n"
           }
         ],
         "responses": {
@@ -5086,8 +4927,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "가맹점 주문번호",
-            "x-portone-summary": "<p>현금영수증 발행 대상 가맹점 주문번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>현금영수증 발행 대상 가맹점 주문번호</p>\n"
           }
         ],
         "responses": {
@@ -5155,8 +4995,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "주문명",
-            "x-portone-summary": "<p>현금영수증 발행할 결제건의 주문명</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>현금영수증 발행할 결제건의 주문명</p>\n"
           },
           {
             "name": "amount",
@@ -5165,8 +5004,7 @@
             "required": true,
             "type": "integer",
             "x-portone-name": "발행 금액",
-            "x-portone-summary": "<p>현금영수증 발행할 결제건의 금액</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>현금영수증 발행할 결제건의 금액</p>\n"
           },
           {
             "name": "product_type",
@@ -5179,7 +5017,7 @@
               "digital"
             ],
             "x-portone-name": "주문 상품구분",
-            "x-portone-summary": "<p>현금영수증 발행할 결제건의 주문 상품구분</p>\n",
+            "x-portone-description": "<p>현금영수증 발행할 결제건의 주문 상품구분</p>\n",
             "x-portone-supported-pgs": [
               "ksnet"
             ],
@@ -5196,8 +5034,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "식별정보",
-            "x-portone-summary": "<p>현금영수증 발행대상 식별정보로 <code>국세청현금영수증카드</code>, <code>휴대폰번호</code>, <code>주민등록번호</code>, <code>사업자등록번호</code>를 기재합니다.</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>현금영수증 발행대상 식별정보로 <code>국세청현금영수증카드</code>, <code>휴대폰번호</code>, <code>주민등록번호</code>, <code>사업자등록번호</code>를 기재합니다.</p>\n",
             "x-portone-per-pg": {
               "html5_inicis": {
                 "description": "<p>identifier을 활용하여 자동으로 타입 처리가 이루어지므로, 별도의 identifier_type 파라미터 입력은 필요하지 않습니다.</p>\n"
@@ -5223,7 +5060,7 @@
               "taxcard"
             ],
             "x-portone-name": "식별정보 구분코드",
-            "x-portone-summary": "<p>현금영수증 발행대상의 식별정보 구분코드</p>\n",
+            "x-portone-description": "<p>현금영수증 발행대상의 식별정보 구분코드</p>\n",
             "x-portone-supported-pgs": [
               "kicc",
               "settle",
@@ -5254,7 +5091,7 @@
               "company"
             ],
             "x-portone-name": "타입(대상)",
-            "x-portone-summary": "<p>현금영수증 발행할 대상의 타입</p>\n",
+            "x-portone-description": "<p>현금영수증 발행할 대상의 타입</p>\n",
             "x-portone-per-pg": {
               "smartro_v2": {
                 "required": true
@@ -5292,8 +5129,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "구매자 Email 주소",
-            "x-portone-summary": "<p>현금영수증을 발행할 결제건의 구매자 Email 주소</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>현금영수증을 발행할 결제건의 구매자 Email 주소</p>\n"
           },
           {
             "name": "buyer_tel",
@@ -5331,7 +5167,7 @@
             "type": "string",
             "maxLength": 80,
             "x-portone-name": "PG 구분코드",
-            "x-portone-summary": "<p>현금영수증을 발행할 PG사 구분코드</p>\n"
+            "x-portone-description": "<p>현금영수증을 발행할 PG사 구분코드</p>\n"
           },
           {
             "name": "vat_amount",
@@ -5340,8 +5176,7 @@
             "required": false,
             "type": "number",
             "x-portone-name": "부가세 지정 금액",
-            "x-portone-summary": "<p>부가세 지정 가맹점에 한해 현금영수증 발행 금액 중 부가세 금액으로 부가세를 지정할 수 있습니다.</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>부가세 지정 가맹점에 한해 현금영수증 발행 금액 중 부가세 금액으로 부가세를 지정할 수 있습니다.</p>\n"
           },
           {
             "name": "corp_reg_no",
@@ -5350,8 +5185,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "상점 사업자 번호",
-            "x-portone-summary": "<p>현금영수증 발행 상점 사업자 번호</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>현금영수증 발행 상점 사업자 번호</p>\n",
             "x-portone-supported-pgs": [
               "welcome"
             ],
@@ -5372,8 +5206,7 @@
               "vbank"
             ],
             "x-portone-name": "결제수단",
-            "x-portone-summary": "<p>현금영수증 발행 할 결제건의 결제수단</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>현금영수증 발행 할 결제건의 결제수단</p>\n",
             "x-portone-supported-pgs": [
               "welcome"
             ],
@@ -5546,8 +5379,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "카드사코드",
-            "x-portone-summary": "<p>조회할 카드사 코드</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>조회할 카드사 코드</p>\n"
           }
         ],
         "responses": {
@@ -5620,8 +5452,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "은행코드",
-            "x-portone-summary": "<p>조회할 은행코드</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>조회할 은행코드</p>\n"
           }
         ],
         "responses": {
@@ -5665,8 +5496,7 @@
             "type": "string",
             "maxLength": 40,
             "x-portone-name": "가맹점 주문번호",
-            "x-portone-summary": "<p>가맹점 거래 고유번호로 매 결제요청 시 고유값으로 요청해야 합니다.</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>가맹점 거래 고유번호로 매 결제요청 시 고유값으로 요청해야 합니다.</p>\n"
           },
           {
             "name": "currency",
@@ -5675,8 +5505,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "결제통화 구분코드",
-            "x-portone-summary": "<p>통화 e.g.) KRW, USD, VND, ... Default: KRW</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>통화 e.g.) KRW, USD, VND, ... Default: KRW</p>\n",
             "x-portone-per-pg": {
               "ksnet": {
                 "description": "<p>USD 결제는 순수 해외카드로만 결제 가능합니다.</p>\n"
@@ -5690,8 +5519,7 @@
             "required": true,
             "type": "number",
             "x-portone-name": "결제금액",
-            "x-portone-summary": "<p>결제요청 할 금액</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>결제요청 할 금액</p>\n"
           },
           {
             "name": "tax_free",
@@ -5700,7 +5528,7 @@
             "required": false,
             "type": "number",
             "x-portone-name": "면세금액",
-            "x-portone-summary": "<p>amount 중 면세공급가액</p>\n",
+            "x-portone-description": "<p>amount 중 면세공급가액</p>\n",
             "x-portone-per-pg": {
               "ksnet": {
                 "description": "<p>면세 설정 상점아이디에서 면세처리를 위해 결제 금액과 동일한 면세 금액을 반드시 입력해야 합니다. 그렇지 않은 경우 매출전표에 전액 면세가 아닌 것으로 표시되고 실제 처리 내역이 다를 수 있습니다.</p>\n<p>과세 설정 상점아이디에서 면세 금액을 전달하지 않아야 합니다. 면세 금액을 전달하는 경우 매출전표에 면세 처리된 것으로 표시되지만 실제 처리 내역과 다를 수 있습니다.</p>\n"
@@ -5747,8 +5575,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "카드번호",
-            "x-portone-summary": "<p>카드번호(<code>dddd-dddd-dddd-dddd</code>) 기재 양식을 유의하세요.</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>카드번호(<code>dddd-dddd-dddd-dddd</code>) 기재 양식을 유의하세요.</p>\n"
           },
           {
             "name": "expiry",
@@ -5757,8 +5584,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "카드 유효기간",
-            "x-portone-summary": "<p>카드 유효기간(<code>YYYY-MM</code>) 기재 양식을 유의하세요.</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>카드 유효기간(<code>YYYY-MM</code>) 기재 양식을 유의하세요.</p>\n"
           },
           {
             "name": "birth",
@@ -5797,8 +5623,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "카드 인증번호",
-            "x-portone-summary": "<p>결제 요청할 카드의 인증번호 (카드 뒷면 3자리, AMEX의 경우 4자리)</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>결제 요청할 카드의 인증번호 (카드 뒷면 3자리, AMEX의 경우 4자리)</p>\n",
             "x-portone-supported-pgs": [
               "paymentwall"
             ],
@@ -5816,7 +5641,7 @@
             "type": "string",
             "maxLength": 80,
             "x-portone-name": "구매자의 결제 수단 식별 고유번호",
-            "x-portone-summary": "<p>빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n",
+            "x-portone-description": "<p>빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n",
             "x-portone-unsupported-pgs": [
               "ksnet",
               "tosspayments"
@@ -5830,7 +5655,7 @@
             "type": "string",
             "maxLength": 80,
             "x-portone-name": "PG 구분코드",
-            "x-portone-summary": "<p>결제 요청할 PG사 구분코드</p>\n"
+            "x-portone-description": "<p>결제 요청할 PG사 구분코드</p>\n"
           },
           {
             "name": "name",
@@ -5840,8 +5665,7 @@
             "type": "string",
             "maxLength": 40,
             "x-portone-name": "주문명",
-            "x-portone-summary": "<p>결제요청 할 결제건의 주문명</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>결제요청 할 결제건의 주문명</p>\n",
             "x-portone-per-pg": {
               "html5_inicis": {
                 "required": true
@@ -5856,8 +5680,7 @@
             "type": "string",
             "maxLength": 16,
             "x-portone-name": "구매자명",
-            "x-portone-summary": "<p>결제건의 구매자명</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>결제건의 구매자명</p>\n",
             "x-portone-per-pg": {
               "html5_inicis": {
                 "required": true
@@ -5881,8 +5704,7 @@
             "type": "string",
             "maxLength": 64,
             "x-portone-name": "주문자 E-mail 주소",
-            "x-portone-summary": "<p>결제건의 주문자 E-mail주소</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>결제건의 주문자 E-mail주소</p>\n",
             "x-portone-per-pg": {
               "html5_inicis": {
                 "required": true
@@ -5897,8 +5719,7 @@
             "type": "string",
             "maxLength": 16,
             "x-portone-name": "주문자 전화번호",
-            "x-portone-summary": "<p>결제건의 주문자 전화번호</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>결제건의 주문자 전화번호</p>\n",
             "x-portone-per-pg": {
               "html5_inicis": {
                 "required": true
@@ -5913,8 +5734,7 @@
             "type": "string",
             "maxLength": 128,
             "x-portone-name": "주문자 주소",
-            "x-portone-summary": "<p>결제건의 주문자 주소</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>결제건의 주문자 주소</p>\n"
           },
           {
             "name": "buyer_postcode",
@@ -5924,8 +5744,7 @@
             "type": "string",
             "maxLength": 8,
             "x-portone-name": "주문자 우편번호",
-            "x-portone-summary": "<p>결제건의 주문자 우편번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>결제건의 주문자 우편번호</p>\n"
           },
           {
             "name": "card_quota",
@@ -5945,8 +5764,7 @@
             "type": "boolean",
             "default": false,
             "x-portone-name": "가맹점 부담 무이자 할부여부",
-            "x-portone-summary": "<p>카드할부처리할 때, 할부이자가 발생하는 경우(카드사 무이자 프로모션 제외) 부과되는 할부이자를 고객대신 가맹점이 지불하는지에 대한 여부 (<strong>PG사와 사전 계약이 필요</strong>)</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>카드할부처리할 때, 할부이자가 발생하는 경우(카드사 무이자 프로모션 제외) 부과되는 할부이자를 고객대신 가맹점이 지불하는지에 대한 여부 (<strong>PG사와 사전 계약이 필요</strong>)</p>\n",
             "x-portone-supported-pgs": [
               "nice_v2",
               "nice"
@@ -5960,8 +5778,7 @@
             "type": "boolean",
             "default": false,
             "x-portone-name": "카드포인트 사용여부",
-            "x-portone-summary": "<p>승인요청시 카드사 포인트 차감하며 결제승인처리할지 여부 flag. <strong>PG사 영업담당자와 계약 당시 사전 협의 필요</strong></p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>승인요청시 카드사 포인트 차감하며 결제승인처리할지 여부 flag. <strong>PG사 영업담당자와 계약 당시 사전 협의 필요</strong></p>\n",
             "x-portone-supported-pgs": [
               "ksnet",
               "nice",
@@ -5975,8 +5792,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "추가 정보",
-            "x-portone-summary": "<p>거래정보와 함께 저장할 추가 정보</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>거래정보와 함께 저장할 추가 정보</p>\n"
           },
           {
             "name": "notice_url",
@@ -5985,8 +5801,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "Notification URL(Webhook URL)",
-            "x-portone-summary": "<p>결제성공 시 통지될 Notification URL(Webhook URL)</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>결제성공 시 통지될 Notification URL(Webhook URL)</p>\n"
           },
           {
             "name": "browser_ip",
@@ -5995,8 +5810,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "브라우져 IP",
-            "x-portone-summary": "<p>구매자 브라우져(PC)의 IP</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>구매자 브라우져(PC)의 IP</p>\n",
             "x-portone-per-pg": {
               "paymentwall": {
                 "required": true
@@ -6010,8 +5824,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "결제 ID",
-            "x-portone-summary": "<p>해외PG 전용 파라미터로 3D secure 인증 후 재결제시 PG사에서 부여한 결제 ID</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>해외PG 전용 파라미터로 3D secure 인증 후 재결제시 PG사에서 부여한 결제 ID</p>\n",
             "x-portone-supported-pgs": [
               "paymentwall"
             ]
@@ -6023,8 +5836,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "토큰",
-            "x-portone-summary": "<p>해외PG 전용 파라미터로 3D secure 인증 후 재결제시 PG사에서 부여한 토큰</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>해외PG 전용 파라미터로 3D secure 인증 후 재결제시 PG사에서 부여한 토큰</p>\n",
             "x-portone-supported-pgs": [
               "paymentwall"
             ]
@@ -6040,7 +5852,7 @@
               "digital"
             ],
             "x-portone-name": "주문 상품구분",
-            "x-portone-summary": "<p>결제 요청할 판매 상품에 대한 구분 값</p>\n",
+            "x-portone-description": "<p>결제 요청할 판매 상품에 대한 구분 값</p>\n",
             "x-portone-supported-pgs": [
               "ksnet"
             ],
@@ -6102,7 +5914,7 @@
             "type": "string",
             "maxLength": 80,
             "x-portone-name": "구매자의 결제 수단 식별 고유번호",
-            "x-portone-summary": "<p>빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n"
+            "x-portone-description": "<p>빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n"
           },
           {
             "name": "merchant_uid",
@@ -6112,8 +5924,7 @@
             "type": "string",
             "maxLength": 40,
             "x-portone-name": "가맹점 주문번호",
-            "x-portone-summary": "<p>결제 요청할 결제건의 가맹점 거래 고유번호</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>결제 요청할 결제건의 가맹점 거래 고유번호</p>\n",
             "x-portone-per-pg": {
               "smartro_v2": {
                 "description": "<p>스마트로는 주문 번호(merchant_uid)에 <strong>특수문자를 허용하고 있지 않습니다.</strong></p>\n<p>따라서 결제창에서 일반결제를 할때와 발급 된 빌링키로 API를 통해 재결제를 하는 경우 숫자, 문자(알파벳 소문자와 대문자) 또는 그 조합으로 이루어진 주문 번호를 사용해주세요.\n또한, 주문번호(merchant_uid)가 <strong>최대 40자</strong>를 넘을 수 없습니다. 40자가 넘을 경우 40자까지 잘려서 저장되기 때문에 유의 바랍니다.</p>\n"
@@ -6127,8 +5938,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "결제 통화 코드",
-            "x-portone-summary": "<p>통화 e.g.) KRW, USD, VND, ... Default: KRW</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>통화 e.g.) KRW, USD, VND, ... Default: KRW</p>\n",
             "x-portone-per-pg": {
               "ksnet": {
                 "description": "<p>USD 결제는 순수 해외카드로만 결제 가능합니다.</p>\n"
@@ -6146,8 +5956,7 @@
             "required": true,
             "type": "number",
             "x-portone-name": "결제금액",
-            "x-portone-summary": "<p>결제 요청할 금액</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>결제 요청할 금액</p>\n"
           },
           {
             "name": "tax_free",
@@ -6156,7 +5965,7 @@
             "required": false,
             "type": "number",
             "x-portone-name": "면세금액",
-            "x-portone-summary": "<p>amount 중 면세공급가액</p>\n",
+            "x-portone-description": "<p>amount 중 면세공급가액</p>\n",
             "x-portone-per-pg": {
               "ksnet": {
                 "description": "<p>면세 설정 상점아이디에서 면세처리를 위해 결제 금액과 동일한 면세 금액을 반드시 입력해야 합니다. 그렇지 않은 경우 매출전표에 전액 면세가 아닌 것으로 표시되고 실제 처리 내역이 다를 수 있습니다.</p>\n<p>과세 설정 상점아이디에서 면세 금액을 전달하지 않아야 합니다. 면세 금액을 전달하는 경우 매출전표에 면세 처리된 것으로 표시되지만 실제 처리 내역과 다를 수 있습니다.</p>\n"
@@ -6203,8 +6012,7 @@
             "type": "string",
             "maxLength": 40,
             "x-portone-name": "제품명",
-            "x-portone-summary": "<p>결제 요청할 결제건의 제품명</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>결제 요청할 결제건의 제품명</p>\n",
             "x-portone-per-pg": {
               "html5_inicis": {
                 "required": true
@@ -6222,8 +6030,7 @@
             "type": "string",
             "maxLength": 16,
             "x-portone-name": "주문자명",
-            "x-portone-summary": "<p>결제건의 주문자명</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>결제건의 주문자명</p>\n",
             "x-portone-per-pg": {
               "smartro_v2": {
                 "required": true
@@ -6247,8 +6054,7 @@
             "type": "string",
             "maxLength": 64,
             "x-portone-name": "주문자 E-mail 주소",
-            "x-portone-summary": "<p>결제건의 주문자 E-mail주소</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>결제건의 주문자 E-mail주소</p>\n",
             "x-portone-per-pg": {
               "smartro_v2": {
                 "required": true
@@ -6267,8 +6073,7 @@
             "type": "string",
             "maxLength": 16,
             "x-portone-name": "주문자 전화번호",
-            "x-portone-summary": "<p>결제건의 주문자 전화번호</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>결제건의 주문자 전화번호</p>\n",
             "x-portone-per-pg": {
               "smartro_v2": {
                 "required": true
@@ -6283,8 +6088,7 @@
             "type": "string",
             "maxLength": 128,
             "x-portone-name": "주문자 주소",
-            "x-portone-summary": "<p>결제건의 주문자 주소</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>결제건의 주문자 주소</p>\n"
           },
           {
             "name": "buyer_postcode",
@@ -6294,8 +6098,7 @@
             "type": "string",
             "maxLength": 8,
             "x-portone-name": "주문자 우편번호",
-            "x-portone-summary": "<p>결제건의 주문자 우편번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>결제건의 주문자 우편번호</p>\n"
           },
           {
             "name": "card_quota",
@@ -6304,7 +6107,7 @@
             "required": false,
             "type": "integer",
             "x-portone-name": "카드 할부 개월수",
-            "x-portone-summary": "<p>결제건의 카드 할부 개월 수로 기본값은 **0(일시불)**입니다.</p>\n"
+            "x-portone-description": "<p>결제건의 카드 할부 개월 수로 기본값은 **0(일시불)**입니다.</p>\n"
           },
           {
             "name": "interest_free_by_merchant",
@@ -6314,8 +6117,7 @@
             "type": "boolean",
             "default": false,
             "x-portone-name": "가맹점부담 무이자 할부여부",
-            "x-portone-summary": "<p>카드할부처리할 때, 할부이자가 발생하는 경우(카드사 무이자 프로모션 제외) 부과되는 할부이자를 고객대신 가맹점이 지불하는지에 대한 여부 (<strong>PG사와 사전 계약이 필요</strong>)</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>카드할부처리할 때, 할부이자가 발생하는 경우(카드사 무이자 프로모션 제외) 부과되는 할부이자를 고객대신 가맹점이 지불하는지에 대한 여부 (<strong>PG사와 사전 계약이 필요</strong>)</p>\n",
             "x-portone-supported-pgs": [
               "nice",
               "ksnet",
@@ -6330,8 +6132,7 @@
             "type": "boolean",
             "default": false,
             "x-portone-name": "카드포인트 사용여부",
-            "x-portone-summary": "<p>승인요청시 카드사 포인트 차감하며 결제승인처리할지 여부 flag. <strong>PG사 영업담당자와 계약 당시 사전 협의 필요</strong></p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>승인요청시 카드사 포인트 차감하며 결제승인처리할지 여부 flag. <strong>PG사 영업담당자와 계약 당시 사전 협의 필요</strong></p>\n",
             "x-portone-supported-pgs": [
               "nice",
               "smartro_v2",
@@ -6345,8 +6146,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "빌링키 발급 시 같이 저장할 가맹점 custom 데이터",
-            "x-portone-summary": "<p>거래정보와 함께 저장할 추가 정보</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>거래정보와 함께 저장할 추가 정보</p>\n"
           },
           {
             "name": "notice_url",
@@ -6355,8 +6155,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "Notification URL(Webhook URL)",
-            "x-portone-summary": "<p>결제성공 시 통지될 Notification URL(Webhook URL)</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>결제성공 시 통지될 Notification URL(Webhook URL)</p>\n"
           },
           {
             "name": "browser_ip",
@@ -6365,8 +6164,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "브라우저의 IP",
-            "x-portone-summary": "<p>구매자 브라우져(PC)의 IP</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>구매자 브라우져(PC)의 IP</p>\n",
             "x-portone-per-pg": {
               "paymentwall": {
                 "required": true
@@ -6384,7 +6182,7 @@
               "digital"
             ],
             "x-portone-name": "주문 상품구분",
-            "x-portone-summary": "<p>결제 요청할 판매 상품에 대한 구분 값</p>\n",
+            "x-portone-description": "<p>결제 요청할 판매 상품에 대한 구분 값</p>\n",
             "x-portone-supported-pgs": [
               "ksnet",
               "paypal_v2"
@@ -6402,8 +6200,7 @@
             "required": false,
             "type": "integer",
             "x-portone-name": "결제 상품의 개수",
-            "x-portone-summary": "<p>결제 상품의 개수로 기본값은 1입니다.</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>결제 상품의 개수로 기본값은 1입니다.</p>\n"
           },
           {
             "name": "cash_receipt_type",
@@ -6417,7 +6214,7 @@
               "anonymous"
             ],
             "x-portone-name": "현금영수증 발행대상 타입",
-            "x-portone-summary": "<p>현금영수증 발행대상의 구분 값</p>\n",
+            "x-portone-description": "<p>현금영수증 발행대상의 구분 값</p>\n",
             "x-portone-supported-pgs": [
               "tosspay_v2"
             ],
@@ -6507,8 +6304,7 @@
             "required": true,
             "type": "integer",
             "x-portone-name": "조회 시작시각",
-            "x-portone-summary": "<p>조회 시작시각 unix timestamp(결제예약건의 '예약시각'기준으로 조회합니다. from &lt;= '예약시각')</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>조회 시작시각 unix timestamp(결제예약건의 '예약시각'기준으로 조회합니다. from &lt;= '예약시각')</p>\n"
           },
           {
             "name": "schedule_to",
@@ -6517,8 +6313,7 @@
             "required": true,
             "type": "integer",
             "x-portone-name": "조회 종료시각",
-            "x-portone-summary": "<p>조회 종료시각 unix timestamp(결제예약건의 '예약시각'기준으로 조회합니다. '예약시각' &lt; to)</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>조회 종료시각 unix timestamp(결제예약건의 '예약시각'기준으로 조회합니다. '예약시각' &lt; to)</p>\n"
           },
           {
             "name": "schedule_status",
@@ -6532,7 +6327,7 @@
               "revoked"
             ],
             "x-portone-name": "예약상태",
-            "x-portone-summary": "<p>조회할 결제건의 예약상태</p>\n"
+            "x-portone-description": "<p>조회할 결제건의 예약상태</p>\n"
           },
           {
             "name": "page",
@@ -6541,8 +6336,7 @@
             "required": false,
             "type": "integer",
             "x-portone-name": "조회목록 페이징",
-            "x-portone-summary": "<p>조회목록 페이징으로 기본값은 1입니다.</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>조회목록 페이징으로 기본값은 1입니다.</p>\n"
           },
           {
             "name": "limit",
@@ -6554,8 +6348,7 @@
             "maximum": "1000",
             "minimum": "1",
             "x-portone-name": "페이지당 조회건수",
-            "x-portone-summary": "<p>한 번에 조회할 결제예약건수.(최대 1000건, 기본값 20건)</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>한 번에 조회할 결제예약건수.(최대 1000건, 기본값 20건)</p>\n"
           },
           {
             "name": "sorting",
@@ -6564,7 +6357,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "정렬방식",
-            "x-portone-summary": "<p>조회된 결제건의 정렬방식</p>\n"
+            "x-portone-description": "<p>조회된 결제건의 정렬방식</p>\n"
           }
         ],
         "responses": {
@@ -6633,8 +6426,7 @@
             "type": "string",
             "maxLength": 80,
             "x-portone-name": "구매자의 결제 수단 식별 고유번호",
-            "x-portone-summary": "<p>빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n"
           },
           {
             "name": "customer_id",
@@ -6642,9 +6434,8 @@
             "description": "string 타입의 구매자 식별 고유번호 (필수 : 토스페이먼츠)",
             "required": false,
             "type": "string",
-            "x-portone-summary": "<p>string 타입의 구매자 식별 고유번호</p>\n",
+            "x-portone-description": "<p>string 타입의 구매자 식별 고유번호</p>\n",
             "x-portone-name": "구매자 ID",
-            "x-portone-description": "",
             "x-portone-per-pg": {
               "tosspayments": {
                 "required": true,
@@ -6669,8 +6460,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "카드번호",
-            "x-portone-summary": "<p>결제 예약 요청할 카드번호(<code>dddd-dddd-dddd-dddd</code>)</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>결제 예약 요청할 카드번호(<code>dddd-dddd-dddd-dddd</code>)</p>\n",
             "x-portone-unsupported-pgs": [
               "chai",
               "danal",
@@ -6694,8 +6484,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "카드 유효기간",
-            "x-portone-summary": "<p>결제 예약 요청할 카드 유효기간(<code>YYYY-MM</code>)</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>결제 예약 요청할 카드 유효기간(<code>YYYY-MM</code>)</p>\n",
             "x-portone-unsupported-pgs": [
               "chai",
               "danal",
@@ -6719,8 +6508,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "생년월일 6자리",
-            "x-portone-summary": "<p>결제 예약 요청할 카드 소유자의 생년월일6자리(법인카드의 경우 사업자등록번호10자리)</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>결제 예약 요청할 카드 소유자의 생년월일6자리(법인카드의 경우 사업자등록번호10자리)</p>\n",
             "x-portone-unsupported-pgs": [
               "chai",
               "danal",
@@ -6744,8 +6532,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "카드비밀번호 앞 2자리",
-            "x-portone-summary": "<p>결제 예약 요청할 카드비밀번호 앞 2자리</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>결제 예약 요청할 카드비밀번호 앞 2자리</p>\n"
           },
           {
             "name": "cvc",
@@ -6754,8 +6541,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "카드 인증번호",
-            "x-portone-summary": "<p>결제 예약 요청할 카드 인증번호 (카드 뒷면 3자리, AMEX의 경우 4자리)</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>결제 예약 요청할 카드 인증번호 (카드 뒷면 3자리, AMEX의 경우 4자리)</p>\n",
             "x-portone-supported-pgs": [
               "paymentwall"
             ],
@@ -6787,7 +6573,7 @@
             },
             "default": "[&#13;&#09;{&#13;&#09;&#09;&quot;merchant_uid&quot;: &quot;your_merchant_uid1&quot;,&#13;&#09;&#09;&quot;schedule_at&quot;: 1478150985,&#13;&#09;&#09;&quot;currency&quot;: &quot;KRW&quot;,&#13;&#09;&#09;&quot;amount&quot;: 1004,&#13;&#09;&#09;&quot;name&quot;: &quot;주문명&quot;,&#13;&#09;&#09;&quot;buyer_name&quot;: &quot;주문자명&quot;,&#13;&#09;&#09;&quot;buyer_email&quot;: &quot;주문자 Email주소&quot;,&#13;&#09;&#09;&quot;buyer_tel&quot;: &quot;주문자 전화번호&quot;,&#13;&#09;&#09;&quot;buyer_addr&quot;: &quot;주문자 주소&quot;,&#13;&#09;&#09;&quot;buyer_postcode&quot;: &quot;주문자 우편번호&quot;&#13;},&#13;&#09;{&#13;&#09;&#09;&quot;merchant_uid&quot;: &quot;your_merchant_uid2&quot;,&#13;&#09;&#09;&quot;schedule_at&quot;: 1478150985,&#13;&#09;&#09;&quot;amount&quot;: 1004,&#13;&#09;&#09;&quot;name&quot;: &quot;주문명&quot;,&#13;&#09;&#09;&quot;buyer_name&quot;: &quot;주문자명&quot;,&#13;&#09;&#09;&quot;buyer_email&quot;: &quot;주문자 Email주소&quot;,&#13;&#09;&#09;&quot;buyer_tel&quot;: &quot;주문자 전화번호&quot;,&#13;&#09;&#09;&quot;buyer_addr&quot;: &quot;주문자 주소&quot;,&#13;&#09;&#09;&quot;buyer_postcode&quot;: &quot;주문자 우편번호&quot;}&#13;]",
             "x-portone-name": "결제예약 스케쥴",
-            "x-portone-summary": "<p>결제예약 스케쥴에 대한 배열</p>\n"
+            "x-portone-description": "<p>결제예약 스케쥴에 대한 배열</p>\n"
           }
         ],
         "responses": {
@@ -6898,8 +6684,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "구매자의 결제 수단 식별 고유번호",
-            "x-portone-summary": "<p>빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n"
           },
           {
             "name": "merchant_uid",
@@ -6979,8 +6764,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "가맹점 주문번호",
-            "x-portone-summary": "<p>결제예약에 사용된 가맹점 거래 고유번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>결제예약에 사용된 가맹점 거래 고유번호</p>\n"
           }
         ],
         "responses": {
@@ -7025,6 +6809,238 @@
           "tosspay_v2"
         ],
         "x-portone-category": "nonAuthPayment.subscribe"
+      },
+      "put": {
+        "tags": [
+          "subscribe"
+        ],
+        "summary": "결제요청 예약시각 수정 API",
+        "description": "결제예약 시 사용한 거래주문번호(merchant_uid)를 이용하여 해당하는 예약 건의 결제요청 예약시각을 수정할 수 있습니다.",
+        "operationId": "updateScheduleByMid",
+        "consumes": [
+          "application/json",
+          "application/x-www-form-urlencoded"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "merchant_uid",
+            "in": "path",
+            "description": "결제예약에 사용된 가맹점 거래 고유번호",
+            "required": true,
+            "type": "string",
+            "x-portone-name": "가맹점 주문번호",
+            "x-portone-description": "<p>결제예약에 사용된 가맹점 거래 고유번호</p>\n"
+          },
+          {
+            "name": "schedule_at",
+            "in": "formData",
+            "description": "수정할 결제요청 예약시각 UNIX timestamp in seconds",
+            "required": true,
+            "type": "integer",
+            "x-portone-name": "수정할 예약시각",
+            "x-portone-description": "<p>수정할 결제요청 예약시각 UNIX timestamp</p>\n"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "정상적으로 예약 변경이 완료되었습니다.",
+            "schema": {
+              "$ref": "#/definitions/SingleScheduleResponse"
+            }
+          },
+          "400": {
+            "description": "필수 파라미터 누락, 이미 실행 혹은 취소된 결제예약, 예약시각이 현재 시각보다 과거인 경우"
+          },
+          "404": {
+            "description": "존재하지 않는 결제예약"
+          },
+          "500": {
+            "description": "포트원 내부 이슈로 인한 API 호출 실패"
+          }
+        },
+        "x-portone-supported-pgs": [
+          "chai",
+          "danal",
+          "danal_tpay",
+          "daou",
+          "html5_inicis",
+          "inicis",
+          "jtnet",
+          "kakaopay",
+          "kcp",
+          "kcp_billing",
+          "kicc",
+          "ksnet",
+          "mobilians",
+          "naverpay",
+          "nice",
+          "nice_v2",
+          "payco",
+          "paymentwall",
+          "settle",
+          "settle_acc",
+          "smartro_v2",
+          "tosspayments",
+          "paypal_v2",
+          "welcome"
+        ],
+        "x-portone-category": "nonAuthPayment.subscribe"
+      }
+    },
+    "/subscribe/payments/schedule/{merchant_uid}/reschedule": {
+      "post": {
+        "tags": [
+          "subscribe"
+        ],
+        "summary": "결제 실패 재예약 API",
+        "description": "결제 예약 실행 시 실패했던 건에 대해 다른 시각으로 다시 결제 예약을 할 수 있습니다.",
+        "operationId": "rescheduleByMid",
+        "consumes": [
+          "application/json",
+          "application/x-www-form-urlencoded"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "merchant_uid",
+            "in": "path",
+            "description": "결제예약에 사용된 가맹점 거래 고유번호",
+            "required": true,
+            "type": "string",
+            "x-portone-name": "가맹점 주문번호",
+            "x-portone-description": "<p>결제예약에 사용된 가맹점 거래 고유번호</p>\n"
+          },
+          {
+            "name": "schedule_at",
+            "in": "formData",
+            "description": "실패한 예약건을 다시 처리할 시각 UNIX timestamp in seconds",
+            "required": true,
+            "type": "integer",
+            "x-portone-name": "예약 시각",
+            "x-portone-description": "<p>실패한 예약건을 다시 처리할 시각 UNIX timestamp</p>\n"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "정상적으로 재예약이 완료되었습니다.",
+            "schema": {
+              "$ref": "#/definitions/SingleScheduleResponse"
+            }
+          },
+          "400": {
+            "description": "필수 파라미터 누락, 이미 취소된 결제예약, 아직 실행되지 않거나 승인된 결제예약, 예약시각이 현재 시각보다 과거인 경우"
+          },
+          "404": {
+            "description": "존재하지 않는 결제예약"
+          },
+          "500": {
+            "description": "포트원 내부 이슈로 인한 API 호출 실패"
+          }
+        },
+        "x-portone-supported_pgs": [
+          "chai",
+          "danal",
+          "danal_tpay",
+          "daou",
+          "html5_inicis",
+          "inicis",
+          "jtnet",
+          "kakaopay",
+          "kcp",
+          "kcp_billing",
+          "kicc",
+          "ksnet",
+          "mobilians",
+          "naverpay",
+          "nice",
+          "nice_v2",
+          "payco",
+          "paymentwall",
+          "settle",
+          "settle_acc",
+          "smartro_v2",
+          "tosspayments",
+          "paypal_v2",
+          "welcome"
+        ],
+        "x-portone-category": "nonAuthPayment.subscribe"
+      }
+    },
+    "/subscribe/payments/schedule/{merchant_uid}/retry": {
+      "post": {
+        "tags": [
+          "subscribe"
+        ],
+        "summary": "결제 실패 재시도 API",
+        "description": "결제 예약 실행 시 실패했던 건에 즉시 결제 재시도 할 수 있습니다.",
+        "operationId": "retryScheduleByMid",
+        "consumes": [
+          "application/json",
+          "application/x-www-form-urlencoded"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "merchant_uid",
+            "in": "path",
+            "description": "결제예약에 사용된 가맹점 거래 고유번호",
+            "required": true,
+            "type": "string",
+            "x-portone-name": "가맹점 주문번호",
+            "x-portone-description": "<p>결제예약에 사용된 가맹점 거래 고유번호</p>\n"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "정상적으로 재시도가 완료되었습니다. (결제 성공/실패 여부는 결제 상태(status)로 확인 필요)",
+            "schema": {
+              "$ref": "#/definitions/PaymentResponse"
+            }
+          },
+          "400": {
+            "description": "필수 파라미터 누락, 이미 취소된 결제예약, 아직 실행되지 않거나 승인된 결제예약"
+          },
+          "404": {
+            "description": "존재하지 않는 결제예약 혹은 빌링키"
+          },
+          "500": {
+            "description": "미지원 PG사, 포트원 내부 이슈 등으로 인한 API 호출 실패"
+          }
+        },
+        "x-portone-supported_pgs": [
+          "chai",
+          "danal",
+          "danal_tpay",
+          "daou",
+          "html5_inicis",
+          "inicis",
+          "jtnet",
+          "kakaopay",
+          "kcp",
+          "kcp_billing",
+          "kicc",
+          "ksnet",
+          "mobilians",
+          "naverpay",
+          "nice",
+          "nice_v2",
+          "payco",
+          "paymentwall",
+          "settle",
+          "settle_acc",
+          "smartro_v2",
+          "tosspayments",
+          "paypal_v2",
+          "welcome"
+        ],
+        "x-portone-category": "nonAuthPayment.subscribe"
       }
     },
     "/subscribe/payments/schedule/customers/{customer_uid}": {
@@ -7050,8 +7066,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "빌링키",
-            "x-portone-summary": "<p>string 타입의 고객의 결제 수단 식별 고유번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>string 타입의 고객의 결제 수단 식별 고유번호</p>\n"
           },
           {
             "name": "page",
@@ -7060,8 +7075,7 @@
             "required": false,
             "type": "integer",
             "x-portone-name": "조회목록 페이징",
-            "x-portone-summary": "<p>조회목록 페이징으로 기본값은 1입니다.</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>조회목록 페이징으로 기본값은 1입니다.</p>\n"
           },
           {
             "name": "from",
@@ -7070,8 +7084,7 @@
             "required": true,
             "type": "integer",
             "x-portone-name": "조회 시작시각",
-            "x-portone-summary": "<p>조회 시작시각 unix timestamp(결제예약건의 '예약시각'기준으로 조회합니다. from &lt;= '예약시각')</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>조회 시작시각 unix timestamp(결제예약건의 '예약시각'기준으로 조회합니다. from &lt;= '예약시각')</p>\n"
           },
           {
             "name": "to",
@@ -7080,8 +7093,7 @@
             "required": true,
             "type": "integer",
             "x-portone-name": "조회 종료시각",
-            "x-portone-summary": "<p>조회 종료시각 unix timestamp(결제예약건의 '예약시각'기준으로 조회합니다. '예약시각' &lt; to)</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>조회 종료시각 unix timestamp(결제예약건의 '예약시각'기준으로 조회합니다. '예약시각' &lt; to)</p>\n"
           },
           {
             "name": "schedule-status",
@@ -7095,7 +7107,7 @@
               "revoked"
             ],
             "x-portone-name": "예약상태",
-            "x-portone-summary": "<p>조회할 결제건의 예약상태</p>\n"
+            "x-portone-description": "<p>조회할 결제건의 예약상태</p>\n"
           }
         ],
         "responses": {
@@ -7166,7 +7178,7 @@
             "type": "string",
             "default": "XYZ",
             "x-portone-name": "Tier 코드",
-            "x-portone-summary": "<p>하위 가맹점의 고유 코드로 알파벳 대문자 또는 숫자만 사용 가능합니다.(<strong>반드시 3자리</strong>)</p>\n"
+            "x-portone-description": "<p>하위 가맹점의 고유 코드로 알파벳 대문자 또는 숫자만 사용 가능합니다.(<strong>반드시 3자리</strong>)</p>\n"
           }
         ],
         "responses": {
@@ -7208,7 +7220,7 @@
             "type": "string",
             "default": "XYZ",
             "x-portone-name": "Tier code",
-            "x-portone-summary": "<p>하위 가맹점의 고유 코드로 알파벳 대문자 또는 숫자만 사용 가능합니다.(<strong>반드시 3자리</strong>)</p>\n"
+            "x-portone-description": "<p>하위 가맹점의 고유 코드로 알파벳 대문자 또는 숫자만 사용 가능합니다.(<strong>반드시 3자리</strong>)</p>\n"
           },
           {
             "name": "tier_name",
@@ -7217,7 +7229,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "하위 가맹점 명칭",
-            "x-portone-summary": "<p>내부 관리용으로 사용되는 하위 가맹점의 명칭</p>\n"
+            "x-portone-description": "<p>내부 관리용으로 사용되는 하위 가맹점의 명칭</p>\n"
           }
         ],
         "responses": {
@@ -7265,7 +7277,7 @@
             "type": "string",
             "default": "XYZ",
             "x-portone-name": "Tier 코드",
-            "x-portone-summary": "<p>하위 가맹점의 고유 코드로 알파벳 대문자 또는 숫자만 사용 가능합니다.(<strong>반드시 3자리</strong>)</p>\n"
+            "x-portone-description": "<p>하위 가맹점의 고유 코드로 알파벳 대문자 또는 숫자만 사용 가능합니다.(<strong>반드시 3자리</strong>)</p>\n"
           },
           {
             "name": "tier_name",
@@ -7274,7 +7286,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "하위 가맹점 명칭",
-            "x-portone-summary": "<p>내부 관리용으로 사용되는 하위 가맹점의 명칭</p>\n"
+            "x-portone-description": "<p>내부 관리용으로 사용되는 하위 가맹점의 명칭</p>\n"
           }
         ],
         "responses": {
@@ -7319,7 +7331,7 @@
             "type": "string",
             "default": "XYZ",
             "x-portone-name": "Tier code",
-            "x-portone-summary": "<p>하위 가맹점의 고유 코드로 알파벳 대문자 또는 숫자만 사용 가능합니다.(<strong>반드시 3자리</strong>)</p>\n"
+            "x-portone-description": "<p>하위 가맹점의 고유 코드로 알파벳 대문자 또는 숫자만 사용 가능합니다.(<strong>반드시 3자리</strong>)</p>\n"
           }
         ],
         "responses": {
@@ -7392,8 +7404,7 @@
             "type": "string",
             "maxLength": 40,
             "x-portone-name": "가맹점 주문번호",
-            "x-portone-summary": "<p>가상계좌를 발급할 결제건의 가맹점 거래 고유번호으로 이미 결제가 이뤄진 적이 있는 merchant_uid로는 추가적인 가상계좌 생성이 불가능합니다.</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>가상계좌를 발급할 결제건의 가맹점 거래 고유번호으로 이미 결제가 이뤄진 적이 있는 merchant_uid로는 추가적인 가상계좌 생성이 불가능합니다.</p>\n",
             "x-portone-per-pg": {
               "smartro_v2": {
                 "descripton": "특수문자 포함이 불가능합니다."
@@ -7407,8 +7418,7 @@
             "required": true,
             "type": "number",
             "x-portone-name": "입금 예정 금액",
-            "x-portone-summary": "<p>발급 된 가상계좌에 입금 될 금액</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>발급 된 가상계좌에 입금 될 금액</p>\n"
           },
           {
             "name": "product_type",
@@ -7421,7 +7431,7 @@
               "digital"
             ],
             "x-portone-name": "상품구분",
-            "x-portone-summary": "<p>가상계좌 발급을 위한 결제건의 상품구분 코드</p>\n",
+            "x-portone-description": "<p>가상계좌 발급을 위한 결제건의 상품구분 코드</p>\n",
             "x-portone-supported-pgs": [
               "ksnet"
             ],
@@ -7438,8 +7448,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "고정 가상 계좌 번호",
-            "x-portone-summary": "<p>고정식 가상계좌 발급 시, pg사로부터 전달받은 가상계좌 번호 (<strong>사용을 위해 PG사와 협의 필요</strong>) </p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>고정식 가상계좌 발급 시, pg사로부터 전달받은 가상계좌 번호 (<strong>사용을 위해 PG사와 협의 필요</strong>) </p>\n",
             "x-portone-supported-pgs": [
               "smartro_v2"
             ],
@@ -7466,8 +7475,7 @@
             "required": true,
             "type": "integer",
             "x-portone-name": "가상계좌 입금기한",
-            "x-portone-summary": "<p>가상계좌 발급시 입금기한 UNIX TIMESTAMP</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>가상계좌 발급시 입금기한 UNIX TIMESTAMP</p>\n"
           },
           {
             "name": "vbank_holder",
@@ -7477,8 +7485,7 @@
             "type": "string",
             "maxLength": 16,
             "x-portone-name": "가상계좌 예금주명",
-            "x-portone-summary": "<p>가상계좌 발급을 위한 예금주명</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>가상계좌 발급을 위한 예금주명</p>\n",
             "x-portone-per-pg": {
               "html5_inicis": {
                 "required": true
@@ -7516,8 +7523,7 @@
             "type": "string",
             "maxLength": 13,
             "x-portone-name": "계좌 고유 키",
-            "x-portone-summary": "<p>고정식 가상계좌를 발급받기 위한 고객과 매칭시킨 계좌 고유 키(<strong>사용을 위해 PG사와 협의 필요</strong>)</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>고정식 가상계좌를 발급받기 위한 고객과 매칭시킨 계좌 고유 키(<strong>사용을 위해 PG사와 협의 필요</strong>)</p>\n",
             "x-portone-supported-pgs": [
               "tosspayments"
             ],
@@ -7535,8 +7541,7 @@
             "type": "string",
             "maxLength": 40,
             "x-portone-name": "주문명",
-            "x-portone-summary": "<p>가상계좌 발급을 위한 결제건의 주문명</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>가상계좌 발급을 위한 결제건의 주문명</p>\n"
           },
           {
             "name": "buyer_name",
@@ -7546,8 +7551,7 @@
             "type": "string",
             "maxLength": 16,
             "x-portone-name": "주문자명",
-            "x-portone-summary": "<p>가상계좌 발급을 위한 결제건의 주문자명</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>가상계좌 발급을 위한 결제건의 주문자명</p>\n",
             "x-portone-per-pg": {
               "html5_inicis": {
                 "required": true
@@ -7574,8 +7578,7 @@
             "type": "string",
             "maxLength": 64,
             "x-portone-name": "주문자 Email 주소",
-            "x-portone-summary": "<p>가상계좌 발급을 위한 결제건의 주문자 Email주소</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>가상계좌 발급을 위한 결제건의 주문자 Email주소</p>\n",
             "x-portone-per-pg": {
               "html5_inicis": {
                 "required": true
@@ -7593,8 +7596,7 @@
             "type": "string",
             "maxLength": 16,
             "x-portone-name": "주문자 전화번호",
-            "x-portone-summary": "<p>가상계좌 발급을 위한 결제건의 주문자 전화번호</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>가상계좌 발급을 위한 결제건의 주문자 전화번호</p>\n",
             "x-portone-per-pg": {
               "smartro_v2": {
                 "required": true
@@ -7612,8 +7614,7 @@
             "type": "string",
             "maxLength": 10,
             "x-portone-name": "사업자 등록번호",
-            "x-portone-summary": "<p>주문자의 사업자 등록번호</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>주문자의 사업자 등록번호</p>\n",
             "x-portone-supported-pgs": [
               "nice_v2"
             ],
@@ -7631,8 +7632,7 @@
             "type": "string",
             "maxLength": 128,
             "x-portone-name": "주문자 주소",
-            "x-portone-summary": "<p>가상계좌 발급을 위한 결제건의 주문자 주소</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>가상계좌 발급을 위한 결제건의 주문자 주소</p>\n"
           },
           {
             "name": "buyer_postcode",
@@ -7642,8 +7642,7 @@
             "type": "string",
             "maxLength": 8,
             "x-portone-name": "주문자 우편번호",
-            "x-portone-summary": "<p>가상계좌 발급을 위한 결제건의 주문자 우편번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>가상계좌 발급을 위한 결제건의 주문자 우편번호</p>\n"
           },
           {
             "name": "pg",
@@ -7652,7 +7651,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "PG사 구분코드",
-            "x-portone-summary": "<p>가상계좌 발급 할 PG사 구분코드</p>\n",
+            "x-portone-description": "<p>가상계좌 발급 할 PG사 구분코드</p>\n",
             "x-portone-per-pg": {
               "html5_inicis": {
                 "required": true,
@@ -7667,7 +7666,7 @@
             "required": false,
             "type": "array",
             "x-portone-name": "Notification URL(Webhook URL)",
-            "x-portone-summary": "<p>가상계좌 입금시 입금통지받을 URL</p>\n"
+            "x-portone-description": "<p>가상계좌 입금시 입금통지받을 URL</p>\n"
           },
           {
             "name": "custom_data",
@@ -7676,8 +7675,7 @@
             "required": false,
             "type": "string",
             "x-portone-name": "추가 정보",
-            "x-portone-summary": "<p>결제정보와 함께 저장할 추가정보로 객체로 전달되는 경우 JSON 문자열로 저장</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>결제정보와 함께 저장할 추가정보로 객체로 전달되는 경우 JSON 문자열로 저장</p>\n"
           },
           {
             "name": "tax_free",
@@ -7686,8 +7684,7 @@
             "required": false,
             "type": "integer",
             "x-portone-name": "면세금액",
-            "x-portone-summary": "<p>가상계좌 발급을 위한 결제건의 면세금액</p>\n",
-            "x-portone-description": "",
+            "x-portone-description": "<p>가상계좌 발급을 위한 결제건의 면세금액</p>\n",
             "x-portone-supported-pgs": [
               "nice",
               "nice_v2",
@@ -7712,7 +7709,7 @@
             "required": false,
             "type": "number",
             "x-portone-name": "부가세",
-            "x-portone-summary": "<p>가상계좌 발급을 위한 결제건의 부가세 금액</p>\n",
+            "x-portone-description": "<p>가상계좌 발급을 위한 결제건의 부가세 금액</p>\n",
             "x-portone-supported-pgs": [
               "nice",
               "nice_v2",
@@ -7750,8 +7747,7 @@
             "required": false,
             "type": "integer",
             "x-portone-name": "결제 상품의 개수",
-            "x-portone-summary": "<p>가상계좌 발급을 위한 결제 상품의 개수로 기본값은 1입니다</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>가상계좌 발급을 위한 결제 상품의 개수로 기본값은 1입니다</p>\n"
           }
         ],
         "responses": {
@@ -7802,8 +7798,7 @@
             "type": "string",
             "default": "imp_448280090638",
             "x-portone-name": "포트원 거래고유번호",
-            "x-portone-summary": "<p>가상계봐 발급 정보를 수정할 결제건의 포트원 거래고유번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>가상계봐 발급 정보를 수정할 결제건의 포트원 거래고유번호</p>\n"
           },
           {
             "name": "amount",
@@ -7812,8 +7807,7 @@
             "required": false,
             "type": "integer",
             "x-portone-name": "발급금액",
-            "x-portone-summary": "<p>수정할 결제금액</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>수정할 결제금액</p>\n"
           },
           {
             "name": "vbank_due",
@@ -7822,8 +7816,7 @@
             "required": false,
             "type": "integer",
             "x-portone-name": "입금기한",
-            "x-portone-summary": "<p>수정할 가상계좌 입금기한 UNIX TIMESTAMP</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>수정할 가상계좌 입금기한 UNIX TIMESTAMP</p>\n"
           }
         ],
         "responses": {
@@ -7871,8 +7864,7 @@
             "type": "string",
             "default": "imp_448280090638",
             "x-portone-name": "포트원 거래고유번호",
-            "x-portone-summary": "<p>가상계좌 발급 취소할 결제건의 포트원 거래고유번호</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>가상계좌 발급 취소할 결제건의 포트원 거래고유번호</p>\n"
           },
           {
             "name": "pg_api_key",
@@ -7951,8 +7943,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "은행코드",
-            "x-portone-summary": "<p>조회할 은행코드(금융결제원 표준코드3자리)</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>조회할 은행코드(금융결제원 표준코드3자리)</p>\n"
           },
           {
             "name": "bank_num",
@@ -7961,8 +7952,7 @@
             "required": true,
             "type": "string",
             "x-portone-name": "계좌번호",
-            "x-portone-summary": "<p>조회할 계좌번호(숫자외 기호 포함 가능)</p>\n",
-            "x-portone-description": ""
+            "x-portone-description": "<p>조회할 계좌번호(숫자외 기호 포함 가능)</p>\n"
           }
         ],
         "responses": {
@@ -7998,22 +7988,19 @@
           "description": "인증이 필요한 REST API요청에 사용할 access_token",
           "type": "string",
           "x-portone-name": "access_token",
-          "x-portone-summary": "<p>인증이 필요한 REST API요청에 사용할 access_token</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>인증이 필요한 REST API요청에 사용할 access_token</p>\n"
         },
         "expired_at": {
           "description": "token만료시각. UNIX timestamp",
           "type": "integer",
           "x-portone-name": "token 만료시각",
-          "x-portone-summary": "<p>access_token의 만료시각. UNIX timestamp</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>access_token의 만료시각. UNIX timestamp</p>\n"
         },
         "now": {
           "description": "현재시각 UNIX timestamp. token만료시각을 정확히 계산하기 위해 사용",
           "type": "integer",
           "x-portone-name": "현재시각",
-          "x-portone-summary": "<p>token 만료시각을 정확히 계산하기 위해 사용되는 현재시각. UNIX timestamp</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>token 만료시각을 정확히 계산하기 위해 사용되는 현재시각. UNIX timestamp</p>\n"
         }
       }
     },
@@ -8040,8 +8027,7 @@
           "description": "베네피아 보유 포인트",
           "type": "integer",
           "x-portone-name": "포인트",
-          "x-portone-summary": "<p>베네피아 보유 포인트</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>베네피아 보유 포인트</p>\n"
         }
       }
     },
@@ -8071,49 +8057,43 @@
           "description": "포트원 인증 고유번호",
           "type": "string",
           "x-portone-name": "포트원 인증 고유번호",
-          "x-portone-summary": "<p>본인인증 결과건의 포트원 인증 고유번호</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>본인인증 결과건의 포트원 인증 고유번호</p>\n"
         },
         "merchant_uid": {
           "description": "가맹점 주문번호",
           "type": "string",
           "x-portone-name": "가맹점 주문번호",
-          "x-portone-summary": "<p>본인인증 결과건의 포트원 가맹점 주문번호</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>본인인증 결과건의 포트원 가맹점 주문번호</p>\n"
         },
         "pg_tid": {
           "description": "PG사 본인인증결과 고유번호",
           "type": "string",
           "x-portone-name": "PG사 본인인증결과 고유번호",
-          "x-portone-summary": "<p>본인인증 결과건의 PG사 본인인증결과 고유번호</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>본인인증 결과건의 PG사 본인인증결과 고유번호</p>\n"
         },
         "pg_provider": {
           "description": "본인인증 제공 PG사 명칭. danal(다날)",
           "type": "string",
           "x-portone-name": "pg사 구분코드",
-          "x-portone-summary": "<p>본인인증 제공 PG사의 명칭</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>본인인증 제공 PG사의 명칭</p>\n"
         },
         "name": {
           "description": "인증결과-실명",
           "type": "string",
           "x-portone-name": "성명",
-          "x-portone-summary": "<p>인증된 사용자의 성명</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>인증된 사용자의 성명</p>\n"
         },
         "gender": {
           "description": "인증결과-성별 <ul><li>male:남성</li> <li>female:여성</li></ul>",
           "type": "string",
           "x-portone-name": "성별",
-          "x-portone-summary": "<p>인증된 사용자의 성별</p>\n"
+          "x-portone-description": "<p>인증된 사용자의 성별</p>\n"
         },
         "birthday": {
           "description": "인증결과-생년월일 <br> ISO8601 형식의 문자열. YYYY-MM-DD 10자리 문자열",
           "type": "string",
           "x-portone-name": "생년월일",
-          "x-portone-summary": "<p>인증된 사용자의 생년월일 ISO8601 형식의 문자열. <code>YYYY-MM-DD</code> 10자리 문자열</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>인증된 사용자의 생년월일 ISO8601 형식의 문자열. <code>YYYY-MM-DD</code> 10자리 문자열</p>\n"
         },
         "foreigner": {
           "description": "인증결과-외국인 여부.<br><b>다날 본인인증서비스 계약시</b>외국인 구분기능을 추가 요청하지 않은 경우 항상 <b>false</b>를 응답합니다.\n     <ul><li>true:외국인</li> <li>false:내국인</li></ul>",
@@ -8140,23 +8120,20 @@
           "description": "인증성공여부",
           "type": "boolean",
           "x-portone-name": "인증성공여부",
-          "x-portone-summary": "<p>본인인증 성공여부</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>본인인증 성공여부</p>\n"
         },
         "certified_at": {
           "description": "인증처리시각 UNIX timestamp",
           "type": "integer",
           "x-portone-name": "인증처리시각",
-          "x-portone-summary": "<p>본인인증 처리시각 UNIX timestamp</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>본인인증 처리시각 UNIX timestamp</p>\n"
         },
         "unique_key": {
           "description": "개인 고유구분 식별키(CI)",
           "type": "string",
           "maxLength": "88",
           "x-portone-name": "개인 고유구분 식별키",
-          "x-portone-summary": "<p>개인별로 고유하게 부여하는 개인 식별키(CI)</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>개인별로 고유하게 부여하는 개인 식별키(CI)</p>\n"
         },
         "unique_in_site": {
           "description": "가맹점 내 개인 고유구분 식별키(DI). 본인인증 PG MID별로 할당되는 개인 식별키",
@@ -8170,8 +8147,7 @@
           "description": "본인인증 프로세스가 진행된 웹 페이지의 URL",
           "type": "string",
           "x-portone-name": "웹 페이지 URL",
-          "x-portone-summary": "<p>본인인증 프로세스가 진행된 웹 페이지의 URL</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>본인인증 프로세스가 진행된 웹 페이지의 URL</p>\n"
         },
         "foreigner_v2": {
           "description": "인증결과-외국인 여부(nullable)\n      <ul><li>true:외국인</li>\n      <li>false:내국인</li></ul>\n      <b>다날 본인인증서비스 계약시</b>외국인 구분기능 추가 요청을 해주셔야 사용이 가능합니다. 요청을 하지 않은 경우 <b>null</b>을 응답합니다.",
@@ -8206,8 +8182,7 @@
           "description": "포트원 인증 고유번호",
           "type": "string",
           "x-portone-name": "포트원 인증 고유번호",
-          "x-portone-summary": "<p>본인인증 결과건의 포트원 인증 고유번호</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>본인인증 결과건의 포트원 인증 고유번호</p>\n"
         }
       }
     },
@@ -8241,38 +8216,33 @@
           "type": "string",
           "maxLength": "80",
           "x-portone-name": "구매자의 결제 수단 식별 고유번호",
-          "x-portone-summary": "<p>빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n"
         },
         "pg_provider": {
           "description": "빌링키가 등록된 PG사 구분코드",
           "type": "string",
           "maxLength": "16",
           "x-portone-name": "PG사 구분코드",
-          "x-portone-summary": "<p>빌링키가 등록된 PG사 구분코드</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>빌링키가 등록된 PG사 구분코드</p>\n"
         },
         "pg_id": {
           "description": "빌링키가 등록된 PG사 상점아이디(MID)",
           "type": "string",
           "maxLength": "80",
           "x-portone-name": "상점아이디(MID)",
-          "x-portone-summary": "<p>빌링키가 등록된 PG사 상점아이디(MID)</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>빌링키가 등록된 PG사 상점아이디(MID)</p>\n"
         },
         "customer_id": {
           "description": "구매자 ID",
           "type": "string",
           "x-portone-name": "구매자 ID",
-          "x-portone-summary": "<p>구매자 식별 고유 번호</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>구매자 식별 고유 번호</p>\n"
         },
         "card_name": {
           "description": "카드사명",
           "type": "string",
           "x-portone-name": "카드명",
-          "x-portone-summary": "<p>빌링키 발급 한 카드명</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>빌링키 발급 한 카드명</p>\n"
         },
         "card_code": {
           "description": "카드사 코드(금융결제원 표준코드번호)\n     <a href='https://chaifinance.notion.site/53589280bbc94fab938d93257d452216?v=eb405baf52134b3f90d438e3bf763630'>링크보기</a>",
@@ -8285,8 +8255,7 @@
           "description": "마스킹 카드번호",
           "type": "string",
           "x-portone-name": "마스킹 카드번호",
-          "x-portone-summary": "<p>빌링키 발급 한 카드의 마스킹된 카드번호</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>빌링키 발급 한 카드의 마스킹된 카드번호</p>\n"
         },
         "card_type": {
           "description": "카드유형 <br>\n     (주의)해당 정보를 제공하지 않는 일부 PG사의 경우 null 로 응답됨(ex. JTNet, 이니시스-빌링)\n     <ul><li> 0 : 신용카드\n     </li><li> 1 : 체크카드 </li></ul>",
@@ -8300,54 +8269,47 @@
           "type": "string",
           "maxLength": "20",
           "x-portone-name": "고객 성함",
-          "x-portone-summary": "<p>빌링키 발급 한 고객(카드소지자)의 성함</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>빌링키 발급 한 고객(카드소지자)의 성함</p>\n"
         },
         "customer_tel": {
           "description": "고객(카드소지자) 전화번호",
           "type": "string",
           "maxLength": "20",
           "x-portone-name": "전화번호",
-          "x-portone-summary": "<p>빌링키 발급 한 고객(카드소지자)의 전화번호</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>빌링키 발급 한 고객(카드소지자)의 전화번호</p>\n"
         },
         "customer_email": {
           "description": "고객(카드소지자) Email 주소",
           "type": "string",
           "maxLength": "200",
           "x-portone-name": "Email 주소",
-          "x-portone-summary": "<p>빌링키 발급 한 고객(카드소지자)의 Email 주소</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>빌링키 발급 한 고객(카드소지자)의 Email 주소</p>\n"
         },
         "customer_addr": {
           "description": "고객(카드소지자) 주소",
           "type": "string",
           "maxLength": "200",
           "x-portone-name": "주소",
-          "x-portone-summary": "<p>빌링키 발급 한 고객(카드소지자)의 주소</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>빌링키 발급 한 고객(카드소지자)의 주소</p>\n"
         },
         "customer_postcode": {
           "description": "고객(카드소지자) 우편번호",
           "type": "string",
           "maxLength": "8",
           "x-portone-name": "우편번호",
-          "x-portone-summary": "<p>빌링키 발급 한 고객(카드소지자)의 우편번호</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>빌링키 발급 한 고객(카드소지자)의 우편번호</p>\n"
         },
         "inserted": {
           "description": "빌링키가 등록된 시각 UNIX timestamp",
           "type": "integer",
           "x-portone-name": "발급 시각",
-          "x-portone-summary": "<p>빌링키가 발급된 시각 UNIX timestamp</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>빌링키가 발급된 시각 UNIX timestamp</p>\n"
         },
         "updated": {
           "description": "빌링키가 업데이트된 시각 UNIX timestamp",
           "type": "integer",
           "x-portone-name": "업데이트 시각",
-          "x-portone-summary": "<p>빌링키가 업데이트된 시각 UNIX timestamp</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>빌링키가 업데이트된 시각 UNIX timestamp</p>\n"
         }
       }
     },
@@ -8396,29 +8358,25 @@
           "description": "택배사코드",
           "type": "string",
           "x-portone-name": "택배사코드",
-          "x-portone-summary": "<p>에스크로 결제건의 택배사 코드</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>에스크로 결제건의 택배사 코드</p>\n"
         },
         "invoice": {
           "description": "송장번호",
           "type": "string",
           "x-portone-name": "송장번호",
-          "x-portone-summary": "<p>에스크로 결제건의 송장번호</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>에스크로 결제건의 송장번호</p>\n"
         },
         "sent_at": {
           "description": "발송일시 UNIX TIMESTAMP",
           "type": "integer",
           "x-portone-name": "발송 시각",
-          "x-portone-summary": "<p>에스크로 결제건의 배송 발송 시각 UNIX timestamp</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>에스크로 결제건의 배송 발송 시각 UNIX timestamp</p>\n"
         },
         "applied_at": {
           "description": "배송정보 등록일시 UNIX TIMESTAMP",
           "type": "integer",
           "x-portone-name": "등록 시각",
-          "x-portone-summary": "<p>에스크로 결제건의 배송 정보 등록 시각 UNIX timestamp</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>에스크로 결제건의 배송 정보 등록 시각 UNIX timestamp</p>\n"
         }
       }
     },
@@ -8443,8 +8401,7 @@
           "description": "보내는 분 성함(필수 : KG이니시스, 스마트로 - 신모듈)",
           "type": "string",
           "x-portone-name": "성함",
-          "x-portone-summary": "<p>배송을 보내는 발신자의 성함</p>\n",
-          "x-portone-description": "",
+          "x-portone-description": "<p>배송을 보내는 발신자의 성함</p>\n",
           "x-portone-per-pg": {
             "html5_inicis": {
               "required": true
@@ -8458,8 +8415,7 @@
           "description": "보내는 분 전화번호(필수 : KG이니시스, 스마트로 - 신모듈)",
           "type": "string",
           "x-portone-name": "전화번호",
-          "x-portone-summary": "<p>배송을 보내는 발신자의 전화번호</p>\n",
-          "x-portone-description": "",
+          "x-portone-description": "<p>배송을 보내는 발신자의 전화번호</p>\n",
           "x-portone-per-pg": {
             "html5_inicis": {
               "required": true
@@ -8473,8 +8429,7 @@
           "description": "보내는 분 주소(필수 : KG이니시스)",
           "type": "string",
           "x-portone-name": "주소",
-          "x-portone-summary": "<p>배송을 보내는 발신자의 주소</p>\n",
-          "x-portone-description": "",
+          "x-portone-description": "<p>배송을 보내는 발신자의 주소</p>\n",
           "x-portone-per-pg": {
             "html5_inicis": {
               "required": true
@@ -8485,8 +8440,7 @@
           "description": "보내는 분 우편번호(필수 : KG이니시스, 스마트로 - 신모듈)",
           "type": "string",
           "x-portone-name": "우편번호",
-          "x-portone-summary": "<p>배송을 보내는 발신자의 우편번호</p>\n",
-          "x-portone-description": "",
+          "x-portone-description": "<p>배송을 보내는 발신자의 우편번호</p>\n",
           "x-portone-per-pg": {
             "html5_inicis": {
               "required": true
@@ -8500,8 +8454,7 @@
           "description": "보내는 분과의 관계(필수 : 키움페이(구 다우, 페이조아), 예: 본인)",
           "type": "string",
           "x-portone-name": "발신자와의 관계",
-          "x-portone-summary": "<p>배송을 보내는 발신자와의 관계 (예 : 본인)</p>\n",
-          "x-portone-description": "",
+          "x-portone-description": "<p>배송을 보내는 발신자와의 관계 (예 : 본인)</p>\n",
           "x-portone-per-pg": {
             "daou": {
               "required": true
@@ -8515,8 +8468,7 @@
               "description": "보내는 분의 지번주소 또는 도로명 주소",
               "type": "string",
               "x-portone-name": "주소 1",
-              "x-portone-summary": "<p>배송을 보내는 발신자의 지번주소 또는 도로명 주소</p>\n",
-              "x-portone-description": "",
+              "x-portone-description": "<p>배송을 보내는 발신자의 지번주소 또는 도로명 주소</p>\n",
               "x-portone-per-pg": {
                 "smartro_v2": {
                   "required": true
@@ -8527,8 +8479,7 @@
               "description": "보내는 분의 상세주소 (ex) 동-호수, 아파트 or 건물명)",
               "type": "string",
               "x-portone-name": "주소 2",
-              "x-portone-summary": "<p>배송을 보내는 발신자의 상세주소 (ex. 동-호수, 아파트 or 건물명)</p>\n",
-              "x-portone-description": "",
+              "x-portone-description": "<p>배송을 보내는 발신자의 상세주소 (ex. 동-호수, 아파트 or 건물명)</p>\n",
               "x-portone-per-pg": {
                 "smartro_v2": {
                   "required": true
@@ -8538,8 +8489,7 @@
           },
           "type": "object",
           "x-portone-name": "주소 구성",
-          "x-portone-summary": "<p>배송을 보내는 발신자의 주소 구성</p>\n",
-          "x-portone-description": "",
+          "x-portone-description": "<p>배송을 보내는 발신자의 주소 구성</p>\n",
           "x-portone-per-pg": {
             "smartro_v2": {
               "required": true,
@@ -8555,8 +8505,7 @@
           "description": "받는 분 성함(필수 : KG이니시스, 스마트로 - 신모듈)",
           "type": "string",
           "x-portone-name": "성함",
-          "x-portone-summary": "<p>배송을 받는 수신자의 성함</p>\n",
-          "x-portone-description": "",
+          "x-portone-description": "<p>배송을 받는 수신자의 성함</p>\n",
           "x-portone-per-pg": {
             "html5_inicis": {
               "required": true
@@ -8570,8 +8519,7 @@
           "description": "받는 분 전화번호(필수 : KG이니시스, 스마트로 - 신모듈)",
           "type": "string",
           "x-portone-name": "전화번호",
-          "x-portone-summary": "<p>배송을 받는 수신자의 전화번호</p>\n",
-          "x-portone-description": "",
+          "x-portone-description": "<p>배송을 받는 수신자의 전화번호</p>\n",
           "x-portone-per-pg": {
             "html5_inicis": {
               "required": true
@@ -8585,8 +8533,7 @@
           "description": "받는 분 주소(필수 : KG이니시스)",
           "type": "string",
           "x-portone-name": "주소",
-          "x-portone-summary": "<p>배송을 받는 수신자의 주소</p>\n",
-          "x-portone-description": "",
+          "x-portone-description": "<p>배송을 받는 수신자의 주소</p>\n",
           "x-portone-per-pg": {
             "html5_inicis": {
               "required": true
@@ -8597,8 +8544,7 @@
           "description": "받는 분 우편번호(필수 : KG이니시스, 스마트로 - 신모듈)",
           "type": "string",
           "x-portone-name": "우편번호",
-          "x-portone-summary": "<p>배송을 받는 수신자의 우편번호</p>\n",
-          "x-portone-description": "",
+          "x-portone-description": "<p>배송을 받는 수신자의 우편번호</p>\n",
           "x-portone-per-pg": {
             "html5_inicis": {
               "required": true
@@ -8615,8 +8561,7 @@
               "description": "보내는 분의 지번주소 또는 도로명 주소",
               "type": "string",
               "x-portone-name": "주소 1",
-              "x-portone-summary": "<p>배송을 받는 수신자의 지번주소 또는 도로명 주소</p>\n",
-              "x-portone-description": "",
+              "x-portone-description": "<p>배송을 받는 수신자의 지번주소 또는 도로명 주소</p>\n",
               "x-portone-per-pg": {
                 "smartro_v2": {
                   "required": true
@@ -8627,8 +8572,7 @@
               "description": "보내는 분의 상세주소 (ex) 동-호수, 아파트 or 건물명)",
               "type": "string",
               "x-portone-name": "주소 2",
-              "x-portone-summary": "<p>배송을 받는 수신자의 상세주소 (ex. 동-호수, 아파트 or 건물명)</p>\n",
-              "x-portone-description": "",
+              "x-portone-description": "<p>배송을 받는 수신자의 상세주소 (ex. 동-호수, 아파트 or 건물명)</p>\n",
               "x-portone-per-pg": {
                 "smartro_v2": {
                   "required": true
@@ -8638,8 +8582,7 @@
           },
           "type": "object",
           "x-portone-name": "주소 구성",
-          "x-portone-summary": "<p>배송을 받는 수신자의 주소 구성</p>\n",
-          "x-portone-description": "",
+          "x-portone-description": "<p>배송을 받는 수신자의 주소 구성</p>\n",
           "x-portone-per-pg": {
             "smartro_v2": {
               "required": true,
@@ -8660,29 +8603,25 @@
           "description": "택배사코드",
           "type": "string",
           "x-portone-name": "택배사코드",
-          "x-portone-summary": "<p>에스크로 결제건의 택배사 코드</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>에스크로 결제건의 택배사 코드</p>\n"
         },
         "invoice": {
           "description": "송장번호",
           "type": "string",
           "x-portone-name": "송장번호",
-          "x-portone-summary": "<p>에스크로 결제건의 송장번호</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>에스크로 결제건의 송장번호</p>\n"
         },
         "sent_at": {
           "description": "발송일시 UNIX TIMESTAMP",
           "type": "integer",
           "x-portone-name": "발송 시각",
-          "x-portone-summary": "<p>에스크로 결제건의 배송 발송 시각 UNIX timestamp</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>에스크로 결제건의 배송 발송 시각 UNIX timestamp</p>\n"
         },
         "receiving_at": {
           "description": "수령일시(필수: 키움페이(구 다우, 페이조아) / 예: YYYYMMDD)",
           "type": "string",
           "x-portone-name": "수령 시각",
-          "x-portone-summary": "<p>에스크로 결제건의 배송 수령 시각 UNIX timestamp</p>\n",
-          "x-portone-description": "",
+          "x-portone-description": "<p>에스크로 결제건의 배송 수령 시각 UNIX timestamp</p>\n",
           "x-portone-per-pg": {
             "daou": {
               "required": true
@@ -8693,8 +8632,7 @@
           "description": "발송주소(필수: 키움페이(구 다우, 페이조아))",
           "type": "string",
           "x-portone-name": "발송 주소",
-          "x-portone-summary": "<p>에스크로 결제건의 배송 발송 주소</p>\n",
-          "x-portone-description": "",
+          "x-portone-description": "<p>에스크로 결제건의 배송 발송 주소</p>\n",
           "x-portone-per-pg": {
             "daou": {
               "required": true
@@ -8714,7 +8652,6 @@
           "description": "상품 고유 아이디 (필수 : 웰컴페이먼츠)",
           "type": "string",
           "x-portone-name": "상품 고유 아이디",
-          "x-portone-summary": "",
           "x-portone-description": "",
           "x-portone-per-pg": {
             "welcome": {
@@ -8726,7 +8663,6 @@
           "description": "상품 이름 (필수 : 웰컴페이먼츠)",
           "type": "string",
           "x-portone-name": "상품 이름",
-          "x-portone-summary": "",
           "x-portone-description": "",
           "x-portone-per-pg": {
             "welcome": {
@@ -8738,14 +8674,12 @@
           "description": "상품 코드",
           "type": "string",
           "x-portone-name": "상품 코드",
-          "x-portone-summary": "<p>가맹점에서 사용하는 상품 관리 코드</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>가맹점에서 사용하는 상품 관리 코드</p>\n"
         },
         "amount": {
           "description": "상품 단위 가격 (필수 : 웰컴페이먼츠)",
           "type": "number",
           "x-portone-name": "상품 단위 가격",
-          "x-portone-summary": "",
           "x-portone-description": "",
           "x-portone-per-pg": {
             "welcome": {
@@ -8758,23 +8692,20 @@
           "type": "string",
           "default": "KRW",
           "x-portone-name": "상품의 결제통화 구분코드",
-          "x-portone-summary": "<p>통화 e.g.) KRW, USD, VND, ... Default: KRW</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>통화 e.g.) KRW, USD, VND, ... Default: KRW</p>\n"
         },
         "quantity": {
           "description": "상품의 수량",
           "type": "integer",
           "default": 1,
           "x-portone-name": "상품의 수량",
-          "x-portone-summary": "<p>상품의 수량으로 기본값은 1입니다.</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>상품의 수량으로 기본값은 1입니다.</p>\n"
         },
         "tag": {
           "description": "상품의 카테고리 e.g) 도서, 가전기기, 인테리어 용품 등",
           "type": "string",
           "x-portone-name": "상품의 카테고리",
-          "x-portone-summary": "<p>상품의 카테고리 e.g) 도서, 가전기기, 인테리어 용품 등</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>상품의 카테고리 e.g) 도서, 가전기기, 인테리어 용품 등</p>\n"
         }
       }
     },
@@ -8807,38 +8738,33 @@
           "type": "string",
           "maxLength": "80",
           "x-portone-name": "구매자 고유 아이디",
-          "x-portone-summary": "<p>구매자의 고유 아이디(memberID)</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>구매자의 고유 아이디(memberID)</p>\n"
         },
         "pg_provider": {
           "description": "PG사 코드. kcp_quick(KCP 퀵페이)",
           "type": "string",
           "maxLength": "16",
           "x-portone-name": "PG사 구분코드",
-          "x-portone-summary": "<p>유저 정보가 등록된 PG사 구분코드. <strong>kcp_quick</strong>(KCP 퀵페이)</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>유저 정보가 등록된 PG사 구분코드. <strong>kcp_quick</strong>(KCP 퀵페이)</p>\n"
         },
         "pg_id": {
           "description": "PG사 상점아이디",
           "type": "string",
           "maxLength": "80",
           "x-portone-name": "PG사 상점아이디",
-          "x-portone-summary": "<p>유저 정보가 등록된 PG사 상점아이디(MID)</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>유저 정보가 등록된 PG사 상점아이디(MID)</p>\n"
         },
         "inserted": {
           "description": "유저 정보가 등록된 시각 UNIX timestamp",
           "type": "integer",
           "x-portone-name": "등록 시각",
-          "x-portone-summary": "<p>유저 정보가 등록된 시각 UNIX timestamp</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>유저 정보가 등록된 시각 UNIX timestamp</p>\n"
         },
         "updated": {
           "description": "유저 정보가 업데이트된 시각 UNIX timestamp",
           "type": "integer",
           "x-portone-name": "업데이트 시각",
-          "x-portone-summary": "<p>유저 정보가 업데이트된 시각 UNIX timestamp</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>유저 정보가 업데이트된 시각 UNIX timestamp</p>\n"
         }
       }
     },
@@ -8869,43 +8795,37 @@
           "description": "기본 주소",
           "type": "string",
           "x-portone-name": "기본주소",
-          "x-portone-summary": "<p>네이버페이 상품 배송 기본 주소</p>\n",
           "x-portone-description": ""
         },
         "detail": {
           "description": "상세 주소",
           "type": "string",
           "x-portone-name": "상세주소",
-          "x-portone-summary": "<p>네이버페이 상품 배송 상세주소</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>네이버페이 상품 배송 상세주소</p>\n"
         },
         "postcode": {
           "description": "우편번호",
           "type": "string",
           "x-portone-name": "우편번호",
-          "x-portone-summary": "<p>네이버페이 상품 배송 우편번호</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>네이버페이 상품 배송 우편번호</p>\n"
         },
         "tel1": {
           "description": "연락처1",
           "type": "string",
           "x-portone-name": "연락처 1",
-          "x-portone-summary": "<p>네이버페이 상품 배송 연락처 1</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>네이버페이 상품 배송 연락처 1</p>\n"
         },
         "tel2": {
           "description": "연락처2",
           "type": "string",
           "x-portone-name": "연락처 2",
-          "x-portone-summary": "<p>네이버페이 상품 배송 연락처 2</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>네이버페이 상품 배송 연락처 2</p>\n"
         },
         "name": {
           "description": "대상 이름",
           "type": "string",
           "x-portone-name": "성함",
-          "x-portone-summary": "<p>네이버페이 상품 배송 수취인 성함</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>네이버페이 상품 배송 수취인 성함</p>\n"
         }
       }
     },
@@ -8922,36 +8842,31 @@
           "description": "현금영수증 발급가능 총액",
           "type": "integer",
           "x-portone-name": "총액",
-          "x-portone-summary": "<p>현금영수증 발급 가능한 총액</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>현금영수증 발급 가능한 총액</p>\n"
         },
         "amount_by_npoint": {
           "description": "현금영수증 발급가능 총액 중 Npoint 에 의한 금액",
           "type": "integer",
           "x-portone-name": "포인트 금액",
-          "x-portone-summary": "<p>현금영수증 발급가능한 총액 중 Npoint에 의한 금액</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>현금영수증 발급가능한 총액 중 Npoint에 의한 금액</p>\n"
         },
         "amount_by_primary": {
           "description": "현금영수증 발급가능 총액 중 메인 결제수단(신용카드, 계좌이체 등)에 의한 금액",
           "type": "integer",
           "x-portone-name": "메인 결제수단 금액",
-          "x-portone-summary": "<p>현금영수증 발급 가능한 총액 중 주 결제수단(신용카드, 계좌이체 등)에 의한 금액</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>현금영수증 발급 가능한 총액 중 주 결제수단(신용카드, 계좌이체 등)에 의한 금액</p>\n"
         },
         "amount_supply": {
           "description": "현금영수증 발급가능 총액 중 공급가액",
           "type": "integer",
           "x-portone-name": "공급가액",
-          "x-portone-summary": "<p>현금영수증 발급 가능한 총액 중 공급가액</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>현금영수증 발급 가능한 총액 중 공급가액</p>\n"
         },
         "amount_vat": {
           "description": "현금영수증 발급가능 총액 중 부가세",
           "type": "integer",
           "x-portone-name": "부가세",
-          "x-portone-summary": "<p>현금영수증 발급 가능한 총액 중 부가세</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>현금영수증 발급 가능한 총액 중 부가세</p>\n"
         }
       }
     },
@@ -8981,22 +8896,19 @@
           "description": "주문자 이름",
           "type": "string",
           "x-portone-name": "성함",
-          "x-portone-summary": "<p>네이버페이 주문자 성함</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>네이버페이 주문자 성함</p>\n"
         },
         "id": {
           "description": "주문자 마스킹된 네이버 아이디",
           "type": "string",
           "x-portone-name": "네이버 아이디",
-          "x-portone-summary": "<p>네이버페이 주문자의 마스킹된 네이버 아이디</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>네이버페이 주문자의 마스킹된 네이버 아이디</p>\n"
         },
         "tel": {
           "description": "주문자 연락처",
           "type": "string",
           "x-portone-name": "연락처",
-          "x-portone-summary": "<p>네이버페이 주문자의 연락처</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>네이버페이 주문자의 연락처</p>\n"
         }
       }
     },
@@ -9015,113 +8927,97 @@
           "description": "네이버페이 상품주문번호",
           "type": "string",
           "x-portone-name": "상품주문번호",
-          "x-portone-summary": "<p>결제건의 네이버페이 상품주문번호</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건의 네이버페이 상품주문번호</p>\n"
         },
         "product_order_status": {
           "description": "네이버페이 상품주문상태",
           "type": "string",
           "x-portone-name": "상품주문상태",
-          "x-portone-summary": "<p>네이버페이 상품주문상테</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>네이버페이 상품주문상테</p>\n"
         },
         "claim_type": {
           "description": "네이버페이 상품주문관련 클레임 타입(취소/교환/환불 등 클레임에 대한 유형)",
           "type": "string",
           "x-portone-name": "클레임 타입",
-          "x-portone-summary": "<p>네이버페이 상품주문관련 클레임 타입(취소/교환/환불 등 클레임에 대한 유형)</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>네이버페이 상품주문관련 클레임 타입(취소/교환/환불 등 클레임에 대한 유형)</p>\n"
         },
         "claim_status": {
           "description": "네이버페이 상품주문관련 클레임에 대한 처리 상태(취소/교환/환불 등 클레임에 대해 처리 진행 상태)",
           "type": "string",
           "x-portone-name": "클레임 처리 상태",
-          "x-portone-summary": "<p>네이버페이 상품주문관련 클레임에 대한 처리 상태(취소/교환/환불 등 클레임에 대해 처리 진행 상태)</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>네이버페이 상품주문관련 클레임에 대한 처리 상태(취소/교환/환불 등 클레임에 대해 처리 진행 상태)</p>\n"
         },
         "product_id": {
           "description": "네이버페이 상품주문의 상품 고유번호",
           "type": "string",
           "x-portone-name": "상품 고유 번호",
-          "x-portone-summary": "<p>네이버페이 상품의 고유 번호</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>네이버페이 상품의 고유 번호</p>\n"
         },
         "product_name": {
           "description": "네이버페이 상품주문의 상품명",
           "type": "string",
           "x-portone-name": "상품명",
-          "x-portone-summary": "<p>네이버페이 상품명</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>네이버페이 상품명</p>\n"
         },
         "product_option_id": {
           "description": "네이버페이 상품주문의 상품옵션 고유번호",
           "type": "string",
           "x-portone-name": "상품 옵션 번호",
-          "x-portone-summary": "<p>네이버페이 상품 옵션 고유 번호</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>네이버페이 상품 옵션 고유 번호</p>\n"
         },
         "product_option_name": {
           "description": "네이버페이 상품주문의 상품옵션명",
           "type": "string",
           "x-portone-name": "상품옵션명",
-          "x-portone-summary": "<p>네이버페이 상품옵션명</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>네이버페이 상품옵션명</p>\n"
         },
         "product_amount": {
           "description": "네이버페이 개별상품 주문금액",
           "type": "integer",
           "x-portone-name": "상품금액",
-          "x-portone-summary": "<p>네이버페이 상품의 금액</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>네이버페이 상품의 금액</p>\n"
         },
         "delivery_amount": {
           "description": "네이버페이 개별상품 배송비",
           "type": "integer",
           "x-portone-name": "상품 배송비",
-          "x-portone-summary": "<p>네이버페이 상품의 배송비</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>네이버페이 상품의 배송비</p>\n"
         },
         "quantity": {
           "description": "네이버페이 상품주문의 상품 수량",
           "type": "integer",
           "x-portone-name": "상품 수량",
-          "x-portone-summary": "<p>네이버페이 상품의 수량</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>네이버페이 상품의 수량</p>\n"
         },
         "orderer": {
           "description": "네이버페이 상품주문의 주문자 정보",
           "x-portone-name": "주문자 정보",
-          "x-portone-summary": "<p>네이버페이 상품주문의 주문자 정보</p>\n",
-          "x-portone-description": "",
+          "x-portone-description": "<p>네이버페이 상품주문의 주문자 정보</p>\n",
           "$ref": "#/definitions/NaverOrderer"
         },
         "shipping_address": {
           "description": "네이버페이 상품주문별 배송주소 정보",
           "x-portone-name": "배송주소 정보",
-          "x-portone-summary": "<p>네이버페이 상품주문별 배송주소 정보</p>\n",
-          "x-portone-description": "",
+          "x-portone-description": "<p>네이버페이 상품주문별 배송주소 정보</p>\n",
           "$ref": "#/definitions/NaverAddress"
         },
         "shipping_memo": {
           "description": "네이버페이 상품주문별 배송메모",
           "type": "string",
           "x-portone-name": "배송메모",
-          "x-portone-summary": "<p>네이버페이 상품주문별 배송메모</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>네이버페이 상품주문별 배송메모</p>\n"
         },
         "shipping_due": {
           "description": "네이버페이 상품주문별 배송기한 Unix Timestamp",
           "type": "integer",
           "x-portone-name": "배송기한",
-          "x-portone-summary": "<p>네이버페이 상품주문별 배송기한 UNIX timestamp</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>네이버페이 상품주문별 배송기한 UNIX timestamp</p>\n"
         },
         "individual_code": {
           "description": "네이버페이 주문자의 개인통고유부호",
           "type": "string",
           "x-portone-name": "개인통관고유부호",
-          "x-portone-summary": "<p>네이버페이 주문자의 개인통관고유부호</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>네이버페이 주문자의 개인통관고유부호</p>\n"
         }
       }
     },
@@ -9174,8 +9070,7 @@
           "description": "네이버페이 구매평 고유 ID",
           "type": "string",
           "x-portone-name": "구매평 고유 ID",
-          "x-portone-summary": "<p>네이버페이 구매평 고유 ID</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>네이버페이 구매평 고유 ID</p>\n"
         },
         "score": {
           "description": "네이버페이 구매만족도. 1, 2, 3, 4, 5 (점)",
@@ -9188,64 +9083,55 @@
           "description": "네이버페이 일반 구매평 내용 또는 프리미엄 구매평 제목",
           "type": "string",
           "x-portone-name": "구매평 내용 or 제목",
-          "x-portone-summary": "<p>네이버페이 일반 구매평 내용 또는 프리미엄 구매평 제목</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>네이버페이 일반 구매평 내용 또는 프리미엄 구매평 제목</p>\n"
         },
         "content": {
           "description": "네이버페이 프리미엄 구매평 내용(일반 구매평인 경우 없음)",
           "type": "string",
           "x-portone-name": "구매평 내용",
-          "x-portone-summary": "<p>네이버페이 프리미엄 구매평 내용으로 일반 구매평인 경우 없습니다.</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>네이버페이 프리미엄 구매평 내용으로 일반 구매평인 경우 없습니다.</p>\n"
         },
         "product_order_id": {
           "description": "네이버페이 상품주문번호",
           "type": "string",
           "x-portone-name": "상품 주문 번호",
-          "x-portone-summary": "<p>네이버페이 상품 주문 번호</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>네이버페이 상품 주문 번호</p>\n"
         },
         "product_id": {
           "description": "네이버페이 상품주문의 상품 고유번호",
           "type": "string",
           "x-portone-name": "상품 고유 번호",
-          "x-portone-summary": "<p>네이버페이 상품의 고유 번호</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>네이버페이 상품의 고유 번호</p>\n"
         },
         "product_name": {
           "description": "네이버페이 상품주문의 상품명",
           "type": "string",
           "x-portone-name": "상품명",
-          "x-portone-summary": "<p>네이버페이 상품명</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>네이버페이 상품명</p>\n"
         },
         "product_option_name": {
           "description": "네이버페이 상품주문의 상품옵션명",
           "type": "string",
           "x-portone-name": "상품 옵션",
-          "x-portone-summary": "<p>네이버페이 상품 옵션(옵션명)</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>네이버페이 상품 옵션(옵션명)</p>\n"
         },
         "writer": {
           "description": "네이버페이 구매평 작성자 아이디",
           "type": "string",
           "x-portone-name": "구매평 작성자 아이디",
-          "x-portone-summary": "<p>암호화된 네이버페이 구매평 작성자 아이디</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>암호화된 네이버페이 구매평 작성자 아이디</p>\n"
         },
         "created_at": {
           "description": "네이버페이 구매평 작성시각 unix timestamp",
           "type": "integer",
           "x-portone-name": "작성시각",
-          "x-portone-summary": "<p>네이버페이 구매평 작성시각 UNIX timestamp</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>네이버페이 구매평 작성시각 UNIX timestamp</p>\n"
         },
         "modified_at": {
           "description": "네이버페이 구매평 수정시각 unix timestamp",
           "type": "integer",
           "x-portone-name": "수정시각",
-          "x-portone-summary": "<p>네이버페이 구매평 수정시각 UNIX timestamp</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>네이버페이 구매평 수정시각 UNIX timestamp</p>\n"
         }
       }
     },
@@ -9278,8 +9164,7 @@
           "description": "하위 상점 사업자번호 (&quot;-&quot; 포함)",
           "type": "string",
           "x-portone-name": "하위 상점 사업자 등록 번호",
-          "x-portone-summary": "<p>거래를 구성하는 하위 상점의 사업자 등록 점번호 (\"-\" 포함)</p>\n",
-          "x-portone-description": "",
+          "x-portone-description": "<p>거래를 구성하는 하위 상점의 사업자 등록 점번호 (\"-\" 포함)</p>\n",
           "x-portone-per-pg": {
             "html5_inicis": {
               "required": true
@@ -9290,8 +9175,7 @@
           "description": "하위 상점 명",
           "type": "string",
           "x-portone-name": "하위 상점 명",
-          "x-portone-summary": "<p>거래를 구성하는 하위 상점의 상점 명</p>\n",
-          "x-portone-description": "",
+          "x-portone-description": "<p>거래를 구성하는 하위 상점의 상점 명</p>\n",
           "x-portone-per-pg": {
             "html5_inicis": {
               "required": true
@@ -9302,8 +9186,7 @@
           "description": "하위 상점 거래 금액",
           "type": "number",
           "x-portone-name": "하위 상점 거래 금액",
-          "x-portone-summary": "<p>거래를 구성하는 하위 상점의 해당 결제건 내 거래 금액</p>\n",
-          "x-portone-description": "",
+          "x-portone-description": "<p>거래를 구성하는 하위 상점의 해당 결제건 내 거래 금액</p>\n",
           "x-portone-per-pg": {
             "html5_inicis": {
               "required": true
@@ -9314,8 +9197,7 @@
           "description": "하위 상점 거래 금액 중 면세 금액 (default = 0)",
           "type": "number",
           "x-portone-name": "하위 상점 거래 금액 중 면세 금액",
-          "x-portone-summary": "<p>거래를 구성하는 하위 상점의 해당 결제건 내 면세 금액</p>\n",
-          "x-portone-description": "",
+          "x-portone-description": "<p>거래를 구성하는 하위 상점의 해당 결제건 내 면세 금액</p>\n",
           "x-portone-per-pg": {
             "html5_inicis": {
               "required": false
@@ -9326,8 +9208,7 @@
           "description": "하위 상점 거래 금액 중 부가세 금액 (default = 거래 금액 / 11)",
           "type": "number",
           "x-portone-name": "하위 상점 거래 금액 중 부가세 금액",
-          "x-portone-summary": "<p>거래를 구성하는 하위 상점의 해당 결제건 내 부가세 금액</p>\n",
-          "x-portone-description": "",
+          "x-portone-description": "<p>거래를 구성하는 하위 상점의 해당 결제건 내 부가세 금액</p>\n",
           "x-portone-per-pg": {
             "html5_inicis": {
               "required": false
@@ -9342,8 +9223,7 @@
           "description": "매출전표 확인 URL",
           "type": "string",
           "x-portone-name": "매출전표 확인 URL",
-          "x-portone-summary": "<p>거래건에 대한 매출전표를 확인할 수 있는 URL</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>거래건에 대한 매출전표를 확인할 수 있는 URL</p>\n"
         }
       }
     },
@@ -9406,23 +9286,21 @@
           "type": "string",
           "maxLength": "32",
           "x-portone-name": "포트원 거래고유번호",
-          "x-portone-summary": "<p>결제건의 포트원 거래고유번호</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건의 포트원 거래고유번호</p>\n"
         },
         "merchant_uid": {
           "description": "가맹점 주문번호",
           "type": "string",
           "maxLength": "40",
           "x-portone-name": "가맹점 주문번호",
-          "x-portone-summary": "<p>결제건의 가맹점 주문번호</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건의 가맹점 주문번호</p>\n"
         },
         "pay_method": {
           "description": "결제수단 구분코드\n     <ul><li>samsung : 삼성페이\n     </li><li> card : 신용카드\n     </li><li>trans : 계좌이체\n     </li><li> vbank : 가상계좌\n     </li><li> phone : 휴대폰\n     </li><li> cultureland : 문화상품권\n     </li><li> smartculture : 스마트문상\n     </li><li> booknlife : 도서문화상품권\n     </li><li> happymoney : 해피머니\n     </li><li> point : 포인트\n     </li><li> ssgpay : SSGPAY\n     </li><li> lpay : LPAY\n     </li><li> payco : 페이코\n     </li><li> kakaopay : 카카오페이\n     </li><li> tosspay : 토스\n     </li><li> naverpay : 네이버페이\n     </li><li> applepay : 애플페이\n     </li><li> paypal : 페이팔</li></ul>",
           "type": "string",
           "maxLength": "20",
           "x-portone-name": "결제수단 구분코드",
-          "x-portone-summary": "<p>결제건의 결제수단을 구분하는 코드</p>\n",
+          "x-portone-description": "<p>결제건의 결제수단을 구분하는 코드</p>\n",
           "x-portone-per-pg": {
             "paypal_v2": {
               "description": "<p>페이팔을 통해 카드 결제 외 BanContact, BLIK, eps, giropay 등 다양한 결제 수단으로 결제가 가능하지만,\n<strong>페이팔이 승인 된 결제 수단을 알려주지 않기 때문에</strong> 페이팔의 모든 결제 건의 결제 수단은 paypal로 일괄 저장됩니다.</p>\n"
@@ -9433,88 +9311,78 @@
           "description": "결제환경 구분코드\n     <ul><li> pc:(인증방식)PC결제\n     </li><li> mobile:(인증방식)모바일결제\n     </li><li> api:정기결제 또는 비인증방식결제</li></ul>",
           "type": "string",
           "x-portone-name": "결제환경 구분코드",
-          "x-portone-summary": "<p>결제건을 생성한 환경을 구분하는 코드</p>\n"
+          "x-portone-description": "<p>결제건을 생성한 환경을 구분하는 코드</p>\n"
         },
         "pg_provider": {
           "description": "PG사 구분코드",
           "type": "string",
           "maxLength": "16",
           "x-portone-name": "PG사 구분코드",
-          "x-portone-summary": "<p>결제건의 PG사 구분코드</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건의 PG사 구분코드</p>\n"
         },
         "emb_pg_provider": {
           "description": "허브형결제 PG사 구분코드",
           "type": "string",
           "maxLength": "16",
           "x-portone-name": "허브형결제 PG사 구분코드",
-          "x-portone-summary": "<p>허브형 결제인 경우 결제건의 허브형 결제 PG사를 구분하는 코드</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>허브형 결제인 경우 결제건의 허브형 결제 PG사를 구분하는 코드</p>\n"
         },
         "pg_tid": {
           "description": "PG사 거래번호",
           "type": "string",
           "maxLength": "64",
           "x-portone-name": "PG사 거래번호",
-          "x-portone-summary": "<p>결제건의 PG사 거래번호</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건의 PG사 거래번호</p>\n"
         },
         "pg_id": {
           "description": "PG사 MID",
           "type": "string",
           "maxLength": "80",
           "x-portone-name": "PG사 상점아이디",
-          "x-portone-summary": "<p>결제건의 PG사 상점아이디</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건의 PG사 상점아이디</p>\n"
         },
         "escrow": {
           "description": "에스크로결제 여부",
           "type": "boolean",
           "x-portone-name": "에스크로결제 여부",
-          "x-portone-summary": "<p>에스크로 결제건인지 구분하는 코드</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>에스크로 결제건인지 구분하는 코드</p>\n"
         },
         "apply_num": {
           "description": "신용카드 승인번호",
           "type": "string",
           "maxLength": "20",
           "x-portone-name": "승인번호",
-          "x-portone-summary": "<p>결제건의 신용카드 승인번호</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건의 신용카드 승인번호</p>\n"
         },
         "bank_code": {
           "description": "은행 표준코드 - (금융결제원기준)",
           "type": "string",
           "x-portone-name": "은행 표준코드",
-          "x-portone-summary": "<p>결제건의 은행 표준코드 (금융결제원기준) - 실시간계좌이체 결제건의 경우</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건의 은행 표준코드 (금융결제원기준) - 실시간계좌이체 결제건의 경우</p>\n"
         },
         "bank_name": {
           "description": "은행 명칭 - (실시간계좌이체 결제 건의 경우)",
           "type": "string",
           "x-portone-name": "은행명",
-          "x-portone-summary": "<p>결제건의 은행명 - 실시간계좌이체 결제 건의 경우</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건의 은행명 - 실시간계좌이체 결제 건의 경우</p>\n"
         },
         "card_code": {
           "description": "카드사 코드번호(금융결제원 표준코드번호)\n     <a href='https://chaifinance.notion.site/53589280bbc94fab938d93257d452216?v=eb405baf52134b3f90d438e3bf763630'>링크보기</a>",
           "type": "string",
           "x-portone-name": "카드사 코드번호",
-          "x-portone-summary": "<p>결제건의 카드사 코드번호 (금융결제원 표준코드번호) - 카드 결제 건의 경우</p>\n"
+          "x-portone-description": "<p>결제건의 카드사 코드번호 (금융결제원 표준코드번호) - 카드 결제 건의 경우</p>\n"
         },
         "card_name": {
           "description": "카드사명 - (신용카드 결제 건의 경우)",
           "type": "string",
           "x-portone-name": "카드사명",
-          "x-portone-summary": "<p>결제건의 카드사명 - 카드 결제 건의 경우</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건의 카드사명 - 카드 결제 건의 경우</p>\n"
         },
         "card_quota": {
           "description": "할부개월 수(0이면 일시불)",
           "type": "integer",
           "x-portone-name": "할부개월 수",
-          "x-portone-summary": "<p>결제건의 할부개월 수(일시불은 0으로 표기) - 신용카드 결제 건의 경우</p>\n",
-          "x-portone-description": "",
+          "x-portone-description": "<p>결제건의 할부개월 수(일시불은 0으로 표기) - 신용카드 결제 건의 경우</p>\n",
           "x-portone-per-pg": {
             "paypal_v2": "Pay Later를 이용하면 할부 결제가 가능합니다. 하지만 **페이팔이 승인 된 할부 정보를 알려주지 않기 때문에**\n실제로 할부로 결제가 됐는지, 됐다면 몇 개월 할부로 결제 됐는지 알 수 없습니다."
           }
@@ -9537,30 +9405,26 @@
           "description": "가상계좌 은행 표준코드 - (금융결제원기준)",
           "type": "string",
           "x-portone-name": "가상계좌 은행 표준코드",
-          "x-portone-summary": "<p>결제건의 가상계좌 은행 표준코드(금융결제원기준)- 가상계좌 결제 건의 경우</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건의 가상계좌 은행 표준코드(금융결제원기준)- 가상계좌 결제 건의 경우</p>\n"
         },
         "vbank_name": {
           "description": "입금받을 가상계좌 은행명",
           "type": "string",
           "x-portone-name": "가상계좌 은행명",
-          "x-portone-summary": "<p>결제건의 입금받을 가상계좌 은행명 - 가상계좌 결제 건의 경우</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건의 입금받을 가상계좌 은행명 - 가상계좌 결제 건의 경우</p>\n"
         },
         "vbank_num": {
           "description": "입금받을 가상계좌 계좌번호",
           "type": "string",
           "maxLength": "32",
           "x-portone-name": "가상계좌 계좌번호",
-          "x-portone-summary": "<p>결제건의 입금받을 가상계좌 계좌번호 - 가상계좌 결제 건의 경우</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건의 입금받을 가상계좌 계좌번호 - 가상계좌 결제 건의 경우</p>\n"
         },
         "vbank_holder": {
           "description": "입금받을 가상계좌 예금주",
           "type": "string",
           "x-portone-name": "가상계좌 예금주",
-          "x-portone-summary": "<p>결제건의 입금받을 가상계좌 예금주 - 가상계좌 결제 건의 경우</p>\n",
-          "x-portone-description": "",
+          "x-portone-description": "<p>결제건의 입금받을 가상계좌 예금주 - 가상계좌 결제 건의 경우</p>\n",
           "x-portone-per-pg": {
             "tosspayments": {
               "description": "<p>토스페이먼츠는 가상계좌 발급 완료시 발급 된 가상계좌의 예금주 명을 전달해주지 않습니다.\n따라서 <code>vbank_holder</code>가 null로 리턴 되지만, <strong>실제 가상계좌 예금주 명은 토스페이먼츠와 계약된 가맹점 이름과 동일</strong>하다고 하니, 참고 부탁드립니다.</p>\n"
@@ -9571,111 +9435,97 @@
           "description": "입금받을 가상계좌 마감기한 UNIX timestamp",
           "type": "integer",
           "x-portone-name": "가상계좌 입금기한",
-          "x-portone-summary": "<p>결제건의 가상계좌 입금기한 - 가상계좌 결제 건의 경우</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건의 가상계좌 입금기한 - 가상계좌 결제 건의 경우</p>\n"
         },
         "vbank_issued_at": {
           "description": "가상계좌 생성 시각 UNIX timestamp",
           "type": "integer",
           "x-portone-name": "가상계좌 생성시각",
-          "x-portone-summary": "<p>결제건의 가상계좌 생성시각 UNIX timestamp - 가상계좌 결제 건의 경우</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건의 가상계좌 생성시각 UNIX timestamp - 가상계좌 결제 건의 경우</p>\n"
         },
         "name": {
           "description": "제품명",
           "type": "string",
           "maxLength": "40",
           "x-portone-name": "제품명",
-          "x-portone-summary": "<p>결제건의 제품명</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건의 제품명</p>\n"
         },
         "amount": {
           "description": "주문(결제)금액",
           "type": "number",
           "x-portone-name": "결제금액",
-          "x-portone-summary": "<p>결제건의 결제금액</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건의 결제금액</p>\n"
         },
         "cancel_amount": {
           "description": "결제취소금액",
           "type": "number",
           "x-portone-name": "취소금액",
-          "x-portone-summary": "<p>결제건의 누적 취소금액</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건의 누적 취소금액</p>\n"
         },
         "currency": {
           "description": "통화구분코드",
           "type": "string",
           "x-portone-name": "결제통화 구분코드",
-          "x-portone-summary": "<p>외환분호 e.g) KRW, USD, VND, ... Default: KRW</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>외환분호 e.g) KRW, USD, VND, ... Default: KRW</p>\n"
         },
         "buyer_name": {
           "description": "주문자명",
           "type": "string",
           "maxLength": 16,
           "x-portone-name": "주문자명",
-          "x-portone-summary": "<p>결제건의 주문자명</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건의 주문자명</p>\n"
         },
         "buyer_email": {
           "description": "주문자 Email주소",
           "type": "string",
           "maxLength": "64",
           "x-portone-name": "주문자 Email주소",
-          "x-portone-summary": "<p>결제건의 주문자의 Email주소</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건의 주문자의 Email주소</p>\n"
         },
         "buyer_tel": {
           "description": "주문자 전화번호",
           "type": "string",
           "maxLength": "16",
           "x-portone-name": "주문자 전화번호",
-          "x-portone-summary": "<p>결제건의 주문자 전화번호</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건의 주문자 전화번호</p>\n"
         },
         "buyer_addr": {
           "description": "주문자 주소",
           "type": "string",
           "maxLength": "128",
           "x-portone-name": "주문자 주소",
-          "x-portone-summary": "<p>결제건의 주문자 주소</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건의 주문자 주소</p>\n"
         },
         "buyer_postcode": {
           "description": "주문자 우편번호",
           "type": "string",
           "maxLength": "8",
           "x-portone-name": "주문자 우편번호",
-          "x-portone-summary": "<p>결제건의 주문자 우편번호</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건의 주문자 우편번호</p>\n"
         },
         "custom_data": {
           "description": "가맹점에서 전달한 custom data <br> JSON string으로 전달",
           "type": "string",
           "x-portone-name": "추가정보",
-          "x-portone-summary": "<p>결제 요청시 가맹점에서 전달한 추가정보 (JSON string으로 전달)</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제 요청시 가맹점에서 전달한 추가정보 (JSON string으로 전달)</p>\n"
         },
         "user_agent": {
           "description": "구매자가 결제를 시작한 단말기의 UserAgent 문자열",
           "type": "string",
           "x-portone-name": "단말기의 UserAgent 문자열",
-          "x-portone-summary": "<p>구매자가 결제시 사용한 단말기의 UserAgent 문자열</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>구매자가 결제시 사용한 단말기의 UserAgent 문자열</p>\n"
         },
         "status": {
           "description": "결제상태\n     <ul><li>ready:미결제\n     </li><li>paid:결제완료\n     </li><li> cancelled:결제취소\n     </li><li> failed:결제실패</li></ul>",
           "type": "string",
           "x-portone-name": "결제상태",
-          "x-portone-summary": "<p>결제건의 결제상태</p>\n"
+          "x-portone-description": "<p>결제건의 결제상태</p>\n"
         },
         "started_at": {
           "description": "결제시작시점 UNIX timestamp",
           "type": "integer",
           "x-portone-name": "요청 시각",
-          "x-portone-summary": "<p>결제건의 결제요청 시각 UNIX timestamp</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건의 결제요청 시각 UNIX timestamp</p>\n"
         },
         "paid_at": {
           "description": "결제완료시점 UNIX timestamp <br> 결제완료가 아닐 경우 0",
@@ -9716,8 +9566,7 @@
           "description": "매출전표 확인 URL <br> PG사 또는 결제 수단에 따라 매출전표가 없을 수 있습니다.",
           "type": "string",
           "x-portone-name": "매출전표 URL",
-          "x-portone-summary": "<p>결제건의 매출전표 URL로 PG사 또는 결제 수단에 따라 매출전표가 없을 수 있습니다.</p>\n",
-          "x-portone-description": "",
+          "x-portone-description": "<p>결제건의 매출전표 URL로 PG사 또는 결제 수단에 따라 매출전표가 없을 수 있습니다.</p>\n",
           "x-portone-per-pg": {
             "tosspayments": {
               "description": "<p>테스트 결제건, 간편결제 중 카드 외 결제건은 매출 전표 확인이 불가능합니다.</p>\n"
@@ -9737,8 +9586,7 @@
             "$ref": "#/definitions/PaymentCancelAnnotation"
           },
           "x-portone-name": "취소 내역",
-          "x-portone-summary": "<p>결제건의 취소/부분취소 내역</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건의 취소/부분취소 내역</p>\n"
         },
         "cancel_receipt_urls": {
           "description": "(Deprecated : cancel_history 사용 권장) 취소/부분취소 시 생성되는 취소 매출전표 확인 URL. 부분취소 횟수만큼 매출전표가 별도로 생성됨",
@@ -9751,21 +9599,19 @@
           "description": "현금영수증 자동발급 여부",
           "type": "boolean",
           "x-portone-name": "현금영수증 발급 여부",
-          "x-portone-summary": "<p>결제건의 현금영수증 발급 여부</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건의 현금영수증 발급 여부</p>\n"
         },
         "customer_uid": {
           "description": "해당 결제처리에 사용된 customer_uid",
           "type": "string",
           "x-portone-name": "구매자의 결제 수단 식별 고유번호",
-          "x-portone-summary": "<p>결제건에 사용된 빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건에 사용된 빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n"
         },
         "customer_uid_usage": {
           "description": "customer_uid가 결제처리에 사용된 상세 용도\n     <ul><li>null:일반결제\n     </li><li> issue:빌링키 발급\n     </li><li> payment:결제\n     </li><li> payment.scheduled:예약결제</li></ul>",
           "type": "string",
           "x-portone-name": "구매자의 결제 수단 식별 고유번호 사용 구분코드",
-          "x-portone-summary": "<p>결제처리에 사용된 구매자의 결제 수단 식별 고유번호의 사용 구분코드</p>\n"
+          "x-portone-description": "<p>결제처리에 사용된 구매자의 결제 수단 식별 고유번호의 사용 구분코드</p>\n"
         }
       }
     },
@@ -9781,29 +9627,25 @@
           "description": "면세 공급가액 (환불시 마이너스 차감된 최종 금액 반환)",
           "type": "number",
           "x-portone-name": "면세 공급가액",
-          "x-portone-summary": "<p>면세 공급가액으로 환불시 마이너스 차감된 최종 금액을 반환합니다.</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>면세 공급가액으로 환불시 마이너스 차감된 최종 금액을 반환합니다.</p>\n"
         },
         "supply": {
           "description": "과세 공급가액 (환불시 마이너스 차감된 최종 금액 반환)",
           "type": "number",
           "x-portone-name": "과세 공급가액",
-          "x-portone-summary": "<p>과세 공급가액으로 환불시 마이너스 차감된 최종 금액을 반환합니다.</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>과세 공급가액으로 환불시 마이너스 차감된 최종 금액을 반환합니다.</p>\n"
         },
         "vat": {
           "description": "부가세액 (환불시 마이너스 차감된 최종 금액 반환)",
           "type": "number",
           "x-portone-name": "부가세액",
-          "x-portone-summary": "<p>부가세액으로 환불시 마이너스 차감된 최종 금액을 반환합니다.</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>부가세액으로 환불시 마이너스 차감된 최종 금액을 반환합니다.</p>\n"
         },
         "service": {
           "description": "봉사료 (환불시 마이너스 차감된 최종 금액 반환)",
           "type": "number",
           "x-portone-name": "봉사료",
-          "x-portone-summary": "<p>봉사료로 환불시 마이너스 차감된 최종 금액을 반환합니다.</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>봉사료로 환불시 마이너스 차감된 최종 금액을 반환합니다.</p>\n"
         }
       }
     },
@@ -9818,37 +9660,32 @@
         "cash_receipt": {
           "description": "현금영수증 발급된 금액 상세",
           "x-portone-name": "현금영수증 발급된 상세 금액",
-          "x-portone-summary": "<p>결제건의 현금영수증이 발급된 경우 상세 금액을 반환합니다.</p>\n",
-          "x-portone-description": "",
+          "x-portone-description": "<p>결제건의 현금영수증이 발급된 경우 상세 금액을 반환합니다.</p>\n",
           "$ref": "#/definitions/PaymentBalanceAnnotation"
         },
         "primary": {
           "description": "1차 결제수단(신용카드, 계좌이체, 가상계좌, 휴대폰소액결제) 금액 상세",
           "x-portone-name": "1차 결제수단",
-          "x-portone-summary": "<p>결제건의 1차 결제수단(신용카드, 계좌이체, 가상계좌, 휴대폰소액결제) 상세 금액을 반환합니다.</p>\n",
-          "x-portone-description": "",
+          "x-portone-description": "<p>결제건의 1차 결제수단(신용카드, 계좌이체, 가상계좌, 휴대폰소액결제) 상세 금액을 반환합니다.</p>\n",
           "$ref": "#/definitions/PaymentBalanceAnnotation"
         },
         "secondary": {
           "description": "2차 결제수단(PG사포인트, 카드사포인트) 금액 상세",
           "x-portone-name": "2차 결제수단",
-          "x-portone-summary": "<p>결제건의 2차 결제수단(PG사포인트, 카드사포인트) 상세 금액을 반환합니다.</p>\n",
-          "x-portone-description": "",
+          "x-portone-description": "<p>결제건의 2차 결제수단(PG사포인트, 카드사포인트) 상세 금액을 반환합니다.</p>\n",
           "$ref": "#/definitions/PaymentBalanceAnnotation"
         },
         "discount": {
           "description": "PG사/카드사 자체 할인 금액 상세",
           "x-portone-name": "할인 금액 상세",
-          "x-portone-summary": "<p>결제건의 PG사/카드사 자체 상세 할인 금액을 반환합니다.</p>\n",
-          "x-portone-description": "",
+          "x-portone-description": "<p>결제건의 PG사/카드사 자체 상세 할인 금액을 반환합니다.</p>\n",
           "$ref": "#/definitions/PaymentBalanceAnnotation"
         },
         "created": {
           "description": "Balance정보가 등록된 시각 UNIX timestamp",
           "type": "integer",
           "x-portone-name": "등록시각",
-          "x-portone-summary": "<p>결제건의 Balance정보가 등록된 시각 UNIX timestamp</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건의 Balance정보가 등록된 시각 UNIX timestamp</p>\n"
         }
       }
     },
@@ -9865,35 +9702,30 @@
           "description": "최초 총 결제금액",
           "type": "number",
           "x-portone-name": "결제금액",
-          "x-portone-summary": "<p>결제건의 총 결제금액</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건의 총 결제금액</p>\n"
         },
         "cash_receipt": {
           "description": "현금영수증 발급된 금액 상세",
           "x-portone-name": "현금영수증 발급된 상세 금액",
-          "x-portone-summary": "<p>결제건의 현금영수증이 발급된 경우 상세 금액을 반환합니다.</p>\n",
-          "x-portone-description": "",
+          "x-portone-description": "<p>결제건의 현금영수증이 발급된 경우 상세 금액을 반환합니다.</p>\n",
           "$ref": "#/definitions/PaymentBalanceAnnotation"
         },
         "primary": {
           "description": "1차 결제수단(신용카드, 계좌이체, 가상계좌, 휴대폰소액결제) 금액 상세",
           "x-portone-name": "1차 결제수단",
-          "x-portone-summary": "<p>결제건의 1차 결제수단(신용카드, 계좌이체, 가상계좌, 휴대폰소액결제) 상세 금액을 반환합니다.</p>\n",
-          "x-portone-description": "",
+          "x-portone-description": "<p>결제건의 1차 결제수단(신용카드, 계좌이체, 가상계좌, 휴대폰소액결제) 상세 금액을 반환합니다.</p>\n",
           "$ref": "#/definitions/PaymentBalanceAnnotation"
         },
         "secondary": {
           "description": "2차 결제수단(PG사포인트, 카드사포인트) 금액 상세",
           "x-portone-name": "2차 결제수단",
-          "x-portone-summary": "<p>결제건의 2차 결제수단(PG사포인트, 카드사포인트) 상세 금액을 반환합니다.</p>\n",
-          "x-portone-description": "",
+          "x-portone-description": "<p>결제건의 2차 결제수단(PG사포인트, 카드사포인트) 상세 금액을 반환합니다.</p>\n",
           "$ref": "#/definitions/PaymentBalanceAnnotation"
         },
         "discount": {
           "description": "PG사/카드사 자체 할인 금액 상세",
           "x-portone-name": "할인 금액 상세",
-          "x-portone-summary": "<p>결제건의 PG사/카드사 자체 상세 할인 금액을 반환합니다.</p>\n",
-          "x-portone-description": "",
+          "x-portone-description": "<p>결제건의 PG사/카드사 자체 상세 할인 금액을 반환합니다.</p>\n",
           "$ref": "#/definitions/PaymentBalanceAnnotation"
         },
         "histories": {
@@ -9903,8 +9735,7 @@
             "$ref": "#/definitions/PaymentBalanceHistoriesAnnotation"
           },
           "x-portone-name": "PaymentBalance이력",
-          "x-portone-summary": "<p>결제건의 Balance 이력을 반환합니다.</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건의 Balance 이력을 반환합니다.</p>\n"
         }
       }
     },
@@ -9919,22 +9750,19 @@
           "description": "검색한 결제 상태에 대한 전체 건수",
           "type": "integer",
           "x-portone-name": "전체 건수",
-          "x-portone-summary": "<p>조회한 결제 상태에 대한 전체 건수</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>조회한 결제 상태에 대한 전체 건수</p>\n"
         },
         "previous": {
           "description": "이전 page숫자. 이전 페이지가 없으면 0",
           "type": "integer",
           "x-portone-name": "이전 page숫자",
-          "x-portone-summary": "<p>이전 page숫자로 이전 페이지가 없는 경우 0을 반환합니다.</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>이전 page숫자로 이전 페이지가 없는 경우 0을 반환합니다.</p>\n"
         },
         "next": {
           "description": "다음 page숫자. 다음 페이지가 없으면 0",
           "type": "integer",
           "x-portone-name": "다음 page숫자",
-          "x-portone-summary": "<p>다음 page숫자로 다음 페이지가 없는 경우 0을 반환합니다.</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>다음 page숫자로 다음 페이지가 없는 경우 0을 반환합니다.</p>\n"
         },
         "list": {
           "description": "결제 상세정보 배열(최대 20개). 바로 아래 Payment structure를 확인하세요.",
@@ -9943,8 +9771,7 @@
             "$ref": "#/definitions/PaymentAnnotation"
           },
           "x-portone-name": "결제 상세정보 배열",
-          "x-portone-summary": "<p>결제 상세정보 배열로 최대 20개를 반환합니다. 바로 아래 Payment structure를 확인해주세요.</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제 상세정보 배열로 최대 20개를 반환합니다. 바로 아래 Payment structure를 확인해주세요.</p>\n"
         }
       }
     },
@@ -10023,36 +9850,31 @@
           "description": "PG사 승인취소번호",
           "type": "string",
           "x-portone-name": "PG사 승인취소번호",
-          "x-portone-summary": "<p>결제건의 PG사 승인취소번호</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건의 PG사 승인취소번호</p>\n"
         },
         "amount": {
           "description": "취소 금액",
           "type": "number",
           "x-portone-name": "취소 금액",
-          "x-portone-summary": "<p>결제건의 취소 금액</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건의 취소 금액</p>\n"
         },
         "cancelled_at": {
           "description": "결제취소된 시각 UNIX timestamp",
           "type": "integer",
           "x-portone-name": "취소 시각",
-          "x-portone-summary": "<p>결제건의 결제취소된 시각 UNIX timestamp</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건의 결제취소된 시각 UNIX timestamp</p>\n"
         },
         "reason": {
           "description": "결제취소 사유",
           "type": "string",
           "x-portone-name": "취소 사유",
-          "x-portone-summary": "<p>결제건의 결제취소 사유</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건의 결제취소 사유</p>\n"
         },
         "receipt_url": {
           "description": "취소에 대한 매출전표 확인 URL <br>PG사, 결제 수단에 따라 제공되지 않는 경우도 있음",
           "type": "string",
           "x-portone-name": "취소 매출전표 URL",
-          "x-portone-summary": "<p>결제건의 취소 매출전표 확인 URL로 PG사, 결제 수단에 따라 제공되지 않을 수 있습니다.</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건의 취소 매출전표 확인 URL로 PG사, 결제 수단에 따라 제공되지 않을 수 있습니다.</p>\n"
         }
       }
     },
@@ -10067,15 +9889,13 @@
           "description": "가맹점 주문번호",
           "type": "string",
           "x-portone-name": "가맹점 주문번호",
-          "x-portone-summary": "<p>사전 등록한 가맹점의 주문번호</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>사전 등록한 가맹점의 주문번호</p>\n"
         },
         "amount": {
           "description": "결제 예정 금액",
           "type": "number",
           "x-portone-name": "결제 예정 금액",
-          "x-portone-summary": "<p>사전 등록한 결제 예정 금액</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>사전 등록한 결제 예정 금액</p>\n"
         }
       }
     },
@@ -10100,21 +9920,18 @@
           "description": "0이면 정상적인 조회, 0아닌 값이면 message를 확인해봐야 합니다",
           "type": "integer",
           "x-portone-name": "응답코드",
-          "x-portone-summary": "<p>0이면 정상적인 조회, 0아닌 값이면 message를 확인해봐야 합니다</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>0이면 정상적인 조회, 0아닌 값이면 message를 확인해봐야 합니다</p>\n"
         },
         "message": {
           "description": "code값이 0이 아닐 때, '존재하지 않는 결제정보입니다'와 같은 오류 메세지를 포함합니다",
           "type": "string",
           "x-portone-name": "응답메세지",
-          "x-portone-summary": "<p>code 값이 0이 아닐 때, ‘존재하지 않는 결제정보입니다’와 같은 오류 메세지를 포함합니다</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>code 값이 0이 아닐 때, ‘존재하지 않는 결제정보입니다’와 같은 오류 메세지를 포함합니다</p>\n"
         },
         "response": {
           "description": "에러 메시지를 포함하거나, 성공시 success: 1 메시지를 포함합니다",
           "x-portone-name": "응답",
-          "x-portone-summary": "<p>에러 메시지를 포함하거나, 성공시 <strong>success: 1</strong> 메시지를 포함합니다</p>\n",
-          "x-portone-description": "",
+          "x-portone-description": "<p>에러 메시지를 포함하거나, 성공시 <strong>success: 1</strong> 메시지를 포함합니다</p>\n",
           "$ref": "#/definitions/PaymentwallDeliveryDetailAnnotation"
         }
       }
@@ -10125,15 +9942,13 @@
           "description": "이 값이 없으면 정상적인 경우, 없으면 notices를 확인해봐야 합니다",
           "type": "integer",
           "x-portone-name": "에러코드",
-          "x-portone-summary": "<p>이 값이 없으면 정상적인 경우, 없으면 notices를 확인해봐야 합니다</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>이 값이 없으면 정상적인 경우, 없으면 notices를 확인해봐야 합니다</p>\n"
         },
         "error": {
           "description": "에러 메시지",
           "type": "string",
           "x-portone-name": "에러메세지",
-          "x-portone-summary": "<p>에러코드에 대응하는 오류메세지를 반환합니다.</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>에러코드에 대응하는 오류메세지를 반환합니다.</p>\n"
         },
         "notices": {
           "description": "자세한 에러 메시지",
@@ -10142,8 +9957,7 @@
             "type": "string"
           },
           "x-portone-name": "자세한 에러메세지",
-          "x-portone-summary": "<p><code>error_code</code> 값이 없는 경우 확인이 필요한 상세 에러메세지</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p><code>error_code</code> 값이 없는 경우 확인이 필요한 상세 에러메세지</p>\n"
         }
       }
     },
@@ -10335,63 +10149,55 @@
           "description": "포트원 거래고유번호",
           "type": "string",
           "x-portone-name": "포트원 거래고유번호",
-          "x-portone-summary": "<p>결제건의 포트원 거래고유번호</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건의 포트원 거래고유번호</p>\n"
         },
         "receipt_tid": {
           "description": "현금영수증 PG사 발행고유번호",
           "type": "string",
           "x-portone-name": "PG사 현금영수증 발행 고유번호",
-          "x-portone-summary": "<p>결제건에 대해 현금영수증 발행시 PG사의 발행고유번호</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건에 대해 현금영수증 발행시 PG사의 발행고유번호</p>\n"
         },
         "apply_num": {
           "description": "현금영수증 국세청 발행번호",
           "type": "string",
           "x-portone-name": "국세청 발행번호",
-          "x-portone-summary": "<p>결제건에 대해 현금영수증 발행시 국세청 발행번호</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건에 대해 현금영수증 발행시 국세청 발행번호</p>\n"
         },
         "type": {
           "description": "현금영수증 발행대상 타입\n     <ul><li>개인 : `person`\n     </li><li>사업자 : `company`</li></ul>",
           "type": "string",
           "x-portone-name": "타입(대상)",
-          "x-portone-summary": "<p>현금영수증 발행 대상의 타입</p>\n"
+          "x-portone-description": "<p>현금영수증 발행 대상의 타입</p>\n"
         },
         "amount": {
           "description": "현금영수증 발행금액",
           "type": "integer",
           "x-portone-name": "발행 금액",
-          "x-portone-summary": "<p>현금영수증 발행 금액</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>현금영수증 발행 금액</p>\n"
         },
         "vat": {
           "description": "현금영수증 발행금액 중 부가세금액",
           "type": "integer",
           "x-portone-name": "부가세액",
-          "x-portone-summary": "<p>현금영수증 발행금액 중 부가세액</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>현금영수증 발행금액 중 부가세액</p>\n"
         },
         "receipt_url": {
           "description": "발행된 현금영수증 URL",
           "type": "string",
           "x-portone-name": "현금영수증 URL",
-          "x-portone-summary": "<p>발행된 현금영수증을 확인할 수 있는 URL</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>발행된 현금영수증을 확인할 수 있는 URL</p>\n"
         },
         "applied_at": {
           "description": "현금영수증 발행시각 UNIX TIMESTAMP",
           "type": "integer",
           "x-portone-name": "발행시각",
-          "x-portone-summary": "<p>현금영수증 발행시각 UNIX timestamp</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>현금영수증 발행시각 UNIX timestamp</p>\n"
         },
         "cancelled_at": {
           "description": "현금영수증 발행취소시각 UNIX TIMESTAMP",
           "type": "integer",
           "x-portone-name": "발행취소시각",
-          "x-portone-summary": "<p>현금영수증 발행취소시각 UNIX timestamp</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>현금영수증 발행취소시각 UNIX timestamp</p>\n"
         }
       }
     },
@@ -10424,63 +10230,55 @@
           "description": "현금영수증 가맹점 주문번호",
           "type": "string",
           "x-portone-name": "가맹점 주문번호",
-          "x-portone-summary": "<p>현금영수증을 발행한 가맹점의 주문번호</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>현금영수증을 발행한 가맹점의 주문번호</p>\n"
         },
         "receipt_tid": {
           "description": "현금영수증 PG사 발행고유번호",
           "type": "string",
           "x-portone-name": "PG사 현금영수증 발행 고유번호",
-          "x-portone-summary": "<p>결제건에 대해 현금영수증 발행시 PG사의 발행고유번호</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건에 대해 현금영수증 발행시 PG사의 발행고유번호</p>\n"
         },
         "apply_num": {
           "description": "현금영수증 국세청 발행번호",
           "type": "string",
           "x-portone-name": "국세청 발행번호",
-          "x-portone-summary": "<p>결제건에 대해 현금영수증 발행시 국세청 발행번호</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건에 대해 현금영수증 발행시 국세청 발행번호</p>\n"
         },
         "type": {
           "description": "현금영수증 발행대상 타입\n     <ul><li>개인 : `person`\n     </li><li>사업자 : `company`</li></ul>",
           "type": "string",
           "x-portone-name": "타입(대상)",
-          "x-portone-summary": "<p>현금영수증 발행 대상의 타입</p>\n"
+          "x-portone-description": "<p>현금영수증 발행 대상의 타입</p>\n"
         },
         "amount": {
           "description": "현금영수증 발행금액",
           "type": "integer",
           "x-portone-name": "발행 금액",
-          "x-portone-summary": "<p>현금영수증 발행 금액</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>현금영수증 발행 금액</p>\n"
         },
         "vat": {
           "description": "현금영수증 발행금액 중 부가세금액",
           "type": "integer",
           "x-portone-name": "부가세액",
-          "x-portone-summary": "<p>현금영수증 발행금액 중 부가세액</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>현금영수증 발행금액 중 부가세액</p>\n"
         },
         "receipt_url": {
           "description": "발행된 현금영수증 URL",
           "type": "string",
           "x-portone-name": "현금영수증 URL",
-          "x-portone-summary": "<p>발행된 현금영수증을 확인할 수 있는 URL</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>발행된 현금영수증을 확인할 수 있는 URL</p>\n"
         },
         "applied_at": {
           "description": "현금영수증 발행시각 UNIX TIMESTAMP",
           "type": "integer",
           "x-portone-name": "발행시각",
-          "x-portone-summary": "<p>현금영수증 발행시각 UNIX timestamp</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>현금영수증 발행시각 UNIX timestamp</p>\n"
         },
         "cancelled_at": {
           "description": "현금영수증 발행취소시각 UNIX TIMESTAMP",
           "type": "integer",
           "x-portone-name": "발행취소시각",
-          "x-portone-summary": "<p>현금영수증 발행취소시각 UNIX timestamp</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>현금영수증 발행취소시각 UNIX timestamp</p>\n"
         }
       }
     },
@@ -10505,15 +10303,13 @@
           "description": "0이면 정상적인 조회, 0아닌 값이면 message를 확인해봐야 합니다",
           "type": "integer",
           "x-portone-name": "응답코드",
-          "x-portone-summary": "<p>0이면 정상적인 조회, 0아닌 값이면 message를 확인해봐야 합니다</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>0이면 정상적인 조회, 0아닌 값이면 message를 확인해봐야 합니다</p>\n"
         },
         "message": {
           "description": "code값이 0이 아닐 때, '존재하지 않는 결제정보입니다'와 같은 오류 메세지를 포함합니다",
           "type": "string",
           "x-portone-name": "응답메세지",
-          "x-portone-summary": "<p>code값이 0이 아닐 때, '존재하지 않는 결제정보입니다'와 같은 오류 메세지를 포함합니다</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>code값이 0이 아닐 때, '존재하지 않는 결제정보입니다'와 같은 오류 메세지를 포함합니다</p>\n"
         }
       }
     },
@@ -10529,8 +10325,7 @@
           "description": "가맹점 주문번호",
           "type": "string",
           "x-portone-name": "가맹점의 주문번호",
-          "x-portone-summary": "<p>결제 예약건의 가맹점 주문번호</p>\n",
-          "x-portone-description": "",
+          "x-portone-description": "<p>결제 예약건의 가맹점 주문번호</p>\n",
           "x-portone-per-pg": {
             "smartro_v2": {
               "description": "<p>스마트로는 주문 번호(merchant_uid)에 <strong>특수문자를 허용하고 있지 않습니다.</strong></p>\n<p>따라서 결제창에서 일반결제를 할때와 발급 된 빌링키로 API를 통해 재결제를 하는 경우 숫자, 문자(알파벳 소문자와 대문자) 또는 그 조합으로 이루어진 주문 번호를 사용해주세요.\n또한, 주문번호(merchant_uid)가 <strong>최대 40자</strong>를 넘을 수 없습니다. 40자가 넘을 경우 40자까지 잘려서 저장되기 때문에 유의 바랍니다.</p>\n"
@@ -10542,16 +10337,14 @@
           "type": "integer",
           "default": 0,
           "x-portone-name": "예약시각",
-          "x-portone-summary": "<p>결제요청 예약시각 UNIX timestamp</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제요청 예약시각 UNIX timestamp</p>\n"
         },
         "currency": {
           "description": "통화 e.g.) KRW, USD, VND, ... Default: KRW ",
           "type": "string",
           "default": "KRW",
           "x-portone-name": "결제 통화 코드",
-          "x-portone-summary": "<p>통화 e.g.) KRW, USD, VND, ... Default: KRW</p>\n",
-          "x-portone-description": "",
+          "x-portone-description": "<p>통화 e.g.) KRW, USD, VND, ... Default: KRW</p>\n",
           "x-portone-per-pg": {
             "ksnet": {
               "description": "<p>USD 결제는 순수 해외카드로만 결제 가능합니다.</p>\n"
@@ -10566,14 +10359,13 @@
           "description": "결제금액",
           "type": "number",
           "x-portone-name": "결제금액",
-          "x-portone-summary": "<p>결제 예약을 요청한 결제금액</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제 예약을 요청한 결제금액</p>\n"
         },
         "tax_free": {
           "description": "amount 중 면세공급가액.<br/>기본값은 0이므로(amount 모두 과세대상이므로) amount의 1/11 이 부가세로 처리됩니다.",
           "type": "number",
           "x-portone-name": "면세공급가액",
-          "x-portone-summary": "<p>결제 예약을 요청한 결제금액 중 면세공급가액</p>\n",
+          "x-portone-description": "<p>결제 예약을 요청한 결제금액 중 면세공급가액</p>\n",
           "x-portone-per-pg": {
             "ksnet": {
               "description": "<p>면세 설정 상점아이디에서 면세처리를 위해 결제 금액과 동일한 면세 금액을 반드시 입력해야 합니다. 그렇지 않은 경우 매출전표에 전액 면세가 아닌 것으로 표시되고 실제 처리 내역이 다를 수 있습니다.</p>\n<p>과세 설정 상점아이디에서 면세 금액을 전달하지 않아야 합니다. 면세 금액을 전달하는 경우 매출전표에 면세 처리된 것으로 표시되지만 실제 처리 내역과 다를 수 있습니다.</p>\n"
@@ -10587,8 +10379,7 @@
           "description": "amount 중 부가세 금액(기본값 : null, 현재 나이스페이먼츠, 이니시스, (신) 나이스페이, 웰컴페이먼츠 지원)",
           "type": "number",
           "x-portone-name": "부가세",
-          "x-portone-summary": "<p>결제 예약을 요청한 결제금액 중 부가세</p>\n",
-          "x-portone-description": "",
+          "x-portone-description": "<p>결제 예약을 요청한 결제금액 중 부가세</p>\n",
           "x-portone-supported-pgs": [
             "nice",
             "html5_inicis",
@@ -10606,8 +10397,7 @@
           "type": "string",
           "maxLength": 40,
           "x-portone-name": "제품명",
-          "x-portone-summary": "<p>결제건의 제품명</p>\n",
-          "x-portone-description": "",
+          "x-portone-description": "<p>결제건의 제품명</p>\n",
           "x-portone-per-pg": {
             "html5_inicis": {
               "required": true
@@ -10622,8 +10412,7 @@
           "type": "string",
           "maxLength": 16,
           "x-portone-name": "주문자명",
-          "x-portone-summary": "<p>결제건의 문자명</p>\n",
-          "x-portone-description": "",
+          "x-portone-description": "<p>결제건의 문자명</p>\n",
           "x-portone-per-pg": {
             "smartro_v2": {
               "required": true
@@ -10644,8 +10433,7 @@
           "type": "string",
           "maxLength": 64,
           "x-portone-name": "주문자 Email주소",
-          "x-portone-summary": "<p>결제건의 주문자 Email주소</p>\n",
-          "x-portone-description": "",
+          "x-portone-description": "<p>결제건의 주문자 Email주소</p>\n",
           "x-portone-per-pg": {
             "smartro_v2": {
               "required": true
@@ -10661,8 +10449,7 @@
           "type": "string",
           "maxLength": 16,
           "x-portone-name": "주문자 전화번호",
-          "x-portone-summary": "<p>결제건의 주문자 전화번호</p>\n",
-          "x-portone-description": "",
+          "x-portone-description": "<p>결제건의 주문자 전화번호</p>\n",
           "x-portone-per-pg": {
             "smartro_v2": {
               "required": true
@@ -10674,23 +10461,20 @@
           "type": "string",
           "maxLength": 128,
           "x-portone-name": "주문자 주소",
-          "x-portone-summary": "<p>결제건의 주문자 주소</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건의 주문자 주소</p>\n"
         },
         "buyer_postcode": {
           "description": "주문자 우편번호",
           "type": "string",
           "maxLength": 8,
           "x-portone-name": "주문자 우편번호",
-          "x-portone-summary": "<p>결제건의 주문자 우편번호</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건의 주문자 우편번호</p>\n"
         },
         "custom_data": {
           "description": "예약된 결제가 수행될 때 Payment.custom_data로 사용할 값.",
           "type": "string",
           "x-portone-name": "추가정보",
-          "x-portone-summary": "<p>예약된 결제가 수행될 때 함께 저장할 추가정보</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>예약된 결제가 수행될 때 함께 저장할 추가정보</p>\n"
         },
         "notice_url": {
           "description": "예약된 결제가 수행된 후 웹훅(Notification)이 발송될 URL을 직접 지정. (지정되지 않으면 관리자페이지의 Notification URL로 발송됨)",
@@ -10703,7 +10487,7 @@
           "description": "판매 상품에 대한 구분 값 (real : 실물상품 digital : 디지털 컨텐츠)",
           "type": "string",
           "x-portone-name": "주문 상품구분",
-          "x-portone-summary": "<p>판매 상품에 대한 구분 값</p>\n",
+          "x-portone-description": "<p>판매 상품에 대한 구분 값</p>\n",
           "x-portone-supported-pgs": [
             "ksnet",
             "paypal_v2"
@@ -10718,7 +10502,7 @@
           "description": "현금영수증 발행대상 구분 값 (person, company, anonymous) <br><br><h5>지원되는 PG사</h5><ul><li>(신) 토스페이</li></ul>(신) 토스페이 경우 anonymous 전달 시 현금영수증 미발행 그 외 경우 현금영수증 자동 발행으로 동작합니다.",
           "type": "string",
           "x-portone-name": "현금영수증 발행대상",
-          "x-portone-summary": "<p>현금영수증 발행대상 구분 값</p>\n",
+          "x-portone-description": "<p>현금영수증 발행대상 구분 값</p>\n",
           "x-portone-supported-pgs": [
             "tosspay_v2"
           ],
@@ -10732,8 +10516,7 @@
           "description": "카드할부개월수. 2 이상의 integer 할부개월수 적용(결제금액 50,000원 이상 한정, default = 0(일시불))",
           "type": "number",
           "x-portone-name": "카드 할부 개월 수",
-          "x-portone-summary": "<p>결제건의 카드 할부 개월 수로 기본값은 **0(일시불)**입니다.</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제건의 카드 할부 개월 수로 기본값은 **0(일시불)**입니다.</p>\n"
         },
         "interest_free_by_merchant": {
           "description": "카드할부처리시, 할부이자가 발생하는 경우(카드사 무이자 프로모션 제외) 부과되는 할부이자를 가맹점이 지불하고자 PG사와 계약된 경우 (default : false)",
@@ -10765,8 +10548,7 @@
           "description": "결제 상품의 개수 (Default : 1)",
           "type": "integer",
           "x-portone-name": "결제 상품의 개수",
-          "x-portone-summary": "<p>결제 상품의 개수로 기본값은 1입니다.</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제 상품의 개수로 기본값은 1입니다.</p>\n"
         },
         "extra": {
           "description": "결제 예약 요청시 필요한 추가 정보",
@@ -10775,7 +10557,7 @@
               "description": "네이버페이 반복결제 계약 시 이용완료일 필수로 설정된 가맹점에 한함",
               "type": "string",
               "x-portone-name": "이용완료일",
-              "x-portone-summary": "<p>이용완료일 <code>YYYYMMDD</code></p>\n",
+              "x-portone-description": "<p>이용완료일 <code>YYYYMMDD</code></p>\n",
               "x-portone-supported-pgs": [
                 "naverpay"
               ]
@@ -10783,8 +10565,7 @@
           },
           "type": "object",
           "x-portone-name": "추가 파라미터",
-          "x-portone-summary": "<p>결제 예약 요청시 필요한 추가 정보</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제 예약 요청시 필요한 추가 정보</p>\n"
         },
         "bypass": {
           "description": "JSON string 형식의 PG사별로 특화된 파라미터. <br>전달 한 값은 가공 없이 그대로 PG사로 전달 됩니다. <br>각 PG사별 스펙은 PG사별 연동 문서 참고해주세요",
@@ -10801,16 +10582,14 @@
           "description": "빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호",
           "type": "string",
           "x-portone-name": "구매자의 결제 수단 식별 고유번호",
-          "x-portone-summary": "<p>빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n"
         },
         "merchant_uid": {
           "description": "가맹점 주문번호",
           "type": "string",
           "maxLength": 40,
           "x-portone-name": "가맹점 주문번호",
-          "x-portone-summary": "<p>예약 결제건의 가맹점 주문번호</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>예약 결제건의 가맹점 주문번호</p>\n"
         },
         "imp_uid": {
           "description": "포트원 거래고유번호<br> 예약된 결제가 실행 전 철회되거나 아직 실행 전 예약 상태에 있으면 imp_uid 는 null 입니다.",
@@ -10824,121 +10603,107 @@
           "description": "구매자 ID",
           "type": "string",
           "x-portone-name": "구매자 ID",
-          "x-portone-summary": "<p>string 타입의 구매자 식별 고유번호</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>string 타입의 구매자 식별 고유번호</p>\n"
         },
         "schedule_at": {
           "description": "예약결제 실행 예정 시각 UNIX timestamp in seconds",
           "type": "integer",
           "default": 0,
           "x-portone-name": "결제 예정 시각",
-          "x-portone-summary": "<p>결제 예약시 요청한 결제 예정 시각 UNIX timestamp</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제 예약시 요청한 결제 예정 시각 UNIX timestamp</p>\n"
         },
         "executed_at": {
           "description": "예약결제가 실행된 시각 UNIX timestamp",
           "type": "integer",
           "default": 0,
           "x-portone-name": "결제 실행 시각",
-          "x-portone-summary": "<p>실제 결제가 실행된 시각 UNIX timestamp</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>실제 결제가 실행된 시각 UNIX timestamp</p>\n"
         },
         "revoked_at": {
           "description": "예약결제 실행을 철회한 시각 UNIX timestamp",
           "type": "integer",
           "default": 0,
           "x-portone-name": "결제 실행 철회 시각",
-          "x-portone-summary": "<p>예약 결제 실행을 철회한 시각 UNIX timestamp</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>예약 결제 실행을 철회한 시각 UNIX timestamp</p>\n"
         },
         "amount": {
           "description": "결제금액",
           "type": "number",
           "x-portone-name": "결제금액",
-          "x-portone-summary": "<p>결제 예약시 요청한 결제금액</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>결제 예약시 요청한 결제금액</p>\n"
         },
         "currency": {
           "description": "통화 e.g.) KRW, USD, VND, ... Default: KRW ",
           "type": "string",
           "default": "KRW",
           "x-portone-name": "결제 통화 코드",
-          "x-portone-summary": "<p>통화 e.g.) KRW, USD, VND, ... Default: KRW </p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>통화 e.g.) KRW, USD, VND, ... Default: KRW </p>\n"
         },
         "name": {
           "description": "제품명",
           "type": "string",
           "maxLength": 40,
           "x-portone-name": "제품명",
-          "x-portone-summary": "<p>예약 결제건의 제품명</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>예약 결제건의 제품명</p>\n"
         },
         "buyer_name": {
           "description": "주문자명",
           "type": "string",
           "maxLength": 16,
           "x-portone-name": "주문자명",
-          "x-portone-summary": "<p>예약 결제건의 주문자명</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>예약 결제건의 주문자명</p>\n"
         },
         "buyer_email": {
           "description": "주문자 Email주소",
           "type": "string",
           "maxLength": 64,
           "x-portone-name": "주문자 Email주소",
-          "x-portone-summary": "<p>예약 결제건의 주문자 Email주소</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>예약 결제건의 주문자 Email주소</p>\n"
         },
         "buyer_tel": {
           "description": "주문자 전화번호",
           "type": "string",
           "maxLength": 16,
           "x-portone-name": "주문자 전화번호",
-          "x-portone-summary": "<p>예약 결제건의 주문자 전화번호</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>예약 결제건의 주문자 전화번호</p>\n"
         },
         "buyer_addr": {
           "description": "주문자 주소",
           "type": "string",
           "maxLength": 128,
           "x-portone-name": "주문자 주소",
-          "x-portone-summary": "<p>예약 결제건의 주문자 주소</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>예약 결제건의 주문자 주소</p>\n"
         },
         "buyer_postcode": {
           "description": "주문자 우편번호",
           "type": "string",
           "maxLength": 8,
           "x-portone-name": "주문자 우편번호",
-          "x-portone-summary": "<p>예약 결제건의 주문자 우편번호</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>예약 결제건의 주문자 우편번호</p>\n"
         },
         "custom_data": {
           "description": "예약된 결제가 수행될 때 결제정보와 함께 저장할 추가정보",
           "type": "string",
           "x-portone-name": "추가정보",
-          "x-portone-summary": "<p>예약된 결제가 수행될 때 결제정보와 함께 저장할 추가정보</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>예약된 결제가 수행될 때 결제정보와 함께 저장할 추가정보</p>\n"
         },
         "schedule_status": {
           "description": "예약상태\n     <ul><li>scheduled:예약됨(실행되기 전)\n     </li><li>executed:예약된 결제실행완료\n     </li><li>revoked:예약철회</li></ul>",
           "type": "string",
           "x-portone-name": "예약상태",
-          "x-portone-summary": "<p>결제건의 예약상태</p>\n"
+          "x-portone-description": "<p>결제건의 예약상태</p>\n"
         },
         "payment_status": {
           "description": "실행된 결제의 승인 상태\n     <ul><li> null:아직 예약결제가 실행되지 않음(null 이라는 값의 문자열이 아닌 실제 null 입니다)\n     </li><li> paid:예약결제가 결제승인됨\n     </li><li>failed:예약결제가 승인실패됨\n     </li><li> cancelled:예약결제가 결제승인 후 환불됨</li></ul>",
           "type": "string",
           "x-portone-name": "결제상태",
-          "x-portone-summary": "<p>예약 결제건의 승인 상태</p>\n"
+          "x-portone-description": "<p>예약 결제건의 승인 상태</p>\n"
         },
         "fail_reason": {
           "description": "실행된 결제가 승인 실패인 경우, 실패사유",
           "type": "string",
           "x-portone-name": "실패사유",
-          "x-portone-summary": "<p>예약 결제건이 결제 승인에 실패한 경우, 실패사유</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>예약 결제건이 결제 승인에 실패한 경우, 실패사유</p>\n"
         }
       }
     },
@@ -10985,15 +10750,13 @@
           "description": "기관코드(금융결제원표준코드)",
           "type": "string",
           "x-portone-name": "기관코드",
-          "x-portone-summary": "<p>금융결제표준코드</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>금융결제표준코드</p>\n"
         },
         "name": {
           "description": "기관명(금융결제원기재명)",
           "type": "string",
           "x-portone-name": "기관명",
-          "x-portone-summary": "<p>금융결제원기재명</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>금융결제원기재명</p>\n"
         }
       }
     },
@@ -11047,7 +10810,7 @@
           "description": "하위 가맹점(Tier) 관리명칭",
           "type": "string",
           "x-portone-name": "티어명",
-          "x-portone-summary": "<p>하위가맹점(Tier)의 관리명칭</p>\n"
+          "x-portone-description": "<p>하위가맹점(Tier)의 관리명칭</p>\n"
         }
       }
     },
@@ -11079,42 +10842,38 @@
           "type": "string",
           "maxLength": "16",
           "x-portone-name": "PG사 구분코드",
-          "x-portone-summary": "<p>설정된 PG사의 구분코드</p>\n"
+          "x-portone-description": "<p>설정된 PG사의 구분코드</p>\n"
         },
         "pg_id": {
           "description": "PG사 상점아이디",
           "type": "string",
           "maxLength": "80",
           "x-portone-name": "PG사 상점아이디",
-          "x-portone-summary": "<p>설정된 PG사의 상점아이디(MID)</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>설정된 PG사의 상점아이디(MID)</p>\n"
         },
         "sandbox": {
           "description": "테스트모드 여부",
           "type": "boolean",
           "x-portone-name": "테스트모드 여부",
-          "x-portone-summary": "<p>설정된 PG사의 테스트모드 여부</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>설정된 PG사의 테스트모드 여부</p>\n"
         },
         "type": {
           "description": "PG 설정 타입 구분코드\n     <ul><li>payment : 인증방식 결제.(관리자 콘솔에서 PG설정(일반결제 및 정기결제) 탭에 해당)\n     </li><li>api_payment : API 방식의 결제. (관리자 콘솔에서 PG설정(일반결제 및 키인결제) 탭에 해당)\n    </li><li>certification : 본인 인증. (관리자 콘솔에서 본인 인증 서비스 탭에 해당)</li></ul>",
           "type": "string",
           "x-portone-name": "PG설정 타입 구분코드",
-          "x-portone-summary": "<p>설정된 PG사의 타입 구분코드</p>\n"
+          "x-portone-description": "<p>설정된 PG사의 타입 구분코드</p>\n"
         },
         "channel_name": {
           "description": "가맹점이 포트원 콘솔에 채널 추가시 설정한 결제 채널 이름",
           "type": "string",
           "x-portone-name": "채널이름",
-          "x-portone-summary": "<p>가맹점이 포트원 콘솔에 채널 추가시 설정한 결제 채널 이름</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>가맹점이 포트원 콘솔에 채널 추가시 설정한 결제 채널 이름</p>\n"
         },
         "channel_key": {
           "description": "가맹점이 포트원 콘솔에 채널 추가시 포트원이 자동 생성한 채널 고유 키",
           "type": "string",
           "x-portone-name": "채널 고유 키",
-          "x-portone-summary": "<p>가맹점이 포트원 콘솔에 채널 추가시 포트원이 자동 생성한 채널 고유 키</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>가맹점이 포트원 콘솔에 채널 추가시 포트원이 자동 생성한 채널 고유 키</p>\n"
         }
       }
     },
@@ -11145,8 +10904,7 @@
           "description": "예금주명",
           "type": "string",
           "x-portone-name": "예금주명",
-          "x-portone-summary": "<p>가상계좌의 예금주명</p>\n",
-          "x-portone-description": ""
+          "x-portone-description": "<p>가상계좌의 예금주명</p>\n"
         }
       }
     },


### PR DESCRIPTION
## 작업요약
더 이상 사용되지 않는 `x-portone-summary` 를 `x-portone-description`으로 변환하는 작업으로 
최종적으로 해야될 작업은 다음과 같지만 phase2의 경우. 개발자센터에 보여질 UI (대표적으로 개행 ) 와 문장이 적절한지 하나 하나 다 읽어봐야 해서 공수도 크고 무엇보다 리뷰가 매우 오래걸릴 것 같아 두 단계로 나누었고 이 PR은 그 중 phase1에 해당합니다.

- phase1: x-portone-summary 를 전부 x-portone-description으로 옮긴다
- phase2: 두개의 값이 이미 존재하고 서로 다른 경우 맥락을 파악하고 내용을 병합하여 x-portone-description 에 넣는다
상기 사유로 이 PR은 모두 기계적으로 단순 변환 되었으며 그 기준은 다음과 같습니다.

상기 사유로 이 PR은 모두 기계적으로 단순 변환 되었으며 그 기준은 다음과 같습니다. 
- `x-portone-summary` 만 존재할 경우 일괄적으로 `x-portone-description` 으로 치환한다.
- `x-portone-summary`, `x-portone-description` 둘다 존재할 경우
    - `x-portone-description` 이 빈문자열일 경우 `x-portone-summary`의 내용을 채우고 `x-portone-summary`는 삭제한다.
    - 두개의 내용이 같을 경우 `x-portone-description` 만 남기고 `x-portone-summary`는 삭제한다.
    - 두개의 내용이 다를 경우 아무 작업도 하지 않고 그대로 둔다 ( phase2에서 진행예정 )

### 작업내용
- [x] [v1 api 선행 PR](https://github.com/portone-io/api-iamport/pull/661)
- [x] api.iamport.kr/api/docs의 결과물을 escape 처리되지 않는 json으로 추출
- [x] scripts/render-v1.ts 수행

### 참고링크
- [참고 슬랙 스레드](https://chai-finance.slack.com/archives/C03N8773P1A/p1704180950354889)