### PR TITLE
date-time 설명을 ISO 8601에서 RFC 3339로 교체

### DIFF
--- a/src/layouts/rest-api/category/type-def.tsx
+++ b/src/layouts/rest-api/category/type-def.tsx
@@ -452,9 +452,9 @@ function TypeReprDoc({ basepath, def }: TypeReprDocProps) {
               <a
                 class="underline-offset-4 hover:underline"
                 target="_blank"
-                href="https://ko.wikipedia.org/wiki/ISO_8601"
+                href="https://datatracker.ietf.org/doc/html/rfc3339#section-5.6"
               >
-                (ISO 8601)
+                (RFC 3339 date-time)
               </a>
             );
           default:


### PR DESCRIPTION
인터넷에서 사용하는 datetime 전송 표준은 RFC 3339이고, 포트원도 ISO 8601의 스펙을 구현하기보다는 RFC 3339를 구현하는 데 가까우므로 설명을 교체합니다.