### PR TITLE
구 영문 문서 링크만 알면 들어갈 수는 있도록 함

### DIFF
--- a/src/pages/docs/[lang]/[...slug].astro
+++ b/src/pages/docs/[lang]/[...slug].astro
@@ -16,20 +16,10 @@ export async function getStaticPaths() {
     const [lang, ...fragments] = entry.slug.split("/");
     const absSlug = path.posix.join("/", entry.slug);
     const slug = fragments.join("/");
-    // 영어문서가 많이 outdated되어 당분간 내림
-    // 영어문서 링크로 들어오면 한국어 문서로 리디렉션
-    // AI 번역으로 전부 대체 예정
-    if (lang === "en") {
-      staticPaths[entry.slug] = {
-        params: { lang, slug },
-        props: { redirTarget: `/ko/${slug}` },
-      };
-    } else {
-      staticPaths[entry.slug] = {
-        params: { lang, slug },
-        props: { entry, slug: absSlug },
-      };
-    }
+    staticPaths[entry.slug] = {
+      params: { lang, slug },
+      props: { entry, slug: absSlug },
+    };
   }
   for (const redir of redirYaml) {
     const entrySlug = redir.old.slice(1);


### PR DESCRIPTION
related: https://github.com/portone-io/developers.portone.io/pull/240
context: https://www.notion.so/chaifinance/2024-01-15-2b0052986a1b4a2a8dad813688a28808

`/docs/en`으로 접속하면 됩니다.