### PR TITLE
api 문서의 request, response에 대해서 nested 속성들을 한 단계 보여주도록 함

### DIFF
--- a/src/layouts/rest-api/DescriptionArea.tsx
+++ b/src/layouts/rest-api/DescriptionArea.tsx
@@ -26,7 +26,9 @@ export default function DescriptionArea({
   }, [maxHeightPx]);
   return (
     <div class="relative overflow-hidden" style={{ maxHeight }}>
-      <div ref={childrenContainerRef}>{children}</div>
+      <div class="flex flex-col gap-2" ref={childrenContainerRef}>
+        {children}
+      </div>
       {maxHeightIsSmall && !open && (
         <>
           <div

--- a/src/layouts/rest-api/category/type-def.tsx
+++ b/src/layouts/rest-api/category/type-def.tsx
@@ -19,6 +19,7 @@ import {
   getTypenameByRef,
   repr,
   getTypeDefKind,
+  resolveTypeDef,
 } from "../schema-utils/type-def";
 import Expand from "./Expand";
 
@@ -90,6 +91,8 @@ export function TypeDefinitions({
                 basepath={basepath}
                 schema={schema}
                 typeDef={typeDef}
+                bgColor="#f1f5f9"
+                nestedBgColor="#fcfdfe"
               />
             </div>
           ))}
@@ -104,12 +107,16 @@ export interface TypeDefDocProps {
   schema: any;
   typeDef?: TypeDef | undefined;
   showNested?: boolean | undefined;
+  bgColor: string;
+  nestedBgColor?: string | undefined;
 }
 export function TypeDefDoc({
   basepath,
   schema,
   typeDef,
   showNested,
+  bgColor,
+  nestedBgColor,
 }: TypeDefDocProps) {
   const kind = getTypeDefKind(typeDef);
   switch (kind) {
@@ -120,6 +127,8 @@ export function TypeDefDoc({
           schema={schema}
           typeDef={typeDef}
           showNested={showNested}
+          bgColor={bgColor}
+          nestedBgColor={nestedBgColor}
         />
       );
     case "enum":
@@ -127,6 +136,7 @@ export function TypeDefDoc({
         <EnumDoc
           basepath={basepath}
           xPortoneEnum={typeDef!["x-portone-enum"]}
+          bgColor={bgColor}
         />
       );
     case "union":
@@ -136,6 +146,8 @@ export function TypeDefDoc({
           schema={schema}
           typeDef={typeDef!}
           showNested={showNested}
+          bgColor={bgColor}
+          nestedBgColor={nestedBgColor}
         />
       );
   }
@@ -146,8 +158,17 @@ interface UnionDocProps {
   schema: any;
   typeDef: TypeDef;
   showNested?: boolean | undefined;
+  bgColor: string;
+  nestedBgColor?: string | undefined;
 }
-function UnionDoc({ basepath, schema, typeDef, showNested }: UnionDocProps) {
+function UnionDoc({
+  basepath,
+  schema,
+  typeDef,
+  showNested,
+  bgColor,
+  nestedBgColor,
+}: UnionDocProps) {
   const { propertyName, mapping } = typeDef.discriminator!;
   const types = Object.keys(mapping);
   const typeSignal = useSignal(types[0]!);
@@ -171,17 +192,17 @@ function UnionDoc({ basepath, schema, typeDef, showNested }: UnionDocProps) {
   const otherProperties = otherPropertiesSignal.value;
   return (
     <div class="flex flex-col gap-2">
-      <div class="bg-slate-1 rounded py-1">
+      <div class="rounded py-1" style={{ backgroundColor: bgColor }}>
         <PropertyDoc
           basepath={basepath}
           name={discriminatorProperty.name}
           required={true}
           property={discriminatorProperty}
-          bgColor="#f1f5f9"
-          nestedBgColor="white"
+          bgColor={bgColor}
+          nestedBgColor={nestedBgColor}
         >
           <select
-            class="border-slate-2 w-full text-ellipsis whitespace-nowrap border px-2 py-1"
+            class="border-slate-2 w-full text-ellipsis whitespace-nowrap rounded border px-2 py-1"
             value={typeSignal.value}
             onChange={(e) => (typeSignal.value = e.currentTarget.value)}
           >
@@ -192,14 +213,18 @@ function UnionDoc({ basepath, schema, typeDef, showNested }: UnionDocProps) {
         </PropertyDoc>
       </div>
       {otherProperties.map((property) => (
-        <div class="bg-slate-1 rounded py-1" key={property.name}>
+        <div
+          class="rounded py-1"
+          key={property.name}
+          style={{ backgroundColor: bgColor }}
+        >
           <PropertyDoc
             basepath={basepath}
             name={property.name}
             required={property.required}
             property={property}
-            bgColor="#f1f5f9"
-            nestedBgColor="#fcfdfe"
+            bgColor={bgColor}
+            nestedBgColor={nestedBgColor}
             schema={schema}
             showNested={showNested}
           />
@@ -212,14 +237,18 @@ function UnionDoc({ basepath, schema, typeDef, showNested }: UnionDocProps) {
 interface EnumDocProps {
   basepath: string;
   xPortoneEnum: TypeDef["x-portone-enum"];
+  bgColor: string;
 }
-function EnumDoc({ basepath, xPortoneEnum }: EnumDocProps) {
+function EnumDoc({ basepath, xPortoneEnum, bgColor }: EnumDocProps) {
   return (
     <div class="flex flex-col gap-2">
       {Object.entries(xPortoneEnum || {}).map(([enumValue, enumCase]) => {
         const title = enumCase["x-portone-title"] || enumCase.title || "";
         return (
-          <div class="bg-slate-1 flex flex-col gap-2 rounded p-2">
+          <div
+            class="flex flex-col gap-2 rounded p-2"
+            style={{ backgroundColor: bgColor }}
+          >
             <div class="flex items-center gap-2 leading-none">
               <code>{enumValue}</code>
               <span class="text-slate-5 text-sm">{title}</span>
@@ -227,7 +256,7 @@ function EnumDoc({ basepath, xPortoneEnum }: EnumDocProps) {
             <DescriptionDoc
               basepath={basepath}
               typeDef={enumCase}
-              bgColor="#f1f5f9"
+              bgColor={bgColor}
             />
           </div>
         );
@@ -241,14 +270,23 @@ interface ObjectDocProps {
   schema: any;
   typeDef?: TypeDef | undefined;
   showNested?: boolean | undefined;
+  bgColor: string;
+  nestedBgColor?: string | undefined;
 }
-function ObjectDoc({ basepath, schema, typeDef, showNested }: ObjectDocProps) {
+function ObjectDoc({
+  basepath,
+  schema,
+  typeDef,
+  showNested,
+  bgColor,
+  nestedBgColor,
+}: ObjectDocProps) {
   const properties = typeDef ? bakeProperties(schema, typeDef) : [];
   return (
     <PropertiesDoc
       basepath={basepath}
-      bgColor="#f1f5f9"
-      nestedBgColor="#fcfdfe"
+      bgColor={bgColor}
+      nestedBgColor={nestedBgColor}
       schema={schema}
       properties={properties}
       showNested={showNested}
@@ -467,22 +505,22 @@ function DescriptionDoc({
   const description = typeDef["x-portone-description"] ?? typeDef.description;
   const summary = typeDef["x-portone-summary"] ?? typeDef.summary;
   const __html = description || summary || "";
-  const nestedProperties = React.useMemo(() => {
-    if (!schema || !showNested || !typeDef.$ref) return [];
-    const nestedTypeDef = getTypeDefByRef(schema, typeDef.$ref);
-    return typeDef ? bakeProperties(schema, nestedTypeDef) : [];
+  const unwrappedTypeDef = React.useMemo(() => {
+    if (!schema || !showNested || !typeDef) return;
+    return resolveTypeDef(schema, typeDef, true);
   }, [typeDef, schema, showNested]);
-  return __html || nestedProperties.length ? (
+  return __html || unwrappedTypeDef ? (
     <DescriptionArea maxHeightPx={16 * 6} bgColor={bgColor}>
       {__html && (
         <div class="text-slate-5 flex flex-col gap-1 text-sm">
           <div dangerouslySetInnerHTML={{ __html }} />
         </div>
       )}
-      {nestedProperties.length ? (
-        <PropertiesDoc
+      {unwrappedTypeDef ? (
+        <TypeDefDoc
           basepath={basepath}
-          properties={nestedProperties}
+          schema={schema}
+          typeDef={unwrappedTypeDef}
           bgColor={nestedBgColor || bgColor}
           nestedBgColor={bgColor}
         />

--- a/src/layouts/rest-api/category/type-def.tsx
+++ b/src/layouts/rest-api/category/type-def.tsx
@@ -103,19 +103,40 @@ export interface TypeDefDocProps {
   basepath: string;
   schema: any;
   typeDef?: TypeDef | undefined;
+  showNested?: boolean | undefined;
 }
-export function TypeDefDoc({ basepath, schema, typeDef }: TypeDefDocProps) {
+export function TypeDefDoc({
+  basepath,
+  schema,
+  typeDef,
+  showNested,
+}: TypeDefDocProps) {
   const kind = getTypeDefKind(typeDef);
   switch (kind) {
     case "object":
       return (
-        <ObjectDoc basepath={basepath} schema={schema} typeDef={typeDef} />
+        <ObjectDoc
+          basepath={basepath}
+          schema={schema}
+          typeDef={typeDef}
+          showNested={showNested}
+        />
       );
     case "enum":
-      return <EnumDoc xPortoneEnum={typeDef!["x-portone-enum"]} />;
+      return (
+        <EnumDoc
+          basepath={basepath}
+          xPortoneEnum={typeDef!["x-portone-enum"]}
+        />
+      );
     case "union":
       return (
-        <UnionDoc basepath={basepath} schema={schema} typeDef={typeDef!} />
+        <UnionDoc
+          basepath={basepath}
+          schema={schema}
+          typeDef={typeDef!}
+          showNested={showNested}
+        />
       );
   }
 }
@@ -124,8 +145,9 @@ interface UnionDocProps {
   basepath: string;
   schema: any;
   typeDef: TypeDef;
+  showNested?: boolean | undefined;
 }
-function UnionDoc({ basepath, schema, typeDef }: UnionDocProps) {
+function UnionDoc({ basepath, schema, typeDef, showNested }: UnionDocProps) {
   const { propertyName, mapping } = typeDef.discriminator!;
   const types = Object.keys(mapping);
   const typeSignal = useSignal(types[0]!);
@@ -155,6 +177,8 @@ function UnionDoc({ basepath, schema, typeDef }: UnionDocProps) {
           name={discriminatorProperty.name}
           required={true}
           property={discriminatorProperty}
+          bgColor="#f1f5f9"
+          nestedBgColor="white"
         >
           <select
             class="border-slate-2 w-full text-ellipsis whitespace-nowrap border px-2 py-1"
@@ -174,6 +198,10 @@ function UnionDoc({ basepath, schema, typeDef }: UnionDocProps) {
             name={property.name}
             required={property.required}
             property={property}
+            bgColor="#f1f5f9"
+            nestedBgColor="#fcfdfe"
+            schema={schema}
+            showNested={showNested}
           />
         </div>
       ))}
@@ -182,9 +210,10 @@ function UnionDoc({ basepath, schema, typeDef }: UnionDocProps) {
 }
 
 interface EnumDocProps {
+  basepath: string;
   xPortoneEnum: TypeDef["x-portone-enum"];
 }
-function EnumDoc({ xPortoneEnum }: EnumDocProps) {
+function EnumDoc({ basepath, xPortoneEnum }: EnumDocProps) {
   return (
     <div class="flex flex-col gap-2">
       {Object.entries(xPortoneEnum || {}).map(([enumValue, enumCase]) => {
@@ -195,7 +224,11 @@ function EnumDoc({ xPortoneEnum }: EnumDocProps) {
               <code>{enumValue}</code>
               <span class="text-slate-5 text-sm">{title}</span>
             </div>
-            <DescriptionDoc typeDef={enumCase} />
+            <DescriptionDoc
+              basepath={basepath}
+              typeDef={enumCase}
+              bgColor="#f1f5f9"
+            />
           </div>
         );
       })}
@@ -207,26 +240,55 @@ interface ObjectDocProps {
   basepath: string;
   schema: any;
   typeDef?: TypeDef | undefined;
+  showNested?: boolean | undefined;
 }
-function ObjectDoc({ basepath, schema, typeDef }: ObjectDocProps) {
+function ObjectDoc({ basepath, schema, typeDef, showNested }: ObjectDocProps) {
   const properties = typeDef ? bakeProperties(schema, typeDef) : [];
-  return <PropertiesDoc basepath={basepath} properties={properties} />;
+  return (
+    <PropertiesDoc
+      basepath={basepath}
+      bgColor="#f1f5f9"
+      nestedBgColor="#fcfdfe"
+      schema={schema}
+      properties={properties}
+      showNested={showNested}
+    />
+  );
 }
 
 export interface PropertiesDocProps {
   basepath: string;
   properties: BakedProperty[];
+  bgColor: string;
+  nestedBgColor?: string | undefined;
+  schema?: any;
+  showNested?: boolean | undefined;
 }
-export function PropertiesDoc({ basepath, properties }: PropertiesDocProps) {
+export function PropertiesDoc({
+  basepath,
+  bgColor,
+  nestedBgColor,
+  schema,
+  properties,
+  showNested,
+}: PropertiesDocProps) {
   return (
     <div class="flex flex-col gap-2">
       {properties.map((property) => (
-        <div class="bg-slate-1 rounded py-1" key={property.name}>
+        <div
+          class="rounded py-1"
+          key={property.name}
+          style={{ backgroundColor: bgColor }}
+        >
           <PropertyDoc
             basepath={basepath}
             name={property.name}
             required={property.required}
             property={property}
+            bgColor={bgColor}
+            nestedBgColor={nestedBgColor}
+            schema={schema}
+            showNested={showNested}
           />
         </div>
       ))}
@@ -237,10 +299,14 @@ export function PropertiesDoc({ basepath, properties }: PropertiesDocProps) {
 export interface ReqPropertiesDocProps {
   basepath: string;
   properties: BakedProperty[];
+  schema?: any;
+  showNested?: boolean | undefined;
 }
 export function ReqPropertiesDoc({
   basepath,
   properties,
+  schema,
+  showNested,
 }: ReqPropertiesDocProps) {
   return (
     <div class="flex flex-col gap-1">
@@ -253,6 +319,9 @@ export function ReqPropertiesDoc({
                 required={property.required}
                 property={property}
                 bgColor="white"
+                nestedBgColor="#f4f8fa"
+                schema={schema}
+                showNested={showNested}
               />
             )),
             <hr />,
@@ -267,7 +336,10 @@ interface PropertyDocProps {
   name: string;
   required?: boolean | undefined;
   property: Property;
-  bgColor?: string | undefined;
+  bgColor: string;
+  nestedBgColor?: string | undefined;
+  schema?: any;
+  showNested?: boolean | undefined;
   children?: any;
 }
 function PropertyDoc({
@@ -276,6 +348,9 @@ function PropertyDoc({
   required,
   property,
   bgColor,
+  nestedBgColor,
+  schema,
+  showNested,
   children,
 }: PropertyDocProps) {
   const title =
@@ -307,7 +382,14 @@ function PropertyDoc({
         </div>
       </div>
       {children}
-      <DescriptionDoc typeDef={property} bgColor={bgColor} />
+      <DescriptionDoc
+        basepath={basepath}
+        typeDef={property}
+        bgColor={bgColor}
+        nestedBgColor={nestedBgColor}
+        schema={schema}
+        showNested={showNested}
+      />
     </div>
   );
 }
@@ -367,21 +449,44 @@ function TypeReprDoc({ basepath, def }: TypeReprDocProps) {
 }
 
 interface DescriptionDocProps {
+  basepath: string;
   typeDef: TypeDef | Property;
-  bgColor?: string | undefined;
+  bgColor: string;
+  nestedBgColor?: string | undefined;
+  schema?: any;
+  showNested?: boolean | undefined;
 }
 function DescriptionDoc({
+  basepath,
   typeDef,
-  bgColor = "rgb(241,245,249)",
+  bgColor,
+  nestedBgColor,
+  schema,
+  showNested,
 }: DescriptionDocProps) {
   const description = typeDef["x-portone-description"] ?? typeDef.description;
   const summary = typeDef["x-portone-summary"] ?? typeDef.summary;
   const __html = description || summary || "";
-  return __html ? (
+  const nestedProperties = React.useMemo(() => {
+    if (!schema || !showNested || !typeDef.$ref) return [];
+    const nestedTypeDef = getTypeDefByRef(schema, typeDef.$ref);
+    return typeDef ? bakeProperties(schema, nestedTypeDef) : [];
+  }, [typeDef, schema, showNested]);
+  return __html || nestedProperties.length ? (
     <DescriptionArea maxHeightPx={16 * 6} bgColor={bgColor}>
-      <div class="text-slate-5 flex flex-col gap-1 text-sm">
-        <div dangerouslySetInnerHTML={{ __html }} />
-      </div>
+      {__html && (
+        <div class="text-slate-5 flex flex-col gap-1 text-sm">
+          <div dangerouslySetInnerHTML={{ __html }} />
+        </div>
+      )}
+      {nestedProperties.length ? (
+        <PropertiesDoc
+          basepath={basepath}
+          properties={nestedProperties}
+          bgColor={nestedBgColor || bgColor}
+          nestedBgColor={bgColor}
+        />
+      ) : null}
     </DescriptionArea>
   ) : null;
 }

--- a/src/layouts/rest-api/endpoint/EndpointDoc.tsx
+++ b/src/layouts/rest-api/endpoint/EndpointDoc.tsx
@@ -112,12 +112,12 @@ function MethodBadge({ method }: MethodBadgeProps) {
     method === "get"
       ? "bg-green-2 text-green-7"
       : method === "post"
-      ? "bg-blue-2 text-blue-7"
-      : method === "put"
-      ? "bg-yellow-2 text-yellow-7"
-      : method === "delete"
-      ? "bg-red-2 text-red-7"
-      : "bg-slate-2 text-slate-7";
+        ? "bg-blue-2 text-blue-7"
+        : method === "put"
+          ? "bg-yellow-2 text-yellow-7"
+          : method === "delete"
+            ? "bg-red-2 text-red-7"
+            : "bg-slate-2 text-slate-7";
   return (
     <span
       class={`${colorClass} shrink-0 rounded-full px-2 font-bold uppercase`}
@@ -157,6 +157,8 @@ function RequestDoc({ basepath, schema, operation }: RequestDocProps) {
             basepath={basepath}
             title="Path"
             parameters={pathParameters}
+            schema={schema}
+            showNested
           />
         )}
         {showQuery && (
@@ -164,6 +166,8 @@ function RequestDoc({ basepath, schema, operation }: RequestDocProps) {
             basepath={basepath}
             title="Query"
             parameters={queryParameters}
+            schema={schema}
+            showNested
           />
         )}
         {showBody && (
@@ -171,6 +175,8 @@ function RequestDoc({ basepath, schema, operation }: RequestDocProps) {
             basepath={basepath}
             title="Body"
             parameters={bodyParameters}
+            schema={schema}
+            showNested
           />
         )}
       </div>
@@ -202,9 +208,10 @@ function ResponseDoc({ basepath, schema, operation }: ResponseDocProps) {
               basepath={basepath}
               schema={schema}
               typeDef={responseSchema && resolveTypeDef(schema, responseSchema)}
+              showNested
             />
           </ReqRes>
-        )
+        ),
       )}
     </div>
   );
@@ -215,16 +222,25 @@ interface ReqParametersProps {
   title?: string | undefined;
   description?: string | undefined;
   parameters: Parameter[];
+  schema?: any;
+  showNested?: boolean | undefined;
 }
 function ReqParameters({
   basepath,
   title,
   description,
   parameters,
+  schema,
+  showNested,
 }: ReqParametersProps) {
   return (
     <ReqRes title={title} description={description}>
-      <ReqPropertiesDoc basepath={basepath} properties={parameters} />
+      <ReqPropertiesDoc
+        basepath={basepath}
+        properties={parameters}
+        schema={schema}
+        showNested={showNested}
+      />
     </ReqRes>
   );
 }

--- a/src/layouts/rest-api/endpoint/EndpointDoc.tsx
+++ b/src/layouts/rest-api/endpoint/EndpointDoc.tsx
@@ -208,6 +208,8 @@ function ResponseDoc({ basepath, schema, operation }: ResponseDocProps) {
               basepath={basepath}
               schema={schema}
               typeDef={responseSchema && resolveTypeDef(schema, responseSchema)}
+              bgColor="#f1f5f9"
+              nestedBgColor="#fcfdfe"
               showNested
             />
           </ReqRes>


### PR DESCRIPTION
| before | after |
| --- | --- |
| ![image](https://github.com/portone-io/developers.portone.io/assets/690661/10c1b49c-10a7-40f0-a585-5230da2aafbf) | ![image](https://github.com/portone-io/developers.portone.io/assets/690661/e1e40e96-9977-45ea-a0d1-d336c517b3d9) |
