### PR TITLE
webhook: add timeout description and remove ip list in en webhook manual

### DIFF
--- a/src/content/docs/en/result/webhook.mdx
+++ b/src/content/docs/en/result/webhook.mdx
@@ -78,7 +78,14 @@ function requestPay() {
 </Tabs>
 
 <Hint style="info">
+**About webhooks**
+
 **You cannot set multiple webhook URLs.**
+
+Webhooks can be sent via initial or resend, each with different timeouts.
+
+1. For the initial webhook, the <mark style="color:red;">**Connection TimeOut is set to 10 seconds**</mark> and the <mark style="color:red;">**Read TimeOut waiting for the response is 30 seconds**</mark>.
+2. For the Resend Webhook, the <mark style="color:red;">**Overall TimeOut for the request is 15 seconds**</mark>.
 
 </Hint>
 

--- a/src/content/docs/en/result/webhook.mdx
+++ b/src/content/docs/en/result/webhook.mdx
@@ -91,13 +91,15 @@ Webhooks can be sent via initial or resend, each with different timeouts.
 
 ### Verify webhook request <a href="#webhook" id="webhook"></a>
 
-Since an i'mport webhook endpoint is a public URL, you must **verify that the request's client IP is an i'mport IP**. An i'mport webhook request must originate from one of the following static IPs.
+When a Webhook event is triggered, a `POST` request is generated to the configured URL endpoint as follows.
 
-> * <mark style="color:red;">**52.78.100.19**</mark>
-> * <mark style="color:red;">**52.78.48.223**</mark>
-> * <mark style="color:red;">**52.78.5.241**</mark>** (when invoked via Test Webhook button)**
+Since the webhook receiving address is a public URL and there's a risk of servers other than PortOne sending webhooks, **the merchant server receive the webhook and then must verify the webhook content by querying the payment transaction using the [Get Payment by ImpUid API](../api/payment-api/get-payment-api).**
+Even if the payment has been successfully processed, there might be cases where the webhook is not received or is delayed due to network issues.
+If a webhook is not received or is delayed, immediately cancelling the transaction could result in financial loss due to a refund of a payment that was successfully processed due to network issues.
+**Even if a webhook does not arrive, before cancelling a payment, query the status of the transaction using the [Get Payment by ImpUid API](../api/payment-api/get-payment-api) to ensure the payment status is normal and avoid cancelling.**
 
-When a webhook event is called, the following `POST` request is generated for the notification URL endpoint.
+Even if the merchant server responds correctly after receiving a webhook, if the webhook response does not reach the PortOne server due to network issues, the webhook may be resent for merchants who have set up the webhook retry feature.
+It is recommended to handle potential multiple receipts of the same webhook content without issues.
 
 <Tabs>
 <Tab title="cURL">

--- a/src/content/docs/ko/result/webhook.mdx
+++ b/src/content/docs/ko/result/webhook.mdx
@@ -88,8 +88,10 @@ function requestPay() {
 
 **웹훅(Webhook) URL 복수개 설정은 지원되지 않습니다.**
 
-**웹훅 **<mark style="color:red;">**Connection TimeOut 설정시각은 10**</mark>**초 이며 가맹접 웹훅응답을 기다리는 **<mark style="color:red;">**Read TimeOut 시각은 30초**</mark>** 입니다.**
+웹훅은 최초 또는 재발송 통해 전송이 가능하며, 각각 타임아웃이 다릅니다.
 
+1. **최초 웹훅**의 경우 <mark style="color:red;">**Connection TimeOut 설정시각은 10초**</mark>이며 가맹접 웹훅응답을 기다리는 <mark style="color:red;">**Read TimeOut 시각은 30초**</mark>입니다.
+2. **재발송 웹훅**의 경우 <mark style="color:red;">**요청에 대한 전체 타임아웃이 15초**</mark>입니다.
 </Hint>
 
 ### 웹훅(Webhook) 요청 검증하기 <a href="#webhook" id="webhook"></a>


### PR DESCRIPTION
### 작업 내용

웹훅 관련해서 기존에 pay-iamport, api-iamport, paymentadmin 통해서 발송되는 웹훅의 타임아웃에 대해서만 설명이 있었는데, 재발송 경우에 대한 타임아웃에 대한 설명을 추가했습니다.

한글 설명
![image](https://github.com/portone-io/developers.portone.io/assets/28570432/16443fe6-86c8-484a-851c-3546d46554ed)

영문 설명
![image](https://github.com/portone-io/developers.portone.io/assets/28570432/b146f24e-964f-4157-a30e-07426b64dd09)

### 관련 링크

- [타임아웃 관련 문의](https://portone-io.slack.com/archives/C067FEWAMAQ/p1708065699880509)
- [재발송의 타임아웃 설정 ](https://github.com/iamport/laravel-webhook-sender/blob/c11a8690a8c514d3190bba7e7fb8a3393cf8d975/app/Console/Commands/RetryErrorWebhook.php#L103-L111)
- [guzzle 설정](https://docs.guzzlephp.org/en/stable/request-options.html#timeout)