### PR TITLE
v2: API Secret을 직접 적어 API 인증하는 방식 사용

### DIFF
--- a/src/content/docs/ko/v2-payment/authpay.mdx
+++ b/src/content/docs/ko/v2-payment/authpay.mdx
@@ -196,27 +196,17 @@ app.post("/payment/complete", async (req, res) => {
     // 요청의 body로 paymentId가 오기를 기대합니다.
     const { paymentId, order } = req.body;
 
-    // 1. 포트원 API를 사용하기 위해 액세스 토큰을 발급받습니다.
-    const signinResponse = await fetch("https://api.portone.io/login/api-secret", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ apiSecret: PORTONE_API_SECRET }),
-    });
-    if (!signinResponse.ok) throw new Error(`signinResponse: ${signinResponse.statusText}`);
-    const { accessToken } = await signinResponse.json();
-
-    // 2. 포트원 결제내역 단건조회 API 호출
+    // 1. 포트원 결제내역 단건조회 API 호출
     const paymentResponse = await fetch(
       `https://api.portone.io/payments/${encodeURIComponent(paymentId)}`,
       {
-        // 1번에서 발급받은 액세스 토큰을 Bearer 형식에 맞게 넣어주세요.
-        headers: { "Authorization": "Bearer " + accessToken },
+        headers: { "Authorization": `PortOne ${PORTONE_API_SECRET}` },
       },
     );
     if (!paymentResponse.ok) throw new Error(`paymentResponse: ${paymentResponse.statusText}`);
     const payment = await paymentResponse.json();
 
-    // 3. 고객사 내부 주문 데이터의 가격과 실제 지불된 금액을 비교합니다.
+    // 2. 고객사 내부 주문 데이터의 가격과 실제 지불된 금액을 비교합니다.
     const orderData = await OrderService.getOrderData(order);
     if (orderData.amount === payment.amount.total) {
       switch (payment.status) {

--- a/src/content/docs/ko/v2-payment/billing-key/1.mdx
+++ b/src/content/docs/ko/v2-payment/billing-key/1.mdx
@@ -65,26 +65,12 @@ if (!response.ok) throw new Error(`response: ${response.statusText}`);
 ```javascript title="server-side"
 // customerId, cardNumber, expiryYear, expiryMonth, birthOrBusinessRegistrationNumber, passwordTwoDigits 등 정보를 전달받습니다.
 
-// 1. 포트원 API를 사용하기 위한 액세스 토큰 발급 받기
-const signinResponse = await fetch(
-  "https://api.portone.io/login/api-secret",
-  {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      apiSecret: PORTONE_API_SECRET, // 포트원 API Secret
-    }),
-  },
-);
-if (!signinResponse.ok) throw new Error(`signinResponse: ${signinResponse.statusText}`);
-const { accessToken } = await signinResponse.json();
-
-// 2. 포트원 빌링키 발급 API 호출
+// 포트원 빌링키 발급 API 호출
 const issueResponse = await fetch("https://api.portone.io/billing-keys",
   {
     method: "POST",
     headers: {
-      "Authorization": `Bearer ${accessToken}`,
+      "Authorization": `PortOne ${PORTONE_API_SECRET}`,
       "Content-Type": "application/json",
     },
     body: JSON.stringify({

--- a/src/content/docs/ko/v2-payment/billing-key/2.mdx
+++ b/src/content/docs/ko/v2-payment/billing-key/2.mdx
@@ -8,31 +8,16 @@ description: 포트원 빌링키 결제 API를 사용해 바로 결제를 요청
 바로 결제를 진행하고 싶은 것이 아니라 미래 특정 시점에 결제가 일어나게 하고 싶다면 [예약 결제 구현](3)을 참고하세요.
 
 ```javascript title="server-side"
-// 1. 포트원 API를 사용하기 위해 액세스 토큰을 발급받습니다.
-const signinResponse = await fetch(
-  "https://api.portone.io/login/api-secret",
-  {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      apiSecret: PORTONE_API_SECRET, // 포트원 API Secret
-    }),
-  },
-);
-if (!signinResponse.ok) throw new Error(`signinResponse: ${signinResponse.statusText}`);
-const { accessToken } = await signinResponse.json();
-
 // 고객사에서 채번하는 새로운 결제 ID를 만들어주세요.
 const paymentId = OrderService.getNewPaymentId();
 
