### PR TITLE
Fix typo in GTM tracker

### DIFF
--- a/src/layouts/trackers/GoogleTagManager.astro
+++ b/src/layouts/trackers/GoogleTagManager.astro
@@ -2,7 +2,6 @@
   is:inline
   async
   src="https://www.googletagmanager.com/gtag/js?id=GTM-PSHZN9XB"></script>
-)
 <script is:inline type="text/javascript">
   window.dataLayer = window.dataLayer || [];
   function gtag(...args) {


### PR DESCRIPTION
This typo renders `)` character in body tag on production deployment.