### PR TITLE
네비게이션 메뉴가 특정 조건에서 잘 안 펼쳐지는 문제 수정

### DIFF
--- a/src/state/server-only/nav.ts
+++ b/src/state/server-only/nav.ts
@@ -60,7 +60,8 @@ export function calcNavMenuAncestors(
 ): NavMenuAncestors {
   const navMenuAncestors: NavMenuAncestors = {};
   for (const { slug, ancestors } of iterNavMenuAncestors(navMenuItems)) {
-    navMenuAncestors[slug] = ancestors;
+    if (navMenuAncestors[slug]) navMenuAncestors[slug]!.push(...ancestors);
+    else navMenuAncestors[slug] = ancestors;
   }
   return navMenuAncestors;
 }


### PR DESCRIPTION
동일한 페이지가 네비게이션 메뉴에서 여러번 등장할 경우 (본래는 이런 일이 생길 수 없다고 가정하였으나 v1/v2에서 다른 트리에서 같은 페이지를 바라보는 경우가 생기면서 가정이 깨짐) 자동 메뉴 펼침 동작이 망가지는 문제를 수정하였습니다.