-// 2. 포트원 빌링키 결제 API 호출
+// 포트원 빌링키 결제 API 호출
 const paymentResponse = await fetch(
   `https://api.portone.io/payments/${encodeURIComponent(paymentId)}/billing-key`,
   {
     method: "POST",
-    // 1번에서 발급받은 액세스 토큰을 Bearer 형식에 맞게 넣어주세요.
     headers: {
-      "Authorization": `Bearer ${accessToken}`,
+      "Authorization": `PortOne ${PORTONE_API_SECRET}`,
       "Content-Type": "application/json",
     },
     body: JSON.stringify({

--- a/src/content/docs/ko/v2-payment/billing-key/3.mdx
+++ b/src/content/docs/ko/v2-payment/billing-key/3.mdx
@@ -8,14 +8,11 @@ description: 발급한 빌링키로 예약/반복결제를 구현하는 방법�
 미래의 특정 시점에 결제가 진행되도록 할 때는 **포트원 결제 예약 API**를 이용합니다.
 
 ```javascript title="server-side"
-// 1. 포트원 API를 사용하기 위한 액세스 토큰을 발급받으세요.
-
-// 2. 포트원 결제 예약 API 호출
+// 포트원 결제 예약 API 호출
 const scheduleResponse = await fetch(`https://api.portone.io/payments/${encodeURIComponent(UNIQUE_PAYMENT_ID)}/schedule`, {
   method: "POST",
-  // 1번에서 발급받은 액세스 토큰을 Bearer 형식에 맞게 넣어주세요.
   headers: {
-    "Authorization": `Bearer ${accessToken}`,
+    "Authorization": `PortOne ${PORTONE_API_SECRET}`,
     "Content-Type": "application/json",
   },
   body: JSON.stringify({

--- a/src/content/docs/ko/v2-payment/identity-verification.mdx
+++ b/src/content/docs/ko/v2-payment/identity-verification.mdx
@@ -121,25 +121,10 @@ app.post("/identity-verifications", async (req, res) => {
   // request의 body에서 identityVerificationId 추출
   const { identityVerificationId } = req.body;
   try {
-    // 1. 포트원 API를 사용하기 위한 액세스 토큰 발급 받기
-    const signinResponse = await fetch(
-      "https://api.portone.io/login/api-secret",
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          apiSecret: PORTONE_API_SECRET, // 포트원 API Secret
-        }),
-      },
-    );
-    if (!signinResponse.ok) throw new Error(`signinResponse: ${signinResponse.statusText}`);
-    const { accessToken } = await signinResponse.json();
-
-    // 2. 포트원 본인인증 내역 단건조회 API 호출
+    // 포트원 본인인증 내역 단건조회 API 호출
     const verificationResponse = await fetch({
       url: `https://api.portone.io/identity-verifications/${encodeURIComponent(identityVerificationId)}`,
-      // 1번에서 발급받은 액세스 토큰을 Bearer 형식에 맞게 넣어주세요.
-      headers: { "Authorization": `Bearer ${accessToken}` },
+      headers: { "Authorization": `PortOne ${PORTONE_API_SECRET}` },
     });
     if (!verificationResponse.ok) throw new Error(`verificationResponse: ${verificationResponse.statusText}`);
     const identityVerification = await verificationResponse.json();

--- a/src/content/docs/ko/v2-payment/key-in.mdx
+++ b/src/content/docs/ko/v2-payment/key-in.mdx
@@ -32,26 +32,13 @@ import Tab from "~/components/gitbook/tabs/Tab.astro";
 고객사 서버에서 아래와 같이 포트원 API를 호출합니다.
 
 ```javascript title="server-side"
-// 1. 포트원 API를 사용하기 위한 액세스 토큰 발급 받기
-const signinResponse = await fetch("https://api.portone.io/login/api-secret", {
-  method: "POST",
-  headers: {
-    "Content-Type": "application/json",
-  },
-  body: JSON.stringify({
-    apiSecret: PORTONE_API_SECRET, // 포트원 API Secret
-  }),
-});
-if (!signinResponse.ok) throw new Error(`signinResponse: ${signinResponse.statusText}`);
-const { accessToken } = await signinResponse.json();
-
-// 2. 포트원 수기(키인)결제 API 호출
+// 포트원 수기(키인)결제 API 호출
 const paymentResponse = await fetch(
   `https://api.portone.io/payments/${encodeURIComponent(UNIQUE_PAYMENT_ID)}/instant`,
   {
     method: "POST",
     headers: {
-      "Authorization": `Bearer ${accessToken}`,
+      "Authorization": `PortOne ${PORTONE_API_SECRET}`,
       "Content-Type": "application/json",
     },
     body: JSON.stringify({

--- a/src/content/docs/ko/v2-payment/pg/ksnet.mdx
+++ b/src/content/docs/ko/v2-payment/pg/ksnet.mdx
@@ -70,7 +70,7 @@ KSNET 기준으로 작성한 예시 코드는 아래와 같습니다.
   const issueResponse = await axios({
     url: `https://api.portone.io/payments/${encodeURIComponent(PAYMENT_ID_HERE)}/instant`,
     method: "post",
-    headers: { "Authorization": "Bearer " + accessToken },
+    headers: { "Authorization": `PortOne ${PORTONE_API_SECRET}` },
     data: {
       channelKey,
       orderName,
@@ -108,7 +108,7 @@ KSNET 기준으로 작성한 예시 코드는 아래와 같습니다.
   const issueResponse = await axios({
     url: "https://api.portone.io/billing-keys",
     method: "post",
-    headers: { "Authorization": "Bearer " + accessToken },
+    headers: { "Authorization": `PortOne ${PORTONE_API_SECRET}` },
     data: {
       channelKey,
       customer: {
@@ -134,13 +134,11 @@ KSNET 기준으로 작성한 예시 코드는 아래와 같습니다.
 
 ```javascript
 async function schedulePayment() {
-  // 1. 포트원 API를 사용하기 위한 액세스 토큰 발급 받기를 진행해주세요.
-  // 2. 포트원 결제 예약 API 호출
+  // 포트원 결제 예약 API 호출
   const response = await axios({
     url: `https://api.portone.io/payments/${encodeURIComponent(UNIQUE_PAYMENT_ID)}/schedule`,
     method: "post",
-    // 1번에서 발급받은 액세스 토큰을 Bearer 형식에 맞게 넣어주세요.
-    headers: { Authorization: "Bearer " + accessToken },
+    headers: { Authorization: `PortOne ${PORTONE_API_SECRET}` },
     data: {
       payment: {
         billing_key: BILLING_KEY_HERE,

--- a/src/content/docs/ko/v2-payment/pg/nice-v2.mdx
+++ b/src/content/docs/ko/v2-payment/pg/nice-v2.mdx
@@ -24,7 +24,7 @@ import Tab from "~/components/gitbook/tabs/Tab.astro";
     - 휴대폰 소액결제 : `MOBILE`
     - 상품권결제: `GIFT_CERTIFICATE`
     - 간편 결제 : `EASY_PAY`
-- **API 수기(키인) 결제** 
+- **API 수기(키인) 결제**
   - `method`파라미터를 `card`로 설정해야 합니다.
 - **API 빌링키 발급**
   - `method`파라미터를 `card`로 설정해야 합니다.
@@ -111,7 +111,7 @@ import Tab from "~/components/gitbook/tabs/Tab.astro";
     const issueResponse = await axios({
       url: `https://api.portone.io/payments/${PAYMENT_ID_HERE}/instant`,
       method: "post",
-      headers: { "Authorization": "Bearer " + access_token },
+      headers: { "Authorization": `PortOne ${PORTONE_API_SECRET}` },
       data: {
         channelKey: 'channel-key-9987cb87-****-****-****-********896d', // 콘솔 결제 연동 화면에서 채널 연동 시 생성된 채널 키를 입력해주세요.
         orderName: '나이키 와플 트레이너 2 SD',
@@ -206,7 +206,7 @@ import Tab from "~/components/gitbook/tabs/Tab.astro";
     const issueResponse = await axios({
       url: "https://api.portone.io/billing-keys",
       method: "post",
-      headers: { "Authorization": "Bearer " + access_token },
+      headers: { "Authorization": `PortOne ${PORTONE_API_SECRET}` },
       data: {
         channelKey: 'channel-key-9987cb87-****-****-****-********896d', // 콘솔 결제 연동 화면에서 채널 연동 시 생성된 채널 키를 입력해주세요.
         customer: {
@@ -234,7 +234,7 @@ import Tab from "~/components/gitbook/tabs/Tab.astro";
     const response = await axios({
       url: `https://api.portone.io/payments/${PAYMENT_ID_HERE}/schedule`,
       method: "post",
-      headers: { Authorization: "Bearer " + access_token },
+      headers: { Authorization: `PortOne ${PORTONE_API_SECRET}` },
       data: {
         payment: {
           billingKey: 'billing-key-1', // 빌링키 발급 API를 통해 발급받은 빌링키
@@ -391,7 +391,7 @@ import Tab from "~/components/gitbook/tabs/Tab.astro";
 
 - 네이버페이 포인트 결제 시 현금영수증 정보를 필수 입력해야합니다.
   - 네이버페이 포인트 결제 시 현금영수증 발급이 가능하며 **현금영수증 정보(`easyPay.cashReceiptType`, `easyPay.customerIdentifier`)를 필수로 입력**해야 합니다. 만약 입력하지 않을 경우 "나이스페이 V2 네이버페이 포인트 결제시 현금영수증 발급 유형은 필수 입력입니다."라는 에러 메시지가 리턴되며, 결제창이 호출되지 않으니 유의하시기 바랍니다. 단, **네이버페이 머니로 결제할 경우에만 현금영수증이 발급**됩니다. 결제 금액 모두 네이버페이 포인트로 결제하는 경우에는 결제창 호출 시 현금영수증 정보를 전달하더라도 발급되지 않습니다.
-  
+
 #### 페이코 일반결제 유의사항
 
 | 기능                                  | 사용 가능 여부 |

--- a/src/content/docs/ko/v2-payment/pg/tosspayments.mdx
+++ b/src/content/docs/ko/v2-payment/pg/tosspayments.mdx
@@ -86,7 +86,7 @@ import Details from "~/components/gitbook/Details.astro";
     const issueResponse = await axios({
       url: `https://api.portone.io/billing-keys`,
       method: "post",
-      headers: { "Authorization": "Bearer " + accessToken },
+      headers: { "Authorization": `PortOne ${PORTONE_API_SECRET}` },
       data: {
         channelKey,
         customer: {
@@ -111,13 +111,11 @@ import Details from "~/components/gitbook/Details.astro";
 <Tab title="API 예약/반복 결제">
  ```javascript
   async function schedulePayment() {
-    // 1. 포트원 API를 사용하기 위한 액세스 토큰 발급 받기를 진행해주세요.
-    // 2. 포트원 결제 예약 API 호출
+    // 포트원 결제 예약 API 호출
     const response = await axios({
       url: `https://api.portone.io/payments/${encodeURIComponent(PAYMENT_ID_HERE)}/schedules`,
       method: "post",
-      // 1번에서 발급받은 액세스 토큰을 Bearer 형식에 맞게 넣어주세요.
-      headers: { Authorization: "Bearer " + accessToken },
+      headers: { Authorization: `PortOne ${PORTONE_API_SECRET}` },
       data: {
         payment: {
           billingKey: BILLING_KEY_HERE,

--- a/src/content/docs/ko/v2-payment/webhook.mdx
+++ b/src/content/docs/ko/v2-payment/webhook.mdx
@@ -68,26 +68,14 @@ app.post("/portone-webhook", async (req, res) => {
   try {
     const { payment_id: paymentId } = req.body;
 
-    // 1. 포트원 API를 사용하기 위한 액세스 토큰 발급 받기
-    const signinResponse = await fetch("https://api.portone.io/login/api-secret", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      data: {
-        apiSecret: PORTONE_API_SECRET, // 포트원 API Secret
-      },
-    });
-    if (!signinResponse.ok) throw new Error(`signinResponse: ${signinResponse.statusText}`);
-    const { accessToken } = await signinResponse.json();
-
-    // 2. 포트원 결제내역 단건조회 API 호출
+    // 1. 포트원 결제내역 단건조회 API 호출
     const paymentResponse = await fetch(`https://api.portone.io/payments/${encodeURIComponent(paymentId)}`, {
-      // 1번에서 발급받은 액세스 토큰을 Bearer 형식에 맞게 넣어주세요.
-      headers: { "Authorization": "Bearer " + accessToken },
+      headers: { "Authorization": `PortOne ${PORTONE_API_SECRET}` },
     });
     if (!paymentResponse.ok) throw new Error(`signinResponse: ${paymentResponse.statusText}`);
     const { id, status, amount, method } = await paymentResponse.json();
 
-    // 3. 고객사 내부 주문 데이터의 가격과 실제 지불된 금액을 비교합니다.
+    // 2. 고객사 내부 주문 데이터의 가격과 실제 지불된 금액을 비교합니다.
     const order = await OrderService.findById(id);
     if (order.amount === amount.total) {
       switch (status) {

--- a/src/pages/api/rest-v2/_Page.tsx
+++ b/src/pages/api/rest-v2/_Page.tsx
@@ -22,7 +22,7 @@ export default function RestV2(props: RestV2Props) {
       schema={schema}
     >
       <prose.p>
-        API 결제, 결제 정보 조회, 결제 취소 등의 기능을 제공하는 REST API입니다. V2 API Secret을 발급받은 뒤 사용하실 수 있습니다.
+        API 결제, 결제 정보 조회, 결제 취소 등의 기능을 제공하는 REST API입니다.
       </prose.p>
       <prose.p>
         <strong>V2 API hostname: </strong>
@@ -36,12 +36,43 @@ export default function RestV2(props: RestV2Props) {
           <PostmanGuide href="https://learning.postman.com/docs/integrations/available-integrations/working-with-openAPI/" />
         </SchemaDownloadButton>
       </prose.p>
-      <prose.h3>
-        연동 안내
-      </prose.h3>
+      <prose.h3>요청 및 응답 형식</prose.h3>
       <prose.p>
-        요청과 응답의 본문은 JSON 형식입니다.<br/>API 응답에 포함된 필드는 별도 안내 없이 추가될 수 있으니, 알지 못하는 필드가 있는 경우에는 무시하도록 개발해 주세요.
+        요청과 응답의 본문은 JSON 형식입니다.
+        <br />
+        API 응답에 포함된 필드는 별도 안내 없이 추가될 수 있으니, 알지 못하는
+        필드가 있는 경우에는 무시하도록 개발해 주세요.
       </prose.p>
+      <prose.p>
+        API 매개 변수 중 URL 경로에 들어가는 문자열 값이 있는 경우, URL 경로에
+        들어갈 수 없는 문자열은 이스케이프하여야 합니다. 자바스크립트의{" "}
+        <code>encodeURIComponent</code> 함수 등을 사용할 수 있습니다.
+        {/* TODO: 안전한 paymentId 사용에 대해 설명 */}
+      </prose.p>
+      <prose.h3>인증 방식</prose.h3>
+      <prose.p>
+        V2 API를 사용하기 위해서는 V2 API Secret이 필요합니다. 관리자 이메일을
+        통해 tech.support@portone.io로 Store ID를 보내 주시면 V2 API Secret을
+        발급해 드립니다.
+      </prose.p>
+      <prose.p>
+        인증 관련 API를 제외한 모든 API는 HTTP <code>Authorization</code> 헤더로
+        인증 정보를 전달해 주셔야 합니다. Authorization 헤더에 전달하는 형식은
+        두 가지 중 하나입니다.
+      </prose.p>
+      <ul>
+        <li>
+          API Secret 직접 사용 (간편)
+          <br />
+          Authorization: PortOne <i>MY_API_SECRET</i>
+        </li>
+        <li>
+          액세스 토큰 사용
+          <br />
+          Authorization: Bearer <i>MY_ACCESS_TOKEN</i>
+        </li>
+      </ul>
+      액세스 토큰을 사용한 인증을 원하는 경우, 인증 관련 API를 이용해 주세요.
     </RestApi>
   );
 }


### PR DESCRIPTION
`Authorization: PortOne <API Secret>` 형식의 인증을 사용할 수 있게 됨에 따라, 두 가지 인증 방식을 설명하고, 간편한 새 인증 방식으로 예제 코드를 교체합니다.

V2 Rest API 명세 페이지 상단에 설명이 좀 추가되었고, V2 예제 코드들이 수정되었습니다.