### PR TITLE
브라우저 내에서 SystemVersion이 v1 혹은 v2이도록 강제

### DIFF
--- a/src/state/nav.ts
+++ b/src/state/nav.ts
@@ -23,12 +23,18 @@ if (isClient) {
 
 export const slugSignal = signal<string>("");
 
+const parseSystemVersion = (value: unknown) => {
+  return ["v1", "v2"].includes(value as string)
+    ? (value as SystemVersion)
+    : "v1"; // default
+};
+
 export const systemVersionSignal = signal(getInitialSystemVersion());
 function getInitialSystemVersion() {
   if (isServer) return "all";
   const storageItem = globalThis.sessionStorage.getItem("systemVersion");
   const searchParams = new URLSearchParams(location.search);
-  return (searchParams.get("v") || storageItem || "v1") as SystemVersion;
+  return parseSystemVersion(searchParams.get("v") || storageItem);
 }
 if (isClient) {
   effect(() => {


### PR DESCRIPTION
기존에는 URL의 쿼리 파라미터 혹은 LocalStorage에 임의의 값을 설정 시 해당 값을 사용할 수 있었음