### PR TITLE
:bug: fix: 잘못된 OpenAPI 스펙 수정 (HTML태그의 잘못된 사용)

### DIFF
--- a/src/schema/v2.openapi.json
+++ b/src/schema/v2.openapi.json
@@ -7,15 +7,15 @@
   "servers": [
     {
       "url": "https://api.portone.io",
-      "description": "<p>운영환경 서버</p>\n"
+      "description": "운영환경 서버\n"
     }
   ],
   "paths": {
     "/login/api-key": {},
     "/login/api-secret": {
       "post": {
-        "summary": "<p>API secret 를 사용한 토큰 발급</p>\n",
-        "description": "<p>API secret 를 사용한 토큰 발급</p>\n<p>API secret 를 통해 API 인증에 사용할 토큰을 가져옵니다.</p>\n",
+        "summary": "API secret 를 사용한 토큰 발급\n",
+        "description": "API secret 를 사용한 토큰 발급\nAPI secret 를 통해 API 인증에 사용할 토큰을 가져옵니다.\n",
         "operationId": "loginViaApiSecret",
         "requestBody": {
           "content": {
@@ -29,7 +29,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 토큰을 반환합니다.</p>\n",
+            "description": "성공 응답으로 토큰을 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -37,7 +37,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 토큰을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 토큰을 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -62,7 +62,7 @@
         },
         "x-portone-category": "auth",
         "x-portone-title": "API secret 를 사용한 토큰 발급",
-        "x-portone-description": "<p>API secret 를 통해 API 인증에 사용할 토큰을 가져옵니다.</p>\n",
+        "x-portone-description": "API secret 를 통해 API 인증에 사용할 토큰을 가져옵니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/LoginViaApiSecretError"
         }
@@ -70,8 +70,8 @@
     },
     "/token/refresh": {
       "post": {
-        "summary": "<p>토큰 갱신</p>\n",
-        "description": "<p>토큰 갱신</p>\n<p>리프레시 토큰을 사용해 유효기간이 연장된 새로운 토큰을 재발급합니다.</p>\n",
+        "summary": "토큰 갱신\n",
+        "description": "토큰 갱신\n리프레시 토큰을 사용해 유효기간이 연장된 새로운 토큰을 재발급합니다.\n",
         "operationId": "refreshToken",
         "requestBody": {
           "content": {
@@ -117,7 +117,7 @@
         },
         "x-portone-category": "auth",
         "x-portone-title": "토큰 갱신",
-        "x-portone-description": "<p>리프레시 토큰을 사용해 유효기간이 연장된 새로운 토큰을 재발급합니다.</p>\n",
+        "x-portone-description": "리프레시 토큰을 사용해 유효기간이 연장된 새로운 토큰을 재발급합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/RefreshTokenError"
         }
@@ -126,11 +126,11 @@
     "/merchant": {},
     "/platform": {
       "get": {
-        "description": "<p>가맹점의 플랫폼 정보를 조회합니다.\n요청된 Authorization header 를 통해 자동으로 요청자의 가맹점을 특정합니다.</p>\n",
+        "description": "가맹점의 플랫폼 정보를 조회합니다.\n요청된 Authorization header 를 통해 자동으로 요청자의 가맹점을 특정합니다.\n",
         "operationId": "getPlatform",
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 플랫폼 객체를 반환합니다.</p>\n",
+            "description": "성공 응답으로 플랫폼 객체를 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -138,7 +138,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 플랫폼 객체를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 플랫폼 객체를 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -179,13 +179,13 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>가맹점의 플랫폼 정보를 조회합니다.\n요청된 Authorization header 를 통해 자동으로 요청자의 가맹점을 특정합니다.</p>\n",
+        "x-portone-description": "가맹점의 플랫폼 정보를 조회합니다.\n요청된 Authorization header 를 통해 자동으로 요청자의 가맹점을 특정합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPlatformError"
         }
       },
       "patch": {
-        "description": "<p>가맹점의 플랫폼 관련 정보를 업데이트합니다.\n요청된 Authorization header 를 통해 자동으로 요청자의 가맹점을 특정합니다.</p>\n",
+        "description": "가맹점의 플랫폼 관련 정보를 업데이트합니다.\n요청된 Authorization header 를 통해 자동으로 요청자의 가맹점을 특정합니다.\n",
         "operationId": "updatePlatform",
         "requestBody": {
           "content": {
@@ -199,7 +199,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -248,7 +248,7 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>가맹점의 플랫폼 관련 정보를 업데이트합니다.\n요청된 Authorization header 를 통해 자동으로 요청자의 가맹점을 특정합니다.</p>\n",
+        "x-portone-description": "가맹점의 플랫폼 관련 정보를 업데이트합니다.\n요청된 Authorization header 를 통해 자동으로 요청자의 가맹점을 특정합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/UpdatePlatformError"
         }
@@ -256,24 +256,24 @@
     },
     "/platform/discount-share-policy-filter-options": {
       "get": {
-        "description": "<p>할인 분담 정책 다건 조회 시 필요한 필터 옵션을 조회합니다.</p>\n",
+        "description": "할인 분담 정책 다건 조회 시 필요한 필터 옵션을 조회합니다.\n",
         "operationId": "getPlatformDiscountSharePolicyFilterOptions",
         "parameters": [
           {
             "name": "isArchived",
             "in": "query",
-            "description": "<p>보관 조회 여부</p>\n<p>true 이면 보관된 할인 분담의 필터 옵션을 조회하고, false 이면 보관되지 않은 할인 분담의 필터 옵션을 조회합니다. 아무 값도 넘기지 않을 경우 기본값은 false 입니다.</p>\n",
+            "description": "보관 조회 여부\ntrue 이면 보관된 할인 분담의 필터 옵션을 조회하고, false 이면 보관되지 않은 할인 분담의 필터 옵션을 조회합니다. 아무 값도 넘기지 않을 경우 기본값은 false 입니다.\n",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "보관 조회 여부",
-            "x-portone-description": "<p>true 이면 보관된 할인 분담의 필터 옵션을 조회하고, false 이면 보관되지 않은 할인 분담의 필터 옵션을 조회합니다. 아무 값도 넘기지 않을 경우 기본값은 false 입니다.</p>\n"
+            "x-portone-description": "true 이면 보관된 할인 분담의 필터 옵션을 조회하고, false 이면 보관되지 않은 할인 분담의 필터 옵션을 조회합니다. 아무 값도 넘기지 않을 경우 기본값은 false 입니다.\n"
           }
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 조회된 할인 분담 정책 필터 옵션을 반환합니다.</p>\n",
+            "description": "성공 응답으로 조회된 할인 분담 정책 필터 옵션을 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -281,7 +281,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 조회된 할인 분담 정책 필터 옵션을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 조회된 할인 분담 정책 필터 옵션을 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -322,7 +322,7 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>할인 분담 정책 다건 조회 시 필요한 필터 옵션을 조회합니다.</p>\n",
+        "x-portone-description": "할인 분담 정책 다건 조회 시 필요한 필터 옵션을 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPlatformDiscountSharePolicyFilterOptionsError"
         },
@@ -331,7 +331,7 @@
     },
     "/platform/discount-share-policies": {
       "get": {
-        "description": "<p>여러 할인 분담을 조회합니다.</p>\n",
+        "description": "여러 할인 분담을 조회합니다.\n",
         "operationId": "getPlatformDiscountSharePolicies",
         "requestBody": {
           "content": {
@@ -345,7 +345,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 조회된 파트너 리스트와 페이지 정보가 반환됩니다.</p>\n",
+            "description": "성공 응답으로 조회된 파트너 리스트와 페이지 정보가 반환됩니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -353,7 +353,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 조회된 파트너 리스트와 페이지 정보가 반환됩니다.</p>\n"
+            "x-portone-description": "성공 응답으로 조회된 파트너 리스트와 페이지 정보가 반환됩니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -394,14 +394,14 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>여러 할인 분담을 조회합니다.</p>\n",
+        "x-portone-description": "여러 할인 분담을 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPlatformDiscountSharePoliciesError"
         },
         "x-portone-unstable": true
       },
       "post": {
-        "description": "<p>새로운 할인 분담을 생성합니다.</p>\n",
+        "description": "새로운 할인 분담을 생성합니다.\n",
         "operationId": "createPlatformDiscountSharePolicy",
         "requestBody": {
           "content": {
@@ -415,7 +415,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 생성된 할인 분담 정책이 반환됩니다.</p>\n",
+            "description": "성공 응답으로 생성된 할인 분담 정책이 반환됩니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -423,7 +423,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 생성된 할인 분담 정책이 반환됩니다.</p>\n"
+            "x-portone-description": "성공 응답으로 생성된 할인 분담 정책이 반환됩니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -474,7 +474,7 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>새로운 할인 분담을 생성합니다.</p>\n",
+        "x-portone-description": "새로운 할인 분담을 생성합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/CreatePlatformDiscountSharePolicyError"
         }
@@ -482,13 +482,13 @@
     },
     "/platform/discount-share-policies/{id}": {
       "get": {
-        "description": "<p>주어진 아이디에 대응되는 할인 분담을 조회합니다.</p>\n",
+        "description": "주어진 아이디에 대응되는 할인 분담을 조회합니다.\n",
         "operationId": "getPlatformDiscountSharePolicy",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>조회할 할인 분담 정책 아이디</p>\n",
+            "description": "조회할 할인 분담 정책 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -498,7 +498,7 @@
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 할인 분담 정책을 반환합니다.</p>\n",
+            "description": "성공 응답으로 할인 분담 정책을 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -506,7 +506,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 할인 분담 정책을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 할인 분담 정책을 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -557,19 +557,19 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>주어진 아이디에 대응되는 할인 분담을 조회합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 할인 분담을 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPlatformDiscountSharePolicyError"
         }
       },
       "patch": {
-        "description": "<p>주어진 아이디에 대응되는 할인 분담을 업데이트합니다.</p>\n",
+        "description": "주어진 아이디에 대응되는 할인 분담을 업데이트합니다.\n",
         "operationId": "updatePlatformDiscountSharePolicy",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>업데이트할 할인 분담 정책 아이디</p>\n",
+            "description": "업데이트할 할인 분담 정책 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -589,7 +589,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 업데이트된 할인 분담 정책을 반환합니다.</p>\n",
+            "description": "성공 응답으로 업데이트된 할인 분담 정책을 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -597,7 +597,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 업데이트된 할인 분담 정책을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 업데이트된 할인 분담 정책을 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -658,7 +658,7 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>주어진 아이디에 대응되는 할인 분담을 업데이트합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 할인 분담을 업데이트합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/UpdatePlatformDiscountSharePolicyError"
         }
@@ -666,13 +666,13 @@
     },
     "/platform/discount-share-policies/{id}/schedule": {
       "get": {
-        "description": "<p>주어진 아이디에 대응되는 할인 분담의 예약 업데이트를 조회합니다.</p>\n",
+        "description": "주어진 아이디에 대응되는 할인 분담의 예약 업데이트를 조회합니다.\n",
         "operationId": "getPlatformDiscountSharePolicySchedule",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>할인 분담 정책 아이디</p>\n",
+            "description": "할인 분담 정책 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -682,7 +682,7 @@
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 예약된 할인 분담 정책을 반환합니다.</p>\n",
+            "description": "성공 응답으로 예약된 할인 분담 정책을 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -690,7 +690,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 예약된 할인 분담 정책을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 예약된 할인 분담 정책을 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -741,20 +741,20 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>주어진 아이디에 대응되는 할인 분담의 예약 업데이트를 조회합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 할인 분담의 예약 업데이트를 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPlatformDiscountSharePolicyScheduleError"
         },
         "x-portone-unstable": true
       },
       "put": {
-        "description": "<p>주어진 아이디에 대응되는 할인 분담에 예약 업데이트를 재설정합니다.</p>\n",
+        "description": "주어진 아이디에 대응되는 할인 분담에 예약 업데이트를 재설정합니다.\n",
         "operationId": "rescheduleDiscountSharePolicy",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>할인 분담 정책 아이디</p>\n",
+            "description": "할인 분담 정책 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -774,7 +774,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 예약된 할인 분담 정책을 반환합니다.</p>\n",
+            "description": "성공 응답으로 예약된 할인 분담 정책을 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -782,7 +782,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 예약된 할인 분담 정책을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 예약된 할인 분담 정책을 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -833,20 +833,20 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>주어진 아이디에 대응되는 할인 분담에 예약 업데이트를 재설정합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 할인 분담에 예약 업데이트를 재설정합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/RescheduleDiscountSharePolicyError"
         },
         "x-portone-unstable": true
       },
       "post": {
-        "description": "<p>주어진 아이디에 대응되는 할인 분담에 업데이트를 예약합니다.</p>\n",
+        "description": "주어진 아이디에 대응되는 할인 분담에 업데이트를 예약합니다.\n",
         "operationId": "scheduleDiscountSharePolicy",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>할인 분담 정책 아이디</p>\n",
+            "description": "할인 분담 정책 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -866,7 +866,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 예약된 할인 분담 정책이 반환됩니다.</p>\n",
+            "description": "성공 응답으로 예약된 할인 분담 정책이 반환됩니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -874,7 +874,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 예약된 할인 분담 정책이 반환됩니다.</p>\n"
+            "x-portone-description": "성공 응답으로 예약된 할인 분담 정책이 반환됩니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -935,20 +935,20 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>주어진 아이디에 대응되는 할인 분담에 업데이트를 예약합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 할인 분담에 업데이트를 예약합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/ScheduleDiscountSharePolicyError"
         },
         "x-portone-unstable": true
       },
       "delete": {
-        "description": "<p>주어진 아이디에 대응되는 할인 분담의 예약 업데이트를 취소합니다.</p>\n",
+        "description": "주어진 아이디에 대응되는 할인 분담의 예약 업데이트를 취소합니다.\n",
         "operationId": "cancelPlatformDiscountSharePolicySchedule",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>할인 분담 정책 아이디</p>\n",
+            "description": "할인 분담 정책 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -958,7 +958,7 @@
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -1017,7 +1017,7 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>주어진 아이디에 대응되는 할인 분담의 예약 업데이트를 취소합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 할인 분담의 예약 업데이트를 취소합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/CancelPlatformDiscountSharePolicyScheduleError"
         },
@@ -1028,7 +1028,7 @@
     "/platform/discount-share-policies/{id}/recover": {},
     "/platform/additional-fee-policies": {
       "get": {
-        "description": "<p>여러 추가 수수료 정책을 조회합니다.</p>\n",
+        "description": "여러 추가 수수료 정책을 조회합니다.\n",
         "operationId": "getPlatformAdditionalFeePolicies",
         "requestBody": {
           "content": {
@@ -1042,7 +1042,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 조회된 추가 수수료 정책 리스트와 페이지 정보를 반환합니다.</p>\n",
+            "description": "성공 응답으로 조회된 추가 수수료 정책 리스트와 페이지 정보를 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -1050,7 +1050,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 조회된 추가 수수료 정책 리스트와 페이지 정보를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 조회된 추가 수수료 정책 리스트와 페이지 정보를 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -1091,14 +1091,14 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>여러 추가 수수료 정책을 조회합니다.</p>\n",
+        "x-portone-description": "여러 추가 수수료 정책을 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPlatformAdditionalFeePoliciesError"
         },
         "x-portone-unstable": true
       },
       "post": {
-        "description": "<p>새로운 추가 수수료 정책을 생성합니다.</p>\n",
+        "description": "새로운 추가 수수료 정책을 생성합니다.\n",
         "operationId": "createPlatformAdditionalFeePolicy",
         "requestBody": {
           "content": {
@@ -1112,7 +1112,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -1171,7 +1171,7 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>새로운 추가 수수료 정책을 생성합니다.</p>\n",
+        "x-portone-description": "새로운 추가 수수료 정책을 생성합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/CreatePlatformAdditionalFeePolicyError"
         }
@@ -1179,13 +1179,13 @@
     },
     "/platform/additional-fee-policies/{id}": {
       "get": {
-        "description": "<p>주어진 아이디에 대응되는 추가 수수료 정책을 조회합니다.</p>\n",
+        "description": "주어진 아이디에 대응되는 추가 수수료 정책을 조회합니다.\n",
         "operationId": "getPlatformAdditionalFeePolicy",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>조회할 추가 수수료 정책 아이디</p>\n",
+            "description": "조회할 추가 수수료 정책 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -1195,7 +1195,7 @@
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 추가 수수료 정책을 반환합니다.</p>\n",
+            "description": "성공 응답으로 추가 수수료 정책을 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -1203,7 +1203,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 추가 수수료 정책을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 추가 수수료 정책을 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -1254,19 +1254,19 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>주어진 아이디에 대응되는 추가 수수료 정책을 조회합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 추가 수수료 정책을 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPlatformAdditionalFeePolicyError"
         }
       },
       "patch": {
-        "description": "<p>주어진 아이디에 대응되는 추가 수수료 정책을 업데이트합니다.</p>\n",
+        "description": "주어진 아이디에 대응되는 추가 수수료 정책을 업데이트합니다.\n",
         "operationId": "updatePlatformAdditionalFeePolicy",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>업데이트할 추가 수수료 정책 아이디</p>\n",
+            "description": "업데이트할 추가 수수료 정책 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -1286,7 +1286,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 업데이트된 추가 수수료 정책이 반환됩니다.</p>\n",
+            "description": "성공 응답으로 업데이트된 추가 수수료 정책이 반환됩니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -1294,7 +1294,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 업데이트된 추가 수수료 정책이 반환됩니다.</p>\n"
+            "x-portone-description": "성공 응답으로 업데이트된 추가 수수료 정책이 반환됩니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -1355,7 +1355,7 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>주어진 아이디에 대응되는 추가 수수료 정책을 업데이트합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 추가 수수료 정책을 업데이트합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/UpdatePlatformAdditionalFeePolicyError"
         }
@@ -1363,13 +1363,13 @@
     },
     "/platform/additional-fee-policies/{id}/schedule": {
       "get": {
-        "description": "<p>주어진 아이디에 대응되는 추가 수수료 정책의 예약 업데이트를 조회합니다.</p>\n",
+        "description": "주어진 아이디에 대응되는 추가 수수료 정책의 예약 업데이트를 조회합니다.\n",
         "operationId": "getPlatformAdditionalFeePolicySchedule",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>추가 수수료 정책 아이디</p>\n",
+            "description": "추가 수수료 정책 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -1379,7 +1379,7 @@
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 예약된 추가 수수료 정책을 반환합니다.</p>\n",
+            "description": "성공 응답으로 예약된 추가 수수료 정책을 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -1387,7 +1387,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 예약된 추가 수수료 정책을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 예약된 추가 수수료 정책을 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -1438,7 +1438,7 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>주어진 아이디에 대응되는 추가 수수료 정책의 예약 업데이트를 조회합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 추가 수수료 정책의 예약 업데이트를 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPlatformAdditionalFeePolicyScheduleError"
         },
@@ -1450,7 +1450,7 @@
           {
             "name": "id",
             "in": "path",
-            "description": "<p>추가 수수료 정책 아이디</p>\n",
+            "description": "추가 수수료 정책 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -1470,7 +1470,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 예약된 추가 수수료 정책이 반환됩니다.</p>\n",
+            "description": "성공 응답으로 예약된 추가 수수료 정책이 반환됩니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -1478,7 +1478,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 예약된 추가 수수료 정책이 반환됩니다.</p>\n"
+            "x-portone-description": "성공 응답으로 예약된 추가 수수료 정책이 반환됩니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -1535,13 +1535,13 @@
         "x-portone-unstable": true
       },
       "post": {
-        "description": "<p>주어진 아이디에 대응되는 추가 수수료 정책에 업데이트를 예약합니다.</p>\n",
+        "description": "주어진 아이디에 대응되는 추가 수수료 정책에 업데이트를 예약합니다.\n",
         "operationId": "scheduleAdditionalFeePolicy",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>추가 수수료 정책 아이디</p>\n",
+            "description": "추가 수수료 정책 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -1561,7 +1561,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 예약된 추가 수수료 정책을 반환합니다.</p>\n",
+            "description": "성공 응답으로 예약된 추가 수수료 정책을 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -1569,7 +1569,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 예약된 추가 수수료 정책을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 예약된 추가 수수료 정책을 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -1630,20 +1630,20 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>주어진 아이디에 대응되는 추가 수수료 정책에 업데이트를 예약합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 추가 수수료 정책에 업데이트를 예약합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/ScheduleAdditionalFeePolicyError"
         },
         "x-portone-unstable": true
       },
       "delete": {
-        "description": "<p>주어진 아이디에 대응되는 추가 수수료 정책의 예약 업데이트를 취소합니다.</p>\n",
+        "description": "주어진 아이디에 대응되는 추가 수수료 정책의 예약 업데이트를 취소합니다.\n",
         "operationId": "cancelPlatformAdditionalFeePolicySchedule",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>추가 수수료 정책 아이디</p>\n",
+            "description": "추가 수수료 정책 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -1653,7 +1653,7 @@
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -1712,7 +1712,7 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>주어진 아이디에 대응되는 추가 수수료 정책의 예약 업데이트를 취소합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 추가 수수료 정책의 예약 업데이트를 취소합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/CancelPlatformAdditionalFeePolicyScheduleError"
         },
@@ -1723,24 +1723,24 @@
     "/platform/additional-fee-policies/{id}/recover": {},
     "/platform/partner-filter-options": {
       "get": {
-        "description": "<p>파트너 다건 조회 시 필요한 필터 옵션을 조회합니다.</p>\n",
+        "description": "파트너 다건 조회 시 필요한 필터 옵션을 조회합니다.\n",
         "operationId": "getPlatformPartnerFilterOptions",
         "parameters": [
           {
             "name": "isArchived",
             "in": "query",
-            "description": "<p>보관 조회 여부</p>\n<p>true 이면 보관된 파트너의 필터 옵션을 조회하고, false 이면 보관되지 않은 파트너의 필터 옵션을 조회합니다. 아무 값도 넘기지 않을 경우 기본값은 false 입니다.</p>\n",
+            "description": "보관 조회 여부\ntrue 이면 보관된 파트너의 필터 옵션을 조회하고, false 이면 보관되지 않은 파트너의 필터 옵션을 조회합니다. 아무 값도 넘기지 않을 경우 기본값은 false 입니다.\n",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "보관 조회 여부",
-            "x-portone-description": "<p>true 이면 보관된 파트너의 필터 옵션을 조회하고, false 이면 보관되지 않은 파트너의 필터 옵션을 조회합니다. 아무 값도 넘기지 않을 경우 기본값은 false 입니다.</p>\n"
+            "x-portone-description": "true 이면 보관된 파트너의 필터 옵션을 조회하고, false 이면 보관되지 않은 파트너의 필터 옵션을 조회합니다. 아무 값도 넘기지 않을 경우 기본값은 false 입니다.\n"
           }
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 조회된 파트너 필터 옵션을 반환합니다.</p>\n",
+            "description": "성공 응답으로 조회된 파트너 필터 옵션을 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -1748,7 +1748,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 조회된 파트너 필터 옵션을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 조회된 파트너 필터 옵션을 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -1789,7 +1789,7 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>파트너 다건 조회 시 필요한 필터 옵션을 조회합니다.</p>\n",
+        "x-portone-description": "파트너 다건 조회 시 필요한 필터 옵션을 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPlatformPartnerFilterOptionsError"
         },
@@ -1798,7 +1798,7 @@
     },
     "/platform/partners": {
       "get": {
-        "description": "<p>여러 파트너를 조회합니다.</p>\n",
+        "description": "여러 파트너를 조회합니다.\n",
         "operationId": "getPlatformPartners",
         "requestBody": {
           "content": {
@@ -1812,7 +1812,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 조회된 파트너 리스트와 페이지 정보가 반환됩니다.</p>\n",
+            "description": "성공 응답으로 조회된 파트너 리스트와 페이지 정보가 반환됩니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -1820,7 +1820,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 조회된 파트너 리스트와 페이지 정보가 반환됩니다.</p>\n"
+            "x-portone-description": "성공 응답으로 조회된 파트너 리스트와 페이지 정보가 반환됩니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -1861,14 +1861,14 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>여러 파트너를 조회합니다.</p>\n",
+        "x-portone-description": "여러 파트너를 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPlatformPartnersError"
         },
         "x-portone-unstable": true
       },
       "post": {
-        "description": "<p>새로운 파트너를 생성합니다.</p>\n",
+        "description": "새로운 파트너를 생성합니다.\n",
         "operationId": "createPlatformPartner",
         "requestBody": {
           "content": {
@@ -1882,7 +1882,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 생성된 파트너 객체가 반환됩니다.</p>\n",
+            "description": "성공 응답으로 생성된 파트너 객체가 반환됩니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -1890,7 +1890,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 생성된 파트너 객체가 반환됩니다.</p>\n"
+            "x-portone-description": "성공 응답으로 생성된 파트너 객체가 반환됩니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -1951,7 +1951,7 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>새로운 파트너를 생성합니다.</p>\n",
+        "x-portone-description": "새로운 파트너를 생성합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/CreatePlatformPartnerError"
         }
@@ -1960,13 +1960,13 @@
     "/platform/partner-dashboard": {},
     "/platform/partners/{id}": {
       "get": {
-        "description": "<p>파트너 객체를 조회합니다.</p>\n",
+        "description": "파트너 객체를 조회합니다.\n",
         "operationId": "getPlatformPartner",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>조회하고 싶은 파트너 아이디</p>\n",
+            "description": "조회하고 싶은 파트너 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -1976,7 +1976,7 @@
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 파트너 객체가 반환됩니다.</p>\n",
+            "description": "성공 응답으로 파트너 객체가 반환됩니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -1984,7 +1984,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 파트너 객체가 반환됩니다.</p>\n"
+            "x-portone-description": "성공 응답으로 파트너 객체가 반환됩니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -2035,19 +2035,19 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>파트너 객체를 조회합니다.</p>\n",
+        "x-portone-description": "파트너 객체를 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPlatformPartnerError"
         }
       },
       "patch": {
-        "description": "<p>주어진 아이디에 대응되는 파트너 정보를 업데이트합니다.</p>\n",
+        "description": "주어진 아이디에 대응되는 파트너 정보를 업데이트합니다.\n",
         "operationId": "updatePlatformPartner",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>업데이트할 파트너 아이디</p>\n",
+            "description": "업데이트할 파트너 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -2067,7 +2067,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 업데이트된 파트너 객체가 반환됩니다.</p>\n",
+            "description": "성공 응답으로 업데이트된 파트너 객체가 반환됩니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -2075,7 +2075,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 업데이트된 파트너 객체가 반환됩니다.</p>\n"
+            "x-portone-description": "성공 응답으로 업데이트된 파트너 객체가 반환됩니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -2136,7 +2136,7 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>주어진 아이디에 대응되는 파트너 정보를 업데이트합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 파트너 정보를 업데이트합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/UpdatePlatformPartnerError"
         }
@@ -2144,7 +2144,7 @@
     },
     "/platform/partners/batch": {
       "post": {
-        "description": "<p>새로운 파트너를 다건 생성합니다.</p>\n",
+        "description": "새로운 파트너를 다건 생성합니다.\n",
         "operationId": "createPlatformPartners",
         "requestBody": {
           "content": {
@@ -2158,7 +2158,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -2227,7 +2227,7 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>새로운 파트너를 다건 생성합니다.</p>\n",
+        "x-portone-description": "새로운 파트너를 다건 생성합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/CreatePlatformPartnersError"
         }
@@ -2237,13 +2237,13 @@
     "/platform/partners/{id}/reject": {},
     "/platform/partners/{id}/schedule": {
       "get": {
-        "description": "<p>주어진 아이디에 대응되는 파트너의 예약 업데이트를 조회합니다.</p>\n",
+        "description": "주어진 아이디에 대응되는 파트너의 예약 업데이트를 조회합니다.\n",
         "operationId": "getPlatformPartnerSchedule",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>파트너 아이디</p>\n",
+            "description": "파트너 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -2253,7 +2253,7 @@
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 예약된 파트너 객체를 반환합니다.</p>\n",
+            "description": "성공 응답으로 예약된 파트너 객체를 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -2261,7 +2261,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 예약된 파트너 객체를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 예약된 파트너 객체를 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -2312,20 +2312,20 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>주어진 아이디에 대응되는 파트너의 예약 업데이트를 조회합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 파트너의 예약 업데이트를 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPlatformPartnerScheduleError"
         },
         "x-portone-unstable": true
       },
       "put": {
-        "description": "<p>주어진 아이디에 대응되는 파트너에 예약 업데이트를 재설정합니다.</p>\n",
+        "description": "주어진 아이디에 대응되는 파트너에 예약 업데이트를 재설정합니다.\n",
         "operationId": "reschedulePartner",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>파트너 아이디</p>\n",
+            "description": "파트너 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -2345,7 +2345,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 예약된 파트너 객체를 반환합니다.</p>\n",
+            "description": "성공 응답으로 예약된 파트너 객체를 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -2353,7 +2353,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 예약된 파트너 객체를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 예약된 파트너 객체를 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -2404,20 +2404,20 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>주어진 아이디에 대응되는 파트너에 예약 업데이트를 재설정합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 파트너에 예약 업데이트를 재설정합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/ReschedulePartnerError"
         },
         "x-portone-unstable": true
       },
       "post": {
-        "description": "<p>주어진 아이디에 대응되는 파트너에 업데이트를 예약합니다.</p>\n",
+        "description": "주어진 아이디에 대응되는 파트너에 업데이트를 예약합니다.\n",
         "operationId": "schedulePartner",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>파트너 아이디</p>\n",
+            "description": "파트너 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -2437,7 +2437,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 예약된 파트너 객체가 반환됩니다.</p>\n",
+            "description": "성공 응답으로 예약된 파트너 객체가 반환됩니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -2445,7 +2445,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 예약된 파트너 객체가 반환됩니다.</p>\n"
+            "x-portone-description": "성공 응답으로 예약된 파트너 객체가 반환됩니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -2506,20 +2506,20 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>주어진 아이디에 대응되는 파트너에 업데이트를 예약합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 파트너에 업데이트를 예약합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/SchedulePartnerError"
         },
         "x-portone-unstable": true
       },
       "delete": {
-        "description": "<p>주어진 아이디에 대응되는 파트너의 예약 업데이트를 취소합니다.</p>\n",
+        "description": "주어진 아이디에 대응되는 파트너의 예약 업데이트를 취소합니다.\n",
         "operationId": "cancelPlatformPartnerSchedule",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>파트너 아이디</p>\n",
+            "description": "파트너 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -2529,7 +2529,7 @@
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -2588,7 +2588,7 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>주어진 아이디에 대응되는 파트너의 예약 업데이트를 취소합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 파트너의 예약 업데이트를 취소합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/CancelPlatformPartnerScheduleError"
         },
@@ -2688,7 +2688,7 @@
     "/platform/partners/{id}/recover": {},
     "/platform/contracts": {
       "get": {
-        "description": "<p>여러 계약을 조회합니다.</p>\n",
+        "description": "여러 계약을 조회합니다.\n",
         "operationId": "getPlatformContracts",
         "requestBody": {
           "content": {
@@ -2702,7 +2702,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 조회된 계약 리스트와 페이지 정보를 반환합니다.</p>\n",
+            "description": "성공 응답으로 조회된 계약 리스트와 페이지 정보를 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -2710,7 +2710,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 조회된 계약 리스트와 페이지 정보를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 조회된 계약 리스트와 페이지 정보를 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -2751,14 +2751,14 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>여러 계약을 조회합니다.</p>\n",
+        "x-portone-description": "여러 계약을 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPlatformContractsError"
         },
         "x-portone-unstable": true
       },
       "post": {
-        "description": "<p>새로운 계약을 생성합니다.</p>\n",
+        "description": "새로운 계약을 생성합니다.\n",
         "operationId": "createPlatformContract",
         "requestBody": {
           "content": {
@@ -2772,7 +2772,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 생성된 계약 객체가 반환됩니다.</p>\n",
+            "description": "성공 응답으로 생성된 계약 객체가 반환됩니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -2780,7 +2780,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 생성된 계약 객체가 반환됩니다.</p>\n"
+            "x-portone-description": "성공 응답으로 생성된 계약 객체가 반환됩니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -2831,7 +2831,7 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>새로운 계약을 생성합니다.</p>\n",
+        "x-portone-description": "새로운 계약을 생성합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/CreatePlatformContractError"
         }
@@ -2844,7 +2844,7 @@
           {
             "name": "id",
             "in": "path",
-            "description": "<p>조회할 계약 아이디</p>\n",
+            "description": "조회할 계약 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -2854,7 +2854,7 @@
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 계약 객체를 반환합니다.</p>\n",
+            "description": "성공 응답으로 계약 객체를 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -2862,7 +2862,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 계약 객체를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 계약 객체를 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -2918,13 +2918,13 @@
         }
       },
       "patch": {
-        "description": "<p>주어진 아이디에 대응되는 계약을 업데이트합니다.</p>\n",
+        "description": "주어진 아이디에 대응되는 계약을 업데이트합니다.\n",
         "operationId": "updatePlatformContract",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>업데이트할 계약 아이디</p>\n",
+            "description": "업데이트할 계약 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -2944,7 +2944,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 업데이트된 계약 객체가 반환됩니다.</p>\n",
+            "description": "성공 응답으로 업데이트된 계약 객체가 반환됩니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -2952,7 +2952,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 업데이트된 계약 객체가 반환됩니다.</p>\n"
+            "x-portone-description": "성공 응답으로 업데이트된 계약 객체가 반환됩니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -3013,7 +3013,7 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>주어진 아이디에 대응되는 계약을 업데이트합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 계약을 업데이트합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/UpdatePlatformContractError"
         }
@@ -3021,13 +3021,13 @@
     },
     "/platform/contracts/{id}/schedule": {
       "get": {
-        "description": "<p>주어진 아이디에 대응되는 계약의 예약 업데이트를 조회합니다.</p>\n",
+        "description": "주어진 아이디에 대응되는 계약의 예약 업데이트를 조회합니다.\n",
         "operationId": "getPlatformContractSchedule",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>계약 아이디</p>\n",
+            "description": "계약 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -3037,7 +3037,7 @@
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 예약된 계약 객체를 반환합니다.</p>\n",
+            "description": "성공 응답으로 예약된 계약 객체를 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -3045,7 +3045,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 예약된 계약 객체를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 예약된 계약 객체를 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -3096,20 +3096,20 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>주어진 아이디에 대응되는 계약의 예약 업데이트를 조회합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 계약의 예약 업데이트를 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPlatformContractScheduleError"
         },
         "x-portone-unstable": true
       },
       "put": {
-        "description": "<p>주어진 아이디에 대응되는 계약에 예약 업데이트를 재설정합니다.</p>\n",
+        "description": "주어진 아이디에 대응되는 계약에 예약 업데이트를 재설정합니다.\n",
         "operationId": "rescheduleContract",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>계약 아이디</p>\n",
+            "description": "계약 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -3129,7 +3129,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 예약된 계약 객체를 반환합니다.</p>\n",
+            "description": "성공 응답으로 예약된 계약 객체를 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -3137,7 +3137,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 예약된 계약 객체를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 예약된 계약 객체를 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -3188,20 +3188,20 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>주어진 아이디에 대응되는 계약에 예약 업데이트를 재설정합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 계약에 예약 업데이트를 재설정합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/RescheduleContractError"
         },
         "x-portone-unstable": true
       },
       "post": {
-        "description": "<p>주어진 아이디에 대응되는 계약에 업데이트를 예약합니다.</p>\n",
+        "description": "주어진 아이디에 대응되는 계약에 업데이트를 예약합니다.\n",
         "operationId": "scheduleContract",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>계약 아이디</p>\n",
+            "description": "계약 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -3221,7 +3221,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 예약된 계약 객체를 반환합니다.</p>\n",
+            "description": "성공 응답으로 예약된 계약 객체를 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -3229,7 +3229,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 예약된 계약 객체를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 예약된 계약 객체를 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -3290,20 +3290,20 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>주어진 아이디에 대응되는 계약에 업데이트를 예약합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 계약에 업데이트를 예약합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/ScheduleContractError"
         },
         "x-portone-unstable": true
       },
       "delete": {
-        "description": "<p>주어진 아이디에 대응되는 계약의 예약 업데이트를 취소합니다.</p>\n",
+        "description": "주어진 아이디에 대응되는 계약의 예약 업데이트를 취소합니다.\n",
         "operationId": "cancelPlatformContractSchedule",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>계약 아이디</p>\n",
+            "description": "계약 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -3313,7 +3313,7 @@
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -3372,7 +3372,7 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>주어진 아이디에 대응되는 계약의 예약 업데이트를 취소합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 계약의 예약 업데이트를 취소합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/CancelPlatformContractScheduleError"
         },
@@ -3464,7 +3464,7 @@
           {
             "name": "id",
             "in": "path",
-            "description": "<p>정산건 아이디</p>\n",
+            "description": "정산건 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -3806,14 +3806,14 @@
     "/platform/payouts/{id}/sheet-file": {},
     "/platform/bank-accounts/{bank}/{accountNumber}/holder": {
       "get": {
-        "summary": "<p>예금주 조회</p>\n",
-        "description": "<p>예금주 조회</p>\n<p>계좌의 예금주를 조회합니다.</p>\n",
+        "summary": "예금주 조회\n",
+        "description": "예금주 조회\n계좌의 예금주를 조회합니다.\n",
         "operationId": "getPlatformAccountHolder",
         "parameters": [
           {
             "name": "bank",
             "in": "path",
-            "description": "<p>은행</p>\n",
+            "description": "은행\n",
             "required": true,
             "schema": {
               "$ref": "#/components/schemas/Bank"
@@ -3823,7 +3823,7 @@
           {
             "name": "accountNumber",
             "in": "path",
-            "description": "<p>'-'를 제외한 계좌 번호</p>\n",
+            "description": "'-'를 제외한 계좌 번호\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -3833,29 +3833,29 @@
           {
             "name": "birthDate",
             "in": "query",
-            "description": "<p>생년월일</p>\n<p>실명 조회를 위해 추가로 보낼 수 있습니다. birthDate과 businessRegistrationNumber 중 하나만 사용해야 합니다.</p>\n",
+            "description": "생년월일\n실명 조회를 위해 추가로 보낼 수 있습니다. birthDate과 businessRegistrationNumber 중 하나만 사용해야 합니다.\n",
             "required": false,
             "schema": {
               "type": "string"
             },
             "x-portone-title": "생년월일",
-            "x-portone-description": "<p>실명 조회를 위해 추가로 보낼 수 있습니다. birthDate과 businessRegistrationNumber 중 하나만 사용해야 합니다.</p>\n"
+            "x-portone-description": "실명 조회를 위해 추가로 보낼 수 있습니다. birthDate과 businessRegistrationNumber 중 하나만 사용해야 합니다.\n"
           },
           {
             "name": "businessRegistrationNumber",
             "in": "query",
-            "description": "<p>사업자등록번호</p>\n<p>실명 조회를 위해 추가로 보낼 수 있습니다. birthDate과 businessRegistrationNumber 중 하나만 사용해야 합니다.</p>\n",
+            "description": "사업자등록번호\n실명 조회를 위해 추가로 보낼 수 있습니다. birthDate과 businessRegistrationNumber 중 하나만 사용해야 합니다.\n",
             "required": false,
             "schema": {
               "type": "string"
             },
             "x-portone-title": "사업자등록번호",
-            "x-portone-description": "<p>실명 조회를 위해 추가로 보낼 수 있습니다. birthDate과 businessRegistrationNumber 중 하나만 사용해야 합니다.</p>\n"
+            "x-portone-description": "실명 조회를 위해 추가로 보낼 수 있습니다. birthDate과 businessRegistrationNumber 중 하나만 사용해야 합니다.\n"
           }
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 조회된 예금주 명이 반환됩니다.</p>\n",
+            "description": "성공 응답으로 조회된 예금주 명이 반환됩니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -3863,7 +3863,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 조회된 예금주 명이 반환됩니다.</p>\n"
+            "x-portone-description": "성공 응답으로 조회된 예금주 명이 반환됩니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -3915,7 +3915,7 @@
           }
         ],
         "x-portone-title": "예금주 조회",
-        "x-portone-description": "<p>계좌의 예금주를 조회합니다.</p>\n",
+        "x-portone-description": "계좌의 예금주를 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPlatformAccountHolderError"
         },
@@ -3924,14 +3924,14 @@
     },
     "/identity-verifications/{identityVerificationId}": {
       "get": {
-        "summary": "<p>본인인증 단건 조회</p>\n",
-        "description": "<p>본인인증 단건 조회</p>\n<p>주어진 아이디에 대응되는 본인인증 내역을 조회합니다.</p>\n",
+        "summary": "본인인증 단건 조회\n",
+        "description": "본인인증 단건 조회\n주어진 아이디에 대응되는 본인인증 내역을 조회합니다.\n",
         "operationId": "getIdentityVerification",
         "parameters": [
           {
             "name": "identityVerificationId",
             "in": "path",
-            "description": "<p>조회할 본인인증 아이디</p>\n",
+            "description": "조회할 본인인증 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -3941,18 +3941,18 @@
           {
             "name": "storeId",
             "in": "query",
-            "description": "<p>상점 아이디</p>\n<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n",
+            "description": "상점 아이디\n접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.\n",
             "required": false,
             "schema": {
               "type": "string"
             },
             "x-portone-title": "상점 아이디",
-            "x-portone-description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "x-portone-description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.\n"
           }
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 본인 인증 객체를 반환합니다.</p>\n",
+            "description": "성공 응답으로 본인 인증 객체를 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -3960,7 +3960,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 본인 인증 객체를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 본인 인증 객체를 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -4013,7 +4013,7 @@
         ],
         "x-portone-category": "identityVerification",
         "x-portone-title": "본인인증 단건 조회",
-        "x-portone-description": "<p>주어진 아이디에 대응되는 본인인증 내역을 조회합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 본인인증 내역을 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetIdentityVerificationError"
         }
@@ -4021,14 +4021,14 @@
     },
     "/identity-verifications/{identityVerificationId}/send": {
       "post": {
-        "summary": "<p>본인인증 요청 전송</p>\n",
-        "description": "<p>본인인증 요청 전송</p>\n<p>SMS 또는 APP 방식을 이용하여 본인인증 요청을 전송합니다.</p>\n",
+        "summary": "본인인증 요청 전송\n",
+        "description": "본인인증 요청 전송\nSMS 또는 APP 방식을 이용하여 본인인증 요청을 전송합니다.\n",
         "operationId": "sendIdentityVerification",
         "parameters": [
           {
             "name": "identityVerificationId",
             "in": "path",
-            "description": "<p>본인인증 아이디</p>\n",
+            "description": "본인인증 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -4048,7 +4048,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -4129,7 +4129,7 @@
         ],
         "x-portone-category": "identityVerification",
         "x-portone-title": "본인인증 요청 전송",
-        "x-portone-description": "<p>SMS 또는 APP 방식을 이용하여 본인인증 요청을 전송합니다.</p>\n",
+        "x-portone-description": "SMS 또는 APP 방식을 이용하여 본인인증 요청을 전송합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/SendIdentityVerificationError"
         }
@@ -4137,14 +4137,14 @@
     },
     "/identity-verifications/{identityVerificationId}/confirm": {
       "post": {
-        "summary": "<p>본인인증 확인</p>\n",
-        "description": "<p>본인인증 확인</p>\n<p>요청된 본인인증에 대한 확인을 진행합니다.</p>\n",
+        "summary": "본인인증 확인\n",
+        "description": "본인인증 확인\n요청된 본인인증에 대한 확인을 진행합니다.\n",
         "operationId": "confirmIdentityVerification",
         "parameters": [
           {
             "name": "identityVerificationId",
             "in": "path",
-            "description": "<p>본인인증 아이디</p>\n",
+            "description": "본인인증 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -4164,7 +4164,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -4245,7 +4245,7 @@
         ],
         "x-portone-category": "identityVerification",
         "x-portone-title": "본인인증 확인",
-        "x-portone-description": "<p>요청된 본인인증에 대한 확인을 진행합니다.</p>\n",
+        "x-portone-description": "요청된 본인인증에 대한 확인을 진행합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/ConfirmIdentityVerificationError"
         }
@@ -4253,14 +4253,14 @@
     },
     "/identity-verifications/{identityVerificationId}/resend": {
       "post": {
-        "summary": "<p>SMS 본인인증 요청 재전송</p>\n",
-        "description": "<p>SMS 본인인증 요청 재전송</p>\n<p>SMS 본인인증 요청을 재전송합니다.</p>\n",
+        "summary": "SMS 본인인증 요청 재전송\n",
+        "description": "SMS 본인인증 요청 재전송\nSMS 본인인증 요청을 재전송합니다.\n",
         "operationId": "resendIdentityVerification",
         "parameters": [
           {
             "name": "identityVerificationId",
             "in": "path",
-            "description": "<p>본인인증 아이디</p>\n",
+            "description": "본인인증 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -4270,18 +4270,18 @@
           {
             "name": "storeId",
             "in": "query",
-            "description": "<p>상점 아이디</p>\n<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n",
+            "description": "상점 아이디\n접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.\n",
             "required": false,
             "schema": {
               "type": "string"
             },
             "x-portone-title": "상점 아이디",
-            "x-portone-description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "x-portone-description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.\n"
           }
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -4362,7 +4362,7 @@
         ],
         "x-portone-category": "identityVerification",
         "x-portone-title": "SMS 본인인증 요청 재전송",
-        "x-portone-description": "<p>SMS 본인인증 요청을 재전송합니다.</p>\n",
+        "x-portone-description": "SMS 본인인증 요청을 재전송합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/ResendIdentityVerificationError"
         }
@@ -4370,14 +4370,14 @@
     },
     "/payments/{paymentId}/pre-register": {
       "post": {
-        "summary": "<p>결제 정보 사전 등록</p>\n",
-        "description": "<p>결제 정보 사전 등록</p>\n<p>결제 정보를 사전 등록합니다.</p>\n",
+        "summary": "결제 정보 사전 등록\n",
+        "description": "결제 정보 사전 등록\n결제 정보를 사전 등록합니다.\n",
         "operationId": "preRegisterPayment",
         "parameters": [
           {
             "name": "paymentId",
             "in": "path",
-            "description": "<p>결제 건 아이디</p>\n",
+            "description": "결제 건 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -4397,7 +4397,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -4458,7 +4458,7 @@
         ],
         "x-portone-category": "payment",
         "x-portone-title": "결제 정보 사전 등록",
-        "x-portone-description": "<p>결제 정보를 사전 등록합니다.</p>\n",
+        "x-portone-description": "결제 정보를 사전 등록합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/PreRegisterPaymentError"
         }
@@ -4466,14 +4466,14 @@
     },
     "/billing-keys/{billingKey}": {
       "get": {
-        "summary": "<p>빌링키 단건 조회</p>\n",
-        "description": "<p>빌링키 단건 조회</p>\n<p>주어진 빌링키에 대응되는 빌링키 정보를 조회합니다.</p>\n",
+        "summary": "빌링키 단건 조회\n",
+        "description": "빌링키 단건 조회\n주어진 빌링키에 대응되는 빌링키 정보를 조회합니다.\n",
         "operationId": "getBillingKeyInfo",
         "parameters": [
           {
             "name": "billingKey",
             "in": "path",
-            "description": "<p>조회할 빌링키</p>\n",
+            "description": "조회할 빌링키\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -4483,18 +4483,18 @@
           {
             "name": "storeId",
             "in": "query",
-            "description": "<p>상점 아이디</p>\n<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n",
+            "description": "상점 아이디\n접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.\n",
             "required": false,
             "schema": {
               "type": "string"
             },
             "x-portone-title": "상점 아이디",
-            "x-portone-description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "x-portone-description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.\n"
           }
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 빌링키 정보를 반환합니다.</p>\n",
+            "description": "성공 응답으로 빌링키 정보를 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -4502,7 +4502,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 빌링키 정보를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 빌링키 정보를 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -4555,20 +4555,20 @@
         ],
         "x-portone-category": "billingKey",
         "x-portone-title": "빌링키 단건 조회",
-        "x-portone-description": "<p>주어진 빌링키에 대응되는 빌링키 정보를 조회합니다.</p>\n",
+        "x-portone-description": "주어진 빌링키에 대응되는 빌링키 정보를 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetBillingKeyInfoError"
         }
       },
       "delete": {
-        "summary": "<p>빌링키 삭제</p>\n",
-        "description": "<p>빌링키 삭제</p>\n<p>빌링키를 삭제합니다.</p>\n",
+        "summary": "빌링키 삭제\n",
+        "description": "빌링키 삭제\n빌링키를 삭제합니다.\n",
         "operationId": "deleteBillingKey",
         "parameters": [
           {
             "name": "billingKey",
             "in": "path",
-            "description": "<p>삭제할 빌링키</p>\n",
+            "description": "삭제할 빌링키\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -4578,18 +4578,18 @@
           {
             "name": "storeId",
             "in": "query",
-            "description": "<p>상점 아이디</p>\n<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n",
+            "description": "상점 아이디\n접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.\n",
             "required": false,
             "schema": {
               "type": "string"
             },
             "x-portone-title": "상점 아이디",
-            "x-portone-description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "x-portone-description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.\n"
           }
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -4670,7 +4670,7 @@
         ],
         "x-portone-category": "billingKey",
         "x-portone-title": "빌링키 삭제",
-        "x-portone-description": "<p>빌링키를 삭제합니다.</p>\n",
+        "x-portone-description": "빌링키를 삭제합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/DeleteBillingKeyError"
         }
@@ -4678,14 +4678,14 @@
     },
     "/payments/{paymentId}/cash-receipt": {
       "get": {
-        "summary": "<p>현금 영수증 단건 조회</p>\n",
-        "description": "<p>현금 영수증 단건 조회</p>\n<p>주어진 결제 아이디에 대응되는 현금 영수증 내역을 조회합니다.</p>\n",
+        "summary": "현금 영수증 단건 조회\n",
+        "description": "현금 영수증 단건 조회\n주어진 결제 아이디에 대응되는 현금 영수증 내역을 조회합니다.\n",
         "operationId": "getCashReceiptByPaymentId",
         "parameters": [
           {
             "name": "paymentId",
             "in": "path",
-            "description": "<p>결제 건 아이디</p>\n",
+            "description": "결제 건 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -4695,18 +4695,18 @@
           {
             "name": "storeId",
             "in": "query",
-            "description": "<p>상점 아이디</p>\n<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n",
+            "description": "상점 아이디\n접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.\n",
             "required": false,
             "schema": {
               "type": "string"
             },
             "x-portone-title": "상점 아이디",
-            "x-portone-description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "x-portone-description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.\n"
           }
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 현금 영수증 객체를 반환합니다.</p>\n",
+            "description": "성공 응답으로 현금 영수증 객체를 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -4714,7 +4714,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 현금 영수증 객체를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 현금 영수증 객체를 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -4767,7 +4767,7 @@
         ],
         "x-portone-category": "cashReceipt",
         "x-portone-title": "현금 영수증 단건 조회",
-        "x-portone-description": "<p>주어진 결제 아이디에 대응되는 현금 영수증 내역을 조회합니다.</p>\n",
+        "x-portone-description": "주어진 결제 아이디에 대응되는 현금 영수증 내역을 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetCashReceiptError"
         }
@@ -4775,14 +4775,14 @@
     },
     "/payments/{paymentId}": {
       "get": {
-        "summary": "<p>결제 단건 조회</p>\n",
-        "description": "<p>결제 단건 조회</p>\n<p>주어진 아이디에 대응되는 결제 건을 조회합니다.</p>\n",
+        "summary": "결제 단건 조회\n",
+        "description": "결제 단건 조회\n주어진 아이디에 대응되는 결제 건을 조회합니다.\n",
         "operationId": "getPayment",
         "parameters": [
           {
             "name": "paymentId",
             "in": "path",
-            "description": "<p>조회할 결제 아이디</p>\n",
+            "description": "조회할 결제 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -4792,7 +4792,7 @@
           {
             "name": "storeId",
             "in": "query",
-            "description": "<p>상점 아이디</p>\n",
+            "description": "상점 아이디\n",
             "required": false,
             "schema": {
               "type": "string"
@@ -4802,7 +4802,7 @@
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 결제 건 객체를 반환합니다.</p>\n",
+            "description": "성공 응답으로 결제 건 객체를 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -4863,7 +4863,7 @@
         ],
         "x-portone-category": "payment",
         "x-portone-title": "결제 단건 조회",
-        "x-portone-description": "<p>주어진 아이디에 대응되는 결제 건을 조회합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 결제 건을 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPaymentError"
         }
@@ -4871,8 +4871,8 @@
     },
     "/payments": {
       "get": {
-        "summary": "<p>결제 다건 조회(페이지 기반)</p>\n",
-        "description": "<p>결제 다건 조회(페이지 기반)</p>\n<p>주어진 조건에 맞는 결제 건들을 페이지 기반으로 조회합니다.</p>\n",
+        "summary": "결제 다건 조회(페이지 기반)\n",
+        "description": "결제 다건 조회(페이지 기반)\n주어진 조건에 맞는 결제 건들을 페이지 기반으로 조회합니다.\n",
         "operationId": "getPayments",
         "requestBody": {
           "content": {
@@ -4886,7 +4886,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 조회된 결제 건 리스트와 페이지 정보가 반환됩니다.</p>\n",
+            "description": "성공 응답으로 조회된 결제 건 리스트와 페이지 정보가 반환됩니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -4937,7 +4937,7 @@
         ],
         "x-portone-category": "payment",
         "x-portone-title": "결제 다건 조회(페이지 기반)",
-        "x-portone-description": "<p>주어진 조건에 맞는 결제 건들을 페이지 기반으로 조회합니다.</p>\n",
+        "x-portone-description": "주어진 조건에 맞는 결제 건들을 페이지 기반으로 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPaymentsError"
         }
@@ -4945,8 +4945,8 @@
     },
     "/payments-by-cursor": {
       "get": {
-        "summary": "<p>결제 대용량 다건 조회(커서 기반)</p>\n",
-        "description": "<p>결제 대용량 다건 조회(커서 기반)</p>\n<p>기간 내 모든 결제 건을 커서 기반으로 조회합니다. 결제 건의 생성일시를 기준으로 주어진 기간 내 존재하는 모든 결제 건이 조회됩니다.</p>\n",
+        "summary": "결제 대용량 다건 조회(커서 기반)\n",
+        "description": "결제 대용량 다건 조회(커서 기반)\n기간 내 모든 결제 건을 커서 기반으로 조회합니다. 결제 건의 생성일시를 기준으로 주어진 기간 내 존재하는 모든 결제 건이 조회됩니다.\n",
         "operationId": "getAllPaymentsByCursor",
         "requestBody": {
           "content": {
@@ -4960,7 +4960,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 조회된 결제 건 리스트와 커서 정보가 반환됩니다.</p>\n",
+            "description": "성공 응답으로 조회된 결제 건 리스트와 커서 정보가 반환됩니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -5011,7 +5011,7 @@
         ],
         "x-portone-category": "payment",
         "x-portone-title": "결제 대용량 다건 조회(커서 기반)",
-        "x-portone-description": "<p>기간 내 모든 결제 건을 커서 기반으로 조회합니다. 결제 건의 생성일시를 기준으로 주어진 기간 내 존재하는 모든 결제 건이 조회됩니다.</p>\n",
+        "x-portone-description": "기간 내 모든 결제 건을 커서 기반으로 조회합니다. 결제 건의 생성일시를 기준으로 주어진 기간 내 존재하는 모든 결제 건이 조회됩니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetAllPaymentsError"
         },
@@ -5020,14 +5020,14 @@
     },
     "/payment-schedules/{paymentScheduleId}": {
       "get": {
-        "summary": "<p>결제 예약 단건 조회</p>\n",
-        "description": "<p>결제 예약 단건 조회</p>\n<p>주어진 아이디에 대응되는 결제 예약 건을 조회합니다.</p>\n",
+        "summary": "결제 예약 단건 조회\n",
+        "description": "결제 예약 단건 조회\n주어진 아이디에 대응되는 결제 예약 건을 조회합니다.\n",
         "operationId": "getPaymentSchedule",
         "parameters": [
           {
             "name": "paymentScheduleId",
             "in": "path",
-            "description": "<p>조회할 결제 예약 건 아이디</p>\n",
+            "description": "조회할 결제 예약 건 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -5037,18 +5037,18 @@
           {
             "name": "storeId",
             "in": "query",
-            "description": "<p>상점 아이디</p>\n<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n",
+            "description": "상점 아이디\n접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.\n",
             "required": false,
             "schema": {
               "type": "string"
             },
             "x-portone-title": "상점 아이디",
-            "x-portone-description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "x-portone-description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.\n"
           }
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 결제 예약 건 객체를 반환합니다.</p>\n",
+            "description": "성공 응답으로 결제 예약 건 객체를 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -5109,7 +5109,7 @@
         ],
         "x-portone-category": "paymentSchedule",
         "x-portone-title": "결제 예약 단건 조회",
-        "x-portone-description": "<p>주어진 아이디에 대응되는 결제 예약 건을 조회합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 결제 예약 건을 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPaymentScheduleError"
         }
@@ -5117,8 +5117,8 @@
     },
     "/payment-schedules": {
       "get": {
-        "summary": "<p>결제 예약 다건 조회</p>\n",
-        "description": "<p>결제 예약 다건 조회</p>\n<p>주어진 조건에 맞는 결제 예약 건들을 조회합니다.</p>\n",
+        "summary": "결제 예약 다건 조회\n",
+        "description": "결제 예약 다건 조회\n주어진 조건에 맞는 결제 예약 건들을 조회합니다.\n",
         "operationId": "getPaymentSchedules",
         "requestBody": {
           "content": {
@@ -5132,7 +5132,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 조회된 예약 결제 건 리스트가 반환됩니다.</p>\n",
+            "description": "성공 응답으로 조회된 예약 결제 건 리스트가 반환됩니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -5140,7 +5140,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 조회된 예약 결제 건 리스트가 반환됩니다.</p>\n"
+            "x-portone-description": "성공 응답으로 조회된 예약 결제 건 리스트가 반환됩니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -5183,14 +5183,14 @@
         ],
         "x-portone-category": "paymentSchedule",
         "x-portone-title": "결제 예약 다건 조회",
-        "x-portone-description": "<p>주어진 조건에 맞는 결제 예약 건들을 조회합니다.</p>\n",
+        "x-portone-description": "주어진 조건에 맞는 결제 예약 건들을 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPaymentSchedulesError"
         }
       },
       "delete": {
-        "summary": "<p>결제 예약 취소</p>\n",
-        "description": "<p>결제 예약 취소</p>\n<p>결제 예약 건을 취소합니다.</p>\n",
+        "summary": "결제 예약 취소\n",
+        "description": "결제 예약 취소\n결제 예약 건을 취소합니다.\n",
         "operationId": "revokePaymentSchedule",
         "requestBody": {
           "content": {
@@ -5204,7 +5204,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -5275,7 +5275,7 @@
         ],
         "x-portone-category": "paymentSchedule",
         "x-portone-title": "결제 예약 취소",
-        "x-portone-description": "<p>결제 예약 건을 취소합니다.</p>\n",
+        "x-portone-description": "결제 예약 건을 취소합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/RevokePaymentScheduleError"
         }
@@ -5283,14 +5283,14 @@
     },
     "/payments/{paymentId}/schedule": {
       "post": {
-        "summary": "<p>결제 예약</p>\n",
-        "description": "<p>결제 예약</p>\n<p>결제를 예약합니다.</p>\n",
+        "summary": "결제 예약\n",
+        "description": "결제 예약\n결제를 예약합니다.\n",
         "operationId": "createPaymentSchedule",
         "parameters": [
           {
             "name": "paymentId",
             "in": "path",
-            "description": "<p>결제 건 아이디</p>\n",
+            "description": "결제 건 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -5310,7 +5310,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -5381,7 +5381,7 @@
         ],
         "x-portone-category": "paymentSchedule",
         "x-portone-title": "결제 예약",
-        "x-portone-description": "<p>결제를 예약합니다.</p>\n",
+        "x-portone-description": "결제를 예약합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/CreatePaymentScheduleError"
         }
@@ -5389,14 +5389,14 @@
     },
     "/payments/{paymentId}/cancel": {
       "post": {
-        "summary": "<p>결제 취소</p>\n",
-        "description": "<p>결제 취소</p>\n<p>결제 취소를 요청합니다.</p>\n",
+        "summary": "결제 취소\n",
+        "description": "결제 취소\n결제 취소를 요청합니다.\n",
         "operationId": "cancelPayment",
         "parameters": [
           {
             "name": "paymentId",
             "in": "path",
-            "description": "<p>결제 건 아이디</p>\n",
+            "description": "결제 건 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -5416,7 +5416,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -5497,7 +5497,7 @@
         ],
         "x-portone-category": "payment",
         "x-portone-title": "결제 취소",
-        "x-portone-description": "<p>결제 취소를 요청합니다.</p>\n",
+        "x-portone-description": "결제 취소를 요청합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/CancelPaymentError"
         }
@@ -5505,14 +5505,14 @@
     },
     "/payments/{paymentId}/billing-key": {
       "post": {
-        "summary": "<p>빌링키 결제</p>\n",
-        "description": "<p>빌링키 결제</p>\n<p>빌링키로 결제를 진행합니다.</p>\n",
+        "summary": "빌링키 결제\n",
+        "description": "빌링키 결제\n빌링키로 결제를 진행합니다.\n",
         "operationId": "PayWithBillingKey",
         "parameters": [
           {
             "name": "paymentId",
             "in": "path",
-            "description": "<p>결제 건 아이디</p>\n",
+            "description": "결제 건 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -5532,7 +5532,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -5613,7 +5613,7 @@
         ],
         "x-portone-category": "payment",
         "x-portone-title": "빌링키 결제",
-        "x-portone-description": "<p>빌링키로 결제를 진행합니다.</p>\n",
+        "x-portone-description": "빌링키로 결제를 진행합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/PayWithBillingKeyError"
         }
@@ -5621,14 +5621,14 @@
     },
     "/payments/{paymentId}/instant": {
       "post": {
-        "summary": "<p>수기 결제</p>\n",
-        "description": "<p>수기 결제</p>\n<p>수기 결제를 진행합니다.</p>\n",
+        "summary": "수기 결제\n",
+        "description": "수기 결제\n수기 결제를 진행합니다.\n",
         "operationId": "PayInstantly",
         "parameters": [
           {
             "name": "paymentId",
             "in": "path",
-            "description": "<p>결제 건 아이디</p>\n",
+            "description": "결제 건 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -5648,7 +5648,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -5729,7 +5729,7 @@
         ],
         "x-portone-category": "payment",
         "x-portone-title": "수기 결제",
-        "x-portone-description": "<p>수기 결제를 진행합니다.</p>\n",
+        "x-portone-description": "수기 결제를 진행합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/PayInstantlyError"
         }
@@ -5737,8 +5737,8 @@
     },
     "/billing-keys": {
       "post": {
-        "summary": "<p>빌링키 발급</p>\n",
-        "description": "<p>빌링키 발급</p>\n<p>빌링키 발급을 요청합니다.</p>\n",
+        "summary": "빌링키 발급\n",
+        "description": "빌링키 발급\n빌링키 발급을 요청합니다.\n",
         "operationId": "issueBillingKey",
         "requestBody": {
           "content": {
@@ -5752,7 +5752,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -5823,7 +5823,7 @@
         ],
         "x-portone-category": "billingKey",
         "x-portone-title": "빌링키 발급",
-        "x-portone-description": "<p>빌링키 발급을 요청합니다.</p>\n",
+        "x-portone-description": "빌링키 발급을 요청합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/IssueBillingKeyError"
         }
@@ -5831,8 +5831,8 @@
     },
     "/cash-receipts": {
       "post": {
-        "summary": "<p>현금 영수증 수동 발급</p>\n",
-        "description": "<p>현금 영수증 수동 발급</p>\n<p>현금 영수증 발급을 요청합니다.</p>\n",
+        "summary": "현금 영수증 수동 발급\n",
+        "description": "현금 영수증 수동 발급\n현금 영수증 발급을 요청합니다.\n",
         "operationId": "issueCashReceipt",
         "requestBody": {
           "content": {
@@ -5846,7 +5846,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -5927,7 +5927,7 @@
         ],
         "x-portone-category": "cashReceipt",
         "x-portone-title": "현금 영수증 수동 발급",
-        "x-portone-description": "<p>현금 영수증 발급을 요청합니다.</p>\n",
+        "x-portone-description": "현금 영수증 발급을 요청합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/IssueCashReceiptError"
         }
@@ -5935,14 +5935,14 @@
     },
     "/payments/{paymentId}/cash-receipt/cancel": {
       "post": {
-        "summary": "<p>현금 영수증 취소</p>\n",
-        "description": "<p>현금 영수증 취소</p>\n<p>현금 영수증 취소를 요청합니다.</p>\n",
+        "summary": "현금 영수증 취소\n",
+        "description": "현금 영수증 취소\n현금 영수증 취소를 요청합니다.\n",
         "operationId": "cancelCashReceiptByPaymentId",
         "parameters": [
           {
             "name": "paymentId",
             "in": "path",
-            "description": "<p>결제 건 아이디</p>\n",
+            "description": "결제 건 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -5952,18 +5952,18 @@
           {
             "name": "storeId",
             "in": "query",
-            "description": "<p>상점 아이디</p>\n<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n",
+            "description": "상점 아이디\n접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.\n",
             "required": false,
             "schema": {
               "type": "string"
             },
             "x-portone-title": "상점 아이디",
-            "x-portone-description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "x-portone-description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.\n"
           }
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -6034,7 +6034,7 @@
         ],
         "x-portone-category": "cashReceipt",
         "x-portone-title": "현금 영수증 취소",
-        "x-portone-description": "<p>현금 영수증 취소를 요청합니다.</p>\n",
+        "x-portone-description": "현금 영수증 취소를 요청합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/CancelCashReceiptError"
         }
@@ -6042,14 +6042,14 @@
     },
     "/payments/{paymentId}/virtual-account/close": {
       "post": {
-        "summary": "<p>가상계좌 말소</p>\n",
-        "description": "<p>가상계좌 말소</p>\n<p>발급된 가상계좌를 말소합니다.</p>\n",
+        "summary": "가상계좌 말소\n",
+        "description": "가상계좌 말소\n발급된 가상계좌를 말소합니다.\n",
         "operationId": "closeVirtualAccount",
         "parameters": [
           {
             "name": "paymentId",
             "in": "path",
-            "description": "<p>결제 건 아이디</p>\n",
+            "description": "결제 건 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -6059,18 +6059,18 @@
           {
             "name": "storeId",
             "in": "query",
-            "description": "<p>상점 아이디</p>\n<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n",
+            "description": "상점 아이디\n접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.\n",
             "required": false,
             "schema": {
               "type": "string"
             },
             "x-portone-title": "상점 아이디",
-            "x-portone-description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "x-portone-description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.\n"
           }
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -6151,7 +6151,7 @@
         ],
         "x-portone-category": "payment",
         "x-portone-title": "가상계좌 말소",
-        "x-portone-description": "<p>발급된 가상계좌를 말소합니다.</p>\n",
+        "x-portone-description": "발급된 가상계좌를 말소합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/CloseVirtualAccountError"
         }
@@ -6159,14 +6159,14 @@
     },
     "/payments/{paymentId}/escrow/logistics": {
       "post": {
-        "summary": "<p>에스크로 배송 정보 등록</p>\n",
-        "description": "<p>에스크로 배송 정보 등록</p>\n<p>에스크로 배송 정보를 등록합니다.</p>\n",
+        "summary": "에스크로 배송 정보 등록\n",
+        "description": "에스크로 배송 정보 등록\n에스크로 배송 정보를 등록합니다.\n",
         "operationId": "applyEscrowLogistics",
         "parameters": [
           {
             "name": "paymentId",
             "in": "path",
-            "description": "<p>결제 건 아이디</p>\n",
+            "description": "결제 건 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -6186,7 +6186,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -6267,20 +6267,20 @@
         ],
         "x-portone-category": "payment",
         "x-portone-title": "에스크로 배송 정보 등록",
-        "x-portone-description": "<p>에스크로 배송 정보를 등록합니다.</p>\n",
+        "x-portone-description": "에스크로 배송 정보를 등록합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/ApplyEscrowLogisticsError"
         }
       },
       "patch": {
-        "summary": "<p>에스크로 배송 정보 수정</p>\n",
-        "description": "<p>에스크로 배송 정보 수정</p>\n<p>에스크로 배송 정보를 수정합니다.</p>\n",
+        "summary": "에스크로 배송 정보 수정\n",
+        "description": "에스크로 배송 정보 수정\n에스크로 배송 정보를 수정합니다.\n",
         "operationId": "modifyEscrowLogistics",
         "parameters": [
           {
             "name": "paymentId",
             "in": "path",
-            "description": "<p>결제 건 아이디</p>\n",
+            "description": "결제 건 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -6300,7 +6300,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -6381,7 +6381,7 @@
         ],
         "x-portone-category": "payment",
         "x-portone-title": "에스크로 배송 정보 수정",
-        "x-portone-description": "<p>에스크로 배송 정보를 수정합니다.</p>\n",
+        "x-portone-description": "에스크로 배송 정보를 수정합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/ModifyEscrowLogisticsError"
         }
@@ -6389,14 +6389,14 @@
     },
     "/payments/{paymentId}/escrow/complete": {
       "post": {
-        "summary": "<p>에스크로 구매 확정</p>\n",
-        "description": "<p>에스크로 구매 확정</p>\n<p>에스크로 결제를 구매 확정 처리합니다</p>\n",
+        "summary": "에스크로 구매 확정\n",
+        "description": "에스크로 구매 확정\n에스크로 결제를 구매 확정 처리합니다\n",
         "operationId": "confirmEscrow",
         "parameters": [
           {
             "name": "paymentId",
             "in": "path",
-            "description": "<p>결제 건 아이디</p>\n",
+            "description": "결제 건 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -6416,7 +6416,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -6497,7 +6497,7 @@
         ],
         "x-portone-category": "payment",
         "x-portone-title": "에스크로 구매 확정",
-        "x-portone-description": "<p>에스크로 결제를 구매 확정 처리합니다</p>\n",
+        "x-portone-description": "에스크로 결제를 구매 확정 처리합니다\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/ConfirmEscrowError"
         }
@@ -6505,14 +6505,14 @@
     },
     "/payments/{paymentId}/resend-webhook": {
       "post": {
-        "summary": "<p>웹훅 재발송</p>\n",
-        "description": "<p>웹훅 재발송</p>\n<p>웹훅을 재발송합니다.</p>\n",
+        "summary": "웹훅 재발송\n",
+        "description": "웹훅 재발송\n웹훅을 재발송합니다.\n",
         "operationId": "resendWebhook",
         "parameters": [
           {
             "name": "paymentId",
             "in": "path",
-            "description": "<p>결제 건 아이디</p>\n",
+            "description": "결제 건 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -6532,7 +6532,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -6593,7 +6593,7 @@
         ],
         "x-portone-category": "payment",
         "x-portone-title": "웹훅 재발송",
-        "x-portone-description": "<p>웹훅을 재발송합니다.</p>\n",
+        "x-portone-description": "웹훅을 재발송합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/ResendWebhookError"
         }
@@ -6602,7 +6602,7 @@
     "/channels": {},
     "/analytics/charts/payment": {
       "get": {
-        "description": "<p>가맹점의 결제 현황을 조회합니다.</p>\n",
+        "description": "가맹점의 결제 현황을 조회합니다.\n",
         "operationId": "getAnalyticsPaymentChart",
         "requestBody": {
           "content": {
@@ -6616,7 +6616,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 결제 현황을 반환합니다.</p>\n",
+            "description": "성공 응답으로 결제 현황을 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -6624,7 +6624,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 결제 현황을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 결제 현황을 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -6666,7 +6666,7 @@
           }
         ],
         "x-portone-category": "analytics",
-        "x-portone-description": "<p>가맹점의 결제 현황을 조회합니다.</p>\n",
+        "x-portone-description": "가맹점의 결제 현황을 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetAnalyticsPaymentChartError"
         },
@@ -6675,7 +6675,7 @@
     },
     "/analytics/charts/payment-insight": {
       "get": {
-        "description": "<p>가맹점의 결제 현황 인사이트를 조회합니다.</p>\n",
+        "description": "가맹점의 결제 현황 인사이트를 조회합니다.\n",
         "operationId": "getAnalyticsPaymentChartInsight",
         "requestBody": {
           "content": {
@@ -6689,7 +6689,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 결제 현황 인사이트를 반환합니다.</p>\n",
+            "description": "성공 응답으로 결제 현황 인사이트를 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -6697,7 +6697,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 결제 현황 인사이트를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 결제 현황 인사이트를 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -6739,7 +6739,7 @@
           }
         ],
         "x-portone-category": "analytics",
-        "x-portone-description": "<p>가맹점의 결제 현황 인사이트를 조회합니다.</p>\n",
+        "x-portone-description": "가맹점의 결제 현황 인사이트를 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetAnalyticsPaymentChartInsightError"
         },
@@ -6748,7 +6748,7 @@
     },
     "/analytics/charts/average-amount": {
       "get": {
-        "description": "<p>가맹점의 평균 거래액 현황을 조회합니다.</p>\n",
+        "description": "가맹점의 평균 거래액 현황을 조회합니다.\n",
         "operationId": "getAverageAmountChart",
         "requestBody": {
           "content": {
@@ -6762,7 +6762,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 평균 거래액 현황을 반환합니다.</p>\n",
+            "description": "성공 응답으로 평균 거래액 현황을 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -6770,7 +6770,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 평균 거래액 현황을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 평균 거래액 현황을 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -6812,7 +6812,7 @@
           }
         ],
         "x-portone-category": "analytics",
-        "x-portone-description": "<p>가맹점의 평균 거래액 현황을 조회합니다.</p>\n",
+        "x-portone-description": "가맹점의 평균 거래액 현황을 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetAverageAmountChartError"
         },
@@ -6821,7 +6821,7 @@
     },
     "/analytics/charts/payment-method": {
       "get": {
-        "description": "<p>가맹점의 결제수단 현황을 조회합니다.</p>\n",
+        "description": "가맹점의 결제수단 현황을 조회합니다.\n",
         "operationId": "getPaymentMethodChart",
         "requestBody": {
           "content": {
@@ -6835,7 +6835,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 결제수단 현황을 반환합니다.</p>\n",
+            "description": "성공 응답으로 결제수단 현황을 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -6843,7 +6843,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 결제수단 현황을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 결제수단 현황을 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -6885,7 +6885,7 @@
           }
         ],
         "x-portone-category": "analytics",
-        "x-portone-description": "<p>가맹점의 결제수단 현황을 조회합니다.</p>\n",
+        "x-portone-description": "가맹점의 결제수단 현황을 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPaymentMethodChartError"
         },
@@ -6894,7 +6894,7 @@
     },
     "/analytics/charts/payment-method-trend": {
       "get": {
-        "description": "<p>가맹점의 결제수단 트렌드를 조회합니다.</p>\n",
+        "description": "가맹점의 결제수단 트렌드를 조회합니다.\n",
         "operationId": "getPaymentMethodTrendChart",
         "requestBody": {
           "content": {
@@ -6908,7 +6908,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 결제수단 트렌드를 반환합니다.</p>\n",
+            "description": "성공 응답으로 결제수단 트렌드를 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -6916,7 +6916,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 결제수단 트렌드를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 결제수단 트렌드를 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -6958,7 +6958,7 @@
           }
         ],
         "x-portone-category": "analytics",
-        "x-portone-description": "<p>가맹점의 결제수단 트렌드를 조회합니다.</p>\n",
+        "x-portone-description": "가맹점의 결제수단 트렌드를 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPaymentMethodTrendChartError"
         },
@@ -6967,7 +6967,7 @@
     },
     "/analytics/charts/card": {
       "get": {
-        "description": "<p>가맹점의 카드결제 현황을 조회합니다.</p>\n",
+        "description": "가맹점의 카드결제 현황을 조회합니다.\n",
         "operationId": "getAnalyticsCardChart",
         "requestBody": {
           "content": {
@@ -6981,7 +6981,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 카드결제 현황을 반환합니다.</p>\n",
+            "description": "성공 응답으로 카드결제 현황을 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -6989,7 +6989,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 카드결제 현황을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 카드결제 현황을 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -7031,7 +7031,7 @@
           }
         ],
         "x-portone-category": "analytics",
-        "x-portone-description": "<p>가맹점의 카드결제 현황을 조회합니다.</p>\n",
+        "x-portone-description": "가맹점의 카드결제 현황을 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetAnalyticsCardChartError"
         },
@@ -7040,7 +7040,7 @@
     },
     "/analytics/charts/card-company": {
       "get": {
-        "description": "<p>가맹점의 카드사별 결제 현황을 조회합니다.</p>\n",
+        "description": "가맹점의 카드사별 결제 현황을 조회합니다.\n",
         "operationId": "getAnalyticsCardCompanyChart",
         "requestBody": {
           "content": {
@@ -7054,7 +7054,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 카드사별 결제 현황을 반환합니다.</p>\n",
+            "description": "성공 응답으로 카드사별 결제 현황을 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -7062,7 +7062,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 카드사별 결제 현황을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 카드사별 결제 현황을 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -7104,7 +7104,7 @@
           }
         ],
         "x-portone-category": "analytics",
-        "x-portone-description": "<p>가맹점의 카드사별 결제 현황을 조회합니다.</p>\n",
+        "x-portone-description": "가맹점의 카드사별 결제 현황을 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetAnalyticsCardCompanyChartError"
         },
@@ -7113,7 +7113,7 @@
     },
     "/analytics/charts/easy-pay": {
       "get": {
-        "description": "<p>가맹점의 간편결제 현황을 조회합니다.</p>\n",
+        "description": "가맹점의 간편결제 현황을 조회합니다.\n",
         "operationId": "getAnalyticsEasyPayChart",
         "requestBody": {
           "content": {
@@ -7127,7 +7127,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 간편결제 현황을 반환합니다.</p>\n",
+            "description": "성공 응답으로 간편결제 현황을 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -7135,7 +7135,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 간편결제 현황을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 간편결제 현황을 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -7177,7 +7177,7 @@
           }
         ],
         "x-portone-category": "analytics",
-        "x-portone-description": "<p>가맹점의 간편결제 현황을 조회합니다.</p>\n",
+        "x-portone-description": "가맹점의 간편결제 현황을 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetAnalyticsEasyPayChartError"
         },
@@ -7186,7 +7186,7 @@
     },
     "/analytics/charts/easy-pay-provider": {
       "get": {
-        "description": "<p>가맹점의 간편결제사별 결제 현황을 조회합니다.</p>\n",
+        "description": "가맹점의 간편결제사별 결제 현황을 조회합니다.\n",
         "operationId": "getAnalyticsEasyPayProviderChart",
         "requestBody": {
           "content": {
@@ -7200,7 +7200,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 간편결제사별 결제 현황을 반환합니다.</p>\n",
+            "description": "성공 응답으로 간편결제사별 결제 현황을 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -7208,7 +7208,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 간편결제사별 결제 현황을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 간편결제사별 결제 현황을 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -7250,7 +7250,7 @@
           }
         ],
         "x-portone-category": "analytics",
-        "x-portone-description": "<p>가맹점의 간편결제사별 결제 현황을 조회합니다.</p>\n",
+        "x-portone-description": "가맹점의 간편결제사별 결제 현황을 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetAnalyticsEasyPayProviderChartError"
         },
@@ -7259,7 +7259,7 @@
     },
     "/analytics/charts/pg-company": {
       "get": {
-        "description": "<p>가맹점의 결제대행사 현황을 조회합니다.</p>\n",
+        "description": "가맹점의 결제대행사 현황을 조회합니다.\n",
         "operationId": "getPgCompanyChart",
         "requestBody": {
           "content": {
@@ -7273,7 +7273,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 결제대행사 현황을 반환합니다.</p>\n",
+            "description": "성공 응답으로 결제대행사 현황을 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -7281,7 +7281,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 결제대행사 현황을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 결제대행사 현황을 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -7323,7 +7323,7 @@
           }
         ],
         "x-portone-category": "analytics",
-        "x-portone-description": "<p>가맹점의 결제대행사 현황을 조회합니다.</p>\n",
+        "x-portone-description": "가맹점의 결제대행사 현황을 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPgCompanyChartError"
         },
@@ -7332,7 +7332,7 @@
     },
     "/analytics/charts/pg-company-trend": {
       "get": {
-        "description": "<p>가맹점의 결제대행사별 거래 추이를 조회합니다.</p>\n",
+        "description": "가맹점의 결제대행사별 거래 추이를 조회합니다.\n",
         "operationId": "getPgCompanyTrendChart",
         "requestBody": {
           "content": {
@@ -7346,7 +7346,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 결제대행사별 거래 추이를 반환합니다.</p>\n",
+            "description": "성공 응답으로 결제대행사별 거래 추이를 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -7354,7 +7354,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 결제대행사별 거래 추이를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 결제대행사별 거래 추이를 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -7396,7 +7396,7 @@
           }
         ],
         "x-portone-category": "analytics",
-        "x-portone-description": "<p>가맹점의 결제대행사별 거래 추이를 조회합니다.</p>\n",
+        "x-portone-description": "가맹점의 결제대행사별 거래 추이를 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPgCompanyTrendChartError"
         },
@@ -7405,11 +7405,11 @@
     },
     "/analytics/overseas-payment-usage": {
       "get": {
-        "description": "<p>가맹점의 해외 결제 사용 여부를 조회합니다.</p>\n",
+        "description": "가맹점의 해외 결제 사용 여부를 조회합니다.\n",
         "operationId": "getAnalyticsOverseasPaymentUsage",
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 해외 결제 사용 여부을 반환합니다.</p>\n",
+            "description": "성공 응답으로 해외 결제 사용 여부을 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -7417,7 +7417,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 해외 결제 사용 여부을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 해외 결제 사용 여부을 반환합니다.\n"
           },
           "401": {
             "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
@@ -7449,7 +7449,7 @@
           }
         ],
         "x-portone-category": "analytics",
-        "x-portone-description": "<p>가맹점의 해외 결제 사용 여부를 조회합니다.</p>\n",
+        "x-portone-description": "가맹점의 해외 결제 사용 여부를 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetAnalyticsOverseasPaymentUsageError"
         },
@@ -7458,7 +7458,7 @@
     },
     "/analytics/cancellation-rate": {
       "get": {
-        "description": "<p>가맹점의 환불율을 조회합니다.</p>\n",
+        "description": "가맹점의 환불율을 조회합니다.\n",
         "operationId": "getAnalyticsCancellationRate",
         "requestBody": {
           "content": {
@@ -7472,7 +7472,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 환불율을 반환합니다.</p>\n",
+            "description": "성공 응답으로 환불율을 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -7480,7 +7480,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 환불율을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 환불율을 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -7522,7 +7522,7 @@
           }
         ],
         "x-portone-category": "analytics",
-        "x-portone-description": "<p>가맹점의 환불율을 조회합니다.</p>\n",
+        "x-portone-description": "가맹점의 환불율을 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetAnalyticsCancellationRateError"
         },
@@ -7531,7 +7531,7 @@
     },
     "/analytics/charts/payment-status": {
       "get": {
-        "description": "<p>가맹점의 결제상태 이력 집계를 조회합니다.</p>\n",
+        "description": "가맹점의 결제상태 이력 집계를 조회합니다.\n",
         "operationId": "getPaymentStatusChart",
         "requestBody": {
           "content": {
@@ -7545,7 +7545,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 결제상태 이력 집계 결과를 반환합니다.</p>\n",
+            "description": "성공 응답으로 결제상태 이력 집계 결과를 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -7553,7 +7553,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 결제상태 이력 집계 결과를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 결제상태 이력 집계 결과를 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -7595,7 +7595,7 @@
           }
         ],
         "x-portone-category": "analytics",
-        "x-portone-description": "<p>가맹점의 결제상태 이력 집계를 조회합니다.</p>\n",
+        "x-portone-description": "가맹점의 결제상태 이력 집계를 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPaymentStatusChartError"
         },
@@ -7604,7 +7604,7 @@
     },
     "/analytics/charts/payment-status/by-method": {
       "get": {
-        "description": "<p>가맹점의 결제수단별 결제전환율을 조회합니다.</p>\n",
+        "description": "가맹점의 결제수단별 결제전환율을 조회합니다.\n",
         "operationId": "getPaymentStatusByPaymentMethodChart",
         "requestBody": {
           "content": {
@@ -7618,7 +7618,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 결제수단별 결제전환율 조회 결과를 반환합니다.</p>\n",
+            "description": "성공 응답으로 결제수단별 결제전환율 조회 결과를 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -7626,7 +7626,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 결제수단별 결제전환율 조회 결과를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 결제수단별 결제전환율 조회 결과를 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -7668,7 +7668,7 @@
           }
         ],
         "x-portone-category": "analytics",
-        "x-portone-description": "<p>가맹점의 결제수단별 결제전환율을 조회합니다.</p>\n",
+        "x-portone-description": "가맹점의 결제수단별 결제전환율을 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPaymentStatusByPaymentMethodChartError"
         },
@@ -7677,7 +7677,7 @@
     },
     "/analytics/charts/payment-status/by-pg-company": {
       "get": {
-        "description": "<p>가맹점의 PG사별 결제전환율을 조회합니다.</p>\n",
+        "description": "가맹점의 PG사별 결제전환율을 조회합니다.\n",
         "operationId": "getPaymentStatusByPgCompanyChart",
         "requestBody": {
           "content": {
@@ -7691,7 +7691,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 PG사별 결제전환율 조회 결과를 반환합니다.</p>\n",
+            "description": "성공 응답으로 PG사별 결제전환율 조회 결과를 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -7699,7 +7699,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 PG사별 결제전환율 조회 결과를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 PG사별 결제전환율 조회 결과를 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -7741,7 +7741,7 @@
           }
         ],
         "x-portone-category": "analytics",
-        "x-portone-description": "<p>가맹점의 PG사별 결제전환율을 조회합니다.</p>\n",
+        "x-portone-description": "가맹점의 PG사별 결제전환율을 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPaymentStatusByPgCompanyChartError"
         },
@@ -7750,7 +7750,7 @@
     },
     "/analytics/charts/payment-status/by-payment-client": {
       "get": {
-        "description": "<p>가맹점의 결제환경별 결제전환율을 조회합니다.</p>\n",
+        "description": "가맹점의 결제환경별 결제전환율을 조회합니다.\n",
         "operationId": "getPaymentStatusByPaymentClientChart",
         "requestBody": {
           "content": {
@@ -7764,7 +7764,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 결제환경별 결제전환율 조회 결과를 반환합니다.</p>\n",
+            "description": "성공 응답으로 결제환경별 결제전환율 조회 결과를 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -7772,7 +7772,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 결제환경별 결제전환율 조회 결과를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 결제환경별 결제전환율 조회 결과를 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -7814,7 +7814,7 @@
           }
         ],
         "x-portone-category": "analytics",
-        "x-portone-description": "<p>가맹점의 결제환경별 결제전환율을 조회합니다.</p>\n",
+        "x-portone-description": "가맹점의 결제환경별 결제전환율을 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPaymentStatusByPaymentClientChartError"
         },
@@ -7823,14 +7823,14 @@
     },
     "/b2b-preview/member-companies/{brn}": {
       "get": {
-        "summary": "<p>연동 사업자 조회</p>\n",
-        "description": "<p>연동 사업자 조회</p>\n<p>포트원 B2B 서비스에 연동된 사업자를 조회합니다.</p>\n",
+        "summary": "연동 사업자 조회\n",
+        "description": "연동 사업자 조회\n포트원 B2B 서비스에 연동된 사업자를 조회합니다.\n",
         "operationId": "getB2bMemberCompany",
         "parameters": [
           {
             "name": "brn",
             "in": "path",
-            "description": "<p>사업자등록번호</p>\n",
+            "description": "사업자등록번호\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -7840,18 +7840,18 @@
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n"
           }
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 사업자 객체를 반환합니다.</p>\n",
+            "description": "성공 응답으로 사업자 객체를 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -7859,7 +7859,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 사업자 객체를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 사업자 객체를 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -7922,7 +7922,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "연동 사업자 조회",
-        "x-portone-description": "<p>포트원 B2B 서비스에 연동된 사업자를 조회합니다.</p>\n",
+        "x-portone-description": "포트원 B2B 서비스에 연동된 사업자를 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetB2bMemberCompanyError"
         },
@@ -7931,20 +7931,20 @@
     },
     "/b2b-preview/member-companies": {
       "post": {
-        "summary": "<p>사업자 연동</p>\n",
-        "description": "<p>사업자 연동</p>\n<p>포트원 B2B 서비스에 사업자를 연동합니다.</p>\n",
+        "summary": "사업자 연동\n",
+        "description": "사업자 연동\n포트원 B2B 서비스에 사업자를 연동합니다.\n",
         "operationId": "registerB2bMemberCompany",
         "parameters": [
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n"
           }
         ],
         "requestBody": {
@@ -7959,7 +7959,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -8020,7 +8020,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "사업자 연동",
-        "x-portone-description": "<p>포트원 B2B 서비스에 사업자를 연동합니다.</p>\n",
+        "x-portone-description": "포트원 B2B 서비스에 사업자를 연동합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/RegisterB2bMemberCompanyError"
         },
@@ -8029,14 +8029,14 @@
     },
     "/b2b-preview/member-companies/{brn}/contacts/{contactId}": {
       "get": {
-        "summary": "<p>담당자 조회</p>\n",
-        "description": "<p>담당자 조회</p>\n<p>연동 사업자에 등록된 담당자를 조회합니다.</p>\n",
+        "summary": "담당자 조회\n",
+        "description": "담당자 조회\n연동 사업자에 등록된 담당자를 조회합니다.\n",
         "operationId": "getB2bMemberCompanyContact",
         "parameters": [
           {
             "name": "brn",
             "in": "path",
-            "description": "<p>사업자등록번호</p>\n",
+            "description": "사업자등록번호\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -8046,7 +8046,7 @@
           {
             "name": "contactId",
             "in": "path",
-            "description": "<p>담당자 ID</p>\n",
+            "description": "담당자 ID\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -8056,18 +8056,18 @@
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n"
           }
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 담당자 객체를 반환합니다.</p>\n",
+            "description": "성공 응답으로 담당자 객체를 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -8075,7 +8075,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 담당자 객체를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 담당자 객체를 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -8138,7 +8138,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "담당자 조회",
-        "x-portone-description": "<p>연동 사업자에 등록된 담당자를 조회합니다.</p>\n",
+        "x-portone-description": "연동 사업자에 등록된 담당자를 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetB2bMemberCompanyContactError"
         },
@@ -8147,14 +8147,14 @@
     },
     "/b2b-preview/member-companies/{brn}/certificate/registration-url": {
       "get": {
-        "summary": "<p>사업자 인증서 등록 URL 조회</p>\n",
-        "description": "<p>사업자 인증서 등록 URL 조회</p>\n<p>연동 사업자의 인증서를 등록하기 위한 URL을 조회합니다.</p>\n",
+        "summary": "사업자 인증서 등록 URL 조회\n",
+        "description": "사업자 인증서 등록 URL 조회\n연동 사업자의 인증서를 등록하기 위한 URL을 조회합니다.\n",
         "operationId": "getB2bCertificateRegistrationUrl",
         "parameters": [
           {
             "name": "brn",
             "in": "path",
-            "description": "<p>사업자등록번호</p>\n",
+            "description": "사업자등록번호\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -8164,18 +8164,18 @@
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n"
           }
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 URL을 반환합니다.</p>\n",
+            "description": "성공 응답으로 URL을 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -8183,7 +8183,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 URL을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 URL을 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -8246,7 +8246,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "사업자 인증서 등록 URL 조회",
-        "x-portone-description": "<p>연동 사업자의 인증서를 등록하기 위한 URL을 조회합니다.</p>\n",
+        "x-portone-description": "연동 사업자의 인증서를 등록하기 위한 URL을 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetB2bCertificateRegistrationUrlError"
         },
@@ -8255,14 +8255,14 @@
     },
     "/b2b-preview/member-companies/{brn}/certificate": {
       "get": {
-        "summary": "<p>인증서 조회</p>\n",
-        "description": "<p>인증서 조회</p>\n<p>연동 사업자의 인증서를 조회합니다.</p>\n",
+        "summary": "인증서 조회\n",
+        "description": "인증서 조회\n연동 사업자의 인증서를 조회합니다.\n",
         "operationId": "getB2bCertificate",
         "parameters": [
           {
             "name": "brn",
             "in": "path",
-            "description": "<p>사업자등록번호</p>\n",
+            "description": "사업자등록번호\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -8272,18 +8272,18 @@
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n"
           }
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 인증서 객체를 반환합니다.</p>\n",
+            "description": "성공 응답으로 인증서 객체를 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -8291,7 +8291,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 인증서 객체를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 인증서 객체를 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -8354,7 +8354,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "인증서 조회",
-        "x-portone-description": "<p>연동 사업자의 인증서를 조회합니다.</p>\n",
+        "x-portone-description": "연동 사업자의 인증서를 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetB2bCertificateError"
         },
@@ -8363,14 +8363,14 @@
     },
     "/b2b-preview/member-companies/contacts/id-existence": {
       "get": {
-        "summary": "<p>담당자 ID 존재 여부 확인</p>\n",
-        "description": "<p>담당자 ID 존재 여부 확인</p>\n<p>담당자 ID가 이미 사용중인지 확인합니다.</p>\n",
+        "summary": "담당자 ID 존재 여부 확인\n",
+        "description": "담당자 ID 존재 여부 확인\n담당자 ID가 이미 사용중인지 확인합니다.\n",
         "operationId": "getB2bContactIdExistence",
         "parameters": [
           {
             "name": "contactId",
             "in": "query",
-            "description": "<p>담당자 ID</p>\n",
+            "description": "담당자 ID\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -8380,18 +8380,18 @@
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n"
           }
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답입니다.</p>\n",
+            "description": "성공 응답입니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -8399,7 +8399,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답입니다.</p>\n"
+            "x-portone-description": "성공 응답입니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -8452,7 +8452,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "담당자 ID 존재 여부 확인",
-        "x-portone-description": "<p>담당자 ID가 이미 사용중인지 확인합니다.</p>\n",
+        "x-portone-description": "담당자 ID가 이미 사용중인지 확인합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/getB2bContactIdExistenceError"
         },
@@ -8461,14 +8461,14 @@
     },
     "/b2b-preview/bank-accounts/{bank}/{accountNumber}/holder": {
       "get": {
-        "summary": "<p>예금주 조회</p>\n",
-        "description": "<p>예금주 조회</p>\n<p>원하는 계좌의 예금주를 조회합니다.</p>\n",
+        "summary": "예금주 조회\n",
+        "description": "예금주 조회\n원하는 계좌의 예금주를 조회합니다.\n",
         "operationId": "getB2bBankAccountHolder",
         "parameters": [
           {
             "name": "bank",
             "in": "path",
-            "description": "<p>은행</p>\n",
+            "description": "은행\n",
             "required": true,
             "schema": {
               "$ref": "#/components/schemas/Bank"
@@ -8478,7 +8478,7 @@
           {
             "name": "accountNumber",
             "in": "path",
-            "description": "<p>'-'를 제외한 계좌 번호</p>\n",
+            "description": "'-'를 제외한 계좌 번호\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -8488,18 +8488,18 @@
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n"
           }
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -8507,7 +8507,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답</p>\n"
+            "x-portone-description": "성공 응답\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -8580,7 +8580,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "예금주 조회",
-        "x-portone-description": "<p>원하는 계좌의 예금주를 조회합니다.</p>\n",
+        "x-portone-description": "원하는 계좌의 예금주를 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetB2bAccountHolderError"
         },
@@ -8589,14 +8589,14 @@
     },
     "/b2b-preview/company/{brn}/state": {
       "get": {
-        "summary": "<p>사업자 상태 조회</p>\n",
-        "description": "<p>사업자 상태 조회</p>\n<p>원하는 사업자의 상태를 조회합니다. 포트원 B2B 서비스에 연동 및 등록되지 않은 사업자도 조회 가능합니다.</p>\n",
+        "summary": "사업자 상태 조회\n",
+        "description": "사업자 상태 조회\n원하는 사업자의 상태를 조회합니다. 포트원 B2B 서비스에 연동 및 등록되지 않은 사업자도 조회 가능합니다.\n",
         "operationId": "getB2bCompanyState",
         "parameters": [
           {
             "name": "brn",
             "in": "path",
-            "description": "<p>사업자등록번호</p>\n",
+            "description": "사업자등록번호\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -8606,18 +8606,18 @@
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n"
           }
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 사업자 상태 객체를 반환합니다.</p>\n",
+            "description": "성공 응답으로 사업자 상태 객체를 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -8625,7 +8625,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 사업자 상태 객체를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 사업자 상태 객체를 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -8688,7 +8688,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "사업자 상태 조회",
-        "x-portone-description": "<p>원하는 사업자의 상태를 조회합니다. 포트원 B2B 서비스에 연동 및 등록되지 않은 사업자도 조회 가능합니다.</p>\n",
+        "x-portone-description": "원하는 사업자의 상태를 조회합니다. 포트원 B2B 서비스에 연동 및 등록되지 않은 사업자도 조회 가능합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetB2bCompanyStateError"
         },
@@ -8697,20 +8697,20 @@
     },
     "/b2b-preview/tax-invoices/request-reverse-issuance": {
       "post": {
-        "summary": "<p>세금계산서 역발행 요청</p>\n",
-        "description": "<p>세금계산서 역발행 요청</p>\n<p>공급자에게 세금계산서 역발행을 요청합니다.</p>\n",
+        "summary": "세금계산서 역발행 요청\n",
+        "description": "세금계산서 역발행 요청\n공급자에게 세금계산서 역발행을 요청합니다.\n",
         "operationId": "requestB2bTaxInvoiceReverseIssuance",
         "parameters": [
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n"
           }
         ],
         "requestBody": {
@@ -8725,7 +8725,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 세금계산서를 반환합니다.</p>\n",
+            "description": "성공 응답으로 세금계산서를 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -8733,7 +8733,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 세금계산서를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 세금계산서를 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -8796,7 +8796,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "세금계산서 역발행 요청",
-        "x-portone-description": "<p>공급자에게 세금계산서 역발행을 요청합니다.</p>\n",
+        "x-portone-description": "공급자에게 세금계산서 역발행을 요청합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/RequestB2bTaxInvoiceReverseIssuanceError"
         },
@@ -8805,14 +8805,14 @@
     },
     "/b2b-preview/tax-invoices/{documentKey}": {
       "get": {
-        "summary": "<p>세금 계산서 조회</p>\n",
-        "description": "<p>세금 계산서 조회</p>\n<p>등록된 세금 계산서를 공급자 혹은 공급받는자 문서번호로 조회합니다.</p>\n",
+        "summary": "세금 계산서 조회\n",
+        "description": "세금 계산서 조회\n등록된 세금 계산서를 공급자 혹은 공급받는자 문서번호로 조회합니다.\n",
         "operationId": "getB2bTaxInvoice",
         "parameters": [
           {
             "name": "documentKey",
             "in": "path",
-            "description": "<p>세금계산서 문서 번호</p>\n",
+            "description": "세금계산서 문서 번호\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -8822,7 +8822,7 @@
           {
             "name": "brn",
             "in": "query",
-            "description": "<p>사업자등록번호</p>\n",
+            "description": "사업자등록번호\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -8832,29 +8832,29 @@
           {
             "name": "documentKeyType",
             "in": "query",
-            "description": "<p>문서 번호 유형</p>\n<p>path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.</p>\n",
+            "description": "문서 번호 유형\npath 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.\n",
             "required": false,
             "schema": {
               "$ref": "#/components/schemas/B2bTaxInvoiceDocumentKeyType"
             },
             "x-portone-title": "문서 번호 유형",
-            "x-portone-description": "<p>path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.</p>\n"
+            "x-portone-description": "path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.\n"
           },
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n"
           }
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 세금계산서를 반환합니다.</p>\n",
+            "description": "성공 응답으로 세금계산서를 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -8862,7 +8862,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 세금계산서를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 세금계산서를 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -8925,21 +8925,21 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "세금 계산서 조회",
-        "x-portone-description": "<p>등록된 세금 계산서를 공급자 혹은 공급받는자 문서번호로 조회합니다.</p>\n",
+        "x-portone-description": "등록된 세금 계산서를 공급자 혹은 공급받는자 문서번호로 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetB2bTaxInvoiceError"
         },
         "x-portone-unstable": true
       },
       "delete": {
-        "summary": "<p>세금계산서 삭제</p>\n",
-        "description": "<p>세금계산서 삭제</p>\n<p>세금계산서를 삭제합니다.</p>\n",
+        "summary": "세금계산서 삭제\n",
+        "description": "세금계산서 삭제\n세금계산서를 삭제합니다.\n",
         "operationId": "deleteB2bTaxInvoice",
         "parameters": [
           {
             "name": "documentKey",
             "in": "path",
-            "description": "<p>세금계산서 문서 번호</p>\n",
+            "description": "세금계산서 문서 번호\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -8949,7 +8949,7 @@
           {
             "name": "brn",
             "in": "query",
-            "description": "<p>사업자등록번호</p>\n",
+            "description": "사업자등록번호\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -8959,24 +8959,24 @@
           {
             "name": "documentKeyType",
             "in": "query",
-            "description": "<p>문서 번호 유형</p>\n<p>path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.</p>\n",
+            "description": "문서 번호 유형\npath 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.\n",
             "required": false,
             "schema": {
               "$ref": "#/components/schemas/B2bTaxInvoiceDocumentKeyType"
             },
             "x-portone-title": "문서 번호 유형",
-            "x-portone-description": "<p>path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.</p>\n"
+            "x-portone-description": "path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.\n"
           },
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n"
           }
         ],
         "responses": {
@@ -9044,7 +9044,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "세금계산서 삭제",
-        "x-portone-description": "<p>세금계산서를 삭제합니다.</p>\n",
+        "x-portone-description": "세금계산서를 삭제합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/DeleteB2bTaxInvoiceError"
         },
@@ -9053,20 +9053,20 @@
     },
     "/b2b-preview/tax-invoices/issue": {
       "post": {
-        "summary": "<p>세금계산서 발행</p>\n",
-        "description": "<p>세금계산서 발행</p>\n<p>역발행의 경우 역발행요청(REQUESTED) 상태, 정발행의 경우 임시저장(REGISTERED) 상태의 세금계산서를 발행합니다.</p>\n",
+        "summary": "세금계산서 발행\n",
+        "description": "세금계산서 발행\n역발행의 경우 역발행요청(REQUESTED) 상태, 정발행의 경우 임시저장(REGISTERED) 상태의 세금계산서를 발행합니다.\n",
         "operationId": "issueB2bTaxInvoice",
         "parameters": [
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n"
           }
         ],
         "requestBody": {
@@ -9081,7 +9081,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 세금계산서를 반환합니다.</p>\n",
+            "description": "성공 응답으로 세금계산서를 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -9089,7 +9089,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 세금계산서를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 세금계산서를 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n<li><code>B2bTaxInvoiceNotRequestedStatusError</code>: 세금계산서가 역발행 대기 상태가 아닌 경우</li>\n</ul>\n",
@@ -9152,7 +9152,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "세금계산서 발행",
-        "x-portone-description": "<p>역발행의 경우 역발행요청(REQUESTED) 상태, 정발행의 경우 임시저장(REGISTERED) 상태의 세금계산서를 발행합니다.</p>\n",
+        "x-portone-description": "역발행의 경우 역발행요청(REQUESTED) 상태, 정발행의 경우 임시저장(REGISTERED) 상태의 세금계산서를 발행합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/IssueB2bTaxInvoiceError"
         },
@@ -9161,20 +9161,20 @@
     },
     "/b2b-preview/tax-invoices/cancel-request": {
       "post": {
-        "summary": "<p>세금계산서 역발행 요청 취소</p>\n",
-        "description": "<p>세금계산서 역발행 요청 취소</p>\n<p>공급받는자가 공급자에게 세금계산서 역발행 요청한 것을 취소합니다.</p>\n",
+        "summary": "세금계산서 역발행 요청 취소\n",
+        "description": "세금계산서 역발행 요청 취소\n공급받는자가 공급자에게 세금계산서 역발행 요청한 것을 취소합니다.\n",
         "operationId": "cancelB2bTaxInvoiceRequest",
         "parameters": [
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n"
           }
         ],
         "requestBody": {
@@ -9189,7 +9189,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 세금계산서를 반환합니다.</p>\n",
+            "description": "성공 응답으로 세금계산서를 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -9197,7 +9197,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 세금계산서를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 세금계산서를 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n<li><code>B2bTaxInvoiceNotRequestedStatusError</code>: 세금계산서가 역발행 대기 상태가 아닌 경우</li>\n<li><code>B2bTaxInvoiceNoRecipientDocumentKeyError</code>: 세금계산서에 공급받는자 문서 번호가 기입되지 않은 경우</li>\n</ul>\n",
@@ -9260,7 +9260,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "세금계산서 역발행 요청 취소",
-        "x-portone-description": "<p>공급받는자가 공급자에게 세금계산서 역발행 요청한 것을 취소합니다.</p>\n",
+        "x-portone-description": "공급받는자가 공급자에게 세금계산서 역발행 요청한 것을 취소합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/CancelB2bTaxInvoiceRequestError"
         },
@@ -9269,20 +9269,20 @@
     },
     "/b2b-preview/tax-invoices/cancel-issuance": {
       "post": {
-        "summary": "<p>세금계산서 역발행 취소</p>\n",
-        "description": "<p>세금계산서 역발행 취소</p>\n<p>공급자가 발행 완료한 세금계산서를 국세청 전송 전 취소합니다.</p>\n",
+        "summary": "세금계산서 역발행 취소\n",
+        "description": "세금계산서 역발행 취소\n공급자가 발행 완료한 세금계산서를 국세청 전송 전 취소합니다.\n",
         "operationId": "cancelB2bTaxInvoiceIssuance",
         "parameters": [
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n"
           }
         ],
         "requestBody": {
@@ -9297,7 +9297,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 세금계산서를 반환합니다.</p>\n",
+            "description": "성공 응답으로 세금계산서를 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -9305,7 +9305,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 세금계산서를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 세금계산서를 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n<li><code>B2bTaxInvoiceNotIssuedStatusError</code>: 세금계산서가 발행된(ISSUED) 상태가 아닌 경우</li>\n</ul>\n",
@@ -9358,7 +9358,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "세금계산서 역발행 취소",
-        "x-portone-description": "<p>공급자가 발행 완료한 세금계산서를 국세청 전송 전 취소합니다.</p>\n",
+        "x-portone-description": "공급자가 발행 완료한 세금계산서를 국세청 전송 전 취소합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/CancelB2bTaxInvoiceIssuanceError"
         },
@@ -9367,20 +9367,20 @@
     },
     "/b2b-preview/tax-invoices/refuse-request": {
       "post": {
-        "summary": "<p>세금계산서 역발행 요청 거부</p>\n",
-        "description": "<p>세금계산서 역발행 요청 거부</p>\n<p>공급자가 공급받는자로부터 요청받은 세금계산서 역발행 건을 거부합니다.</p>\n",
+        "summary": "세금계산서 역발행 요청 거부\n",
+        "description": "세금계산서 역발행 요청 거부\n공급자가 공급받는자로부터 요청받은 세금계산서 역발행 건을 거부합니다.\n",
         "operationId": "refuseB2bTaxInvoiceRequest",
         "parameters": [
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n"
           }
         ],
         "requestBody": {
@@ -9395,7 +9395,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 세금계산서를 반환합니다.</p>\n",
+            "description": "성공 응답으로 세금계산서를 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -9403,7 +9403,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 세금계산서를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 세금계산서를 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n<li><code>B2bTaxInvoiceNotRequestedStatusError</code>: 세금계산서가 역발행 대기 상태가 아닌 경우</li>\n<li><code>B2bTaxInvoiceNoSupplierDocumentKeyError</code>: 세금계산서에 공급자 문서 번호가 기입되지 않은 경우</li>\n</ul>\n",
@@ -9466,7 +9466,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "세금계산서 역발행 요청 거부",
-        "x-portone-description": "<p>공급자가 공급받는자로부터 요청받은 세금계산서 역발행 건을 거부합니다.</p>\n",
+        "x-portone-description": "공급자가 공급받는자로부터 요청받은 세금계산서 역발행 건을 거부합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/RefuseB2bTaxInvoiceRequestError"
         },
@@ -9475,14 +9475,14 @@
     },
     "/b2b-preview/tax-invoices": {
       "get": {
-        "summary": "<p>세금 계산서 다건조회</p>\n",
-        "description": "<p>세금 계산서 다건조회</p>\n<p>조회 기간 내 등록된 세금 계산서를 다건 조회합니다.</p>\n",
+        "summary": "세금 계산서 다건조회\n",
+        "description": "세금 계산서 다건조회\n조회 기간 내 등록된 세금 계산서를 다건 조회합니다.\n",
         "operationId": "getB2bTaxInvoices",
         "parameters": [
           {
             "name": "brn",
             "in": "query",
-            "description": "<p>사업자등록번호</p>\n",
+            "description": "사업자등록번호\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -9492,55 +9492,55 @@
           {
             "name": "pageNumber",
             "in": "query",
-            "description": "<p>페이지 번호</p>\n<p>0부터 시작하는 페이지 번호. 기본 값은 0.</p>\n",
+            "description": "페이지 번호\n0부터 시작하는 페이지 번호. 기본 값은 0.\n",
             "required": false,
             "schema": {
               "type": "integer",
               "format": "int32"
             },
             "x-portone-title": "페이지 번호",
-            "x-portone-description": "<p>0부터 시작하는 페이지 번호. 기본 값은 0.</p>\n"
+            "x-portone-description": "0부터 시작하는 페이지 번호. 기본 값은 0.\n"
           },
           {
             "name": "pageSize",
             "in": "query",
-            "description": "<p>페이지 크기</p>\n<p>각 페이지 당 포함할 객체 수. 기본 값은 500이며 최대 1000까지 요청가능합니다.</p>\n",
+            "description": "페이지 크기\n각 페이지 당 포함할 객체 수. 기본 값은 500이며 최대 1000까지 요청가능합니다.\n",
             "required": false,
             "schema": {
               "type": "integer",
               "format": "int32"
             },
             "x-portone-title": "페이지 크기",
-            "x-portone-description": "<p>각 페이지 당 포함할 객체 수. 기본 값은 500이며 최대 1000까지 요청가능합니다.</p>\n"
+            "x-portone-description": "각 페이지 당 포함할 객체 수. 기본 값은 500이며 최대 1000까지 요청가능합니다.\n"
           },
           {
             "name": "from",
             "in": "query",
-            "description": "<p>조회 시작일</p>\n",
+            "description": "조회 시작일\n",
             "required": true,
             "schema": {
               "type": "string",
-              "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-              "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n"
+              "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+              "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n"
             },
             "x-portone-title": "조회 시작일"
           },
           {
             "name": "until",
             "in": "query",
-            "description": "<p>조회 종료일</p>\n",
+            "description": "조회 종료일\n",
             "required": true,
             "schema": {
               "type": "string",
-              "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-              "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n"
+              "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+              "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n"
             },
             "x-portone-title": "조회 종료일"
           },
           {
             "name": "dateType",
             "in": "query",
-            "description": "<p>조회 기간 기준</p>\n",
+            "description": "조회 기간 기준\n",
             "required": true,
             "schema": {
               "$ref": "#/components/schemas/B2bSearchDateType"
@@ -9550,24 +9550,24 @@
           {
             "name": "documentKeyType",
             "in": "query",
-            "description": "<p>문서 번호 유형</p>\n<p>path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.</p>\n",
+            "description": "문서 번호 유형\npath 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.\n",
             "required": false,
             "schema": {
               "$ref": "#/components/schemas/B2bTaxInvoiceDocumentKeyType"
             },
             "x-portone-title": "문서 번호 유형",
-            "x-portone-description": "<p>path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.</p>\n"
+            "x-portone-description": "path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.\n"
           },
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n"
           }
         ],
         "responses": {
@@ -9632,7 +9632,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "세금 계산서 다건조회",
-        "x-portone-description": "<p>조회 기간 내 등록된 세금 계산서를 다건 조회합니다.</p>\n",
+        "x-portone-description": "조회 기간 내 등록된 세금 계산서를 다건 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetB2bTaxInvoicesError"
         },
@@ -9641,14 +9641,14 @@
     },
     "/b2b-preview/tax-invoices/{documentKey}/popup-url": {
       "get": {
-        "summary": "<p>세금 계산서 팝업 URL 조회</p>\n",
-        "description": "<p>세금 계산서 팝업 URL 조회</p>\n<p>등록된 세금 계산서 팝업 URL을 공급자 혹은 공급받는자 문서번호로 조회합니다.</p>\n",
+        "summary": "세금 계산서 팝업 URL 조회\n",
+        "description": "세금 계산서 팝업 URL 조회\n등록된 세금 계산서 팝업 URL을 공급자 혹은 공급받는자 문서번호로 조회합니다.\n",
         "operationId": "getB2bTaxInvoicePopupUrl",
         "parameters": [
           {
             "name": "documentKey",
             "in": "path",
-            "description": "<p>세금계산서 문서 번호</p>\n",
+            "description": "세금계산서 문서 번호\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -9658,7 +9658,7 @@
           {
             "name": "brn",
             "in": "query",
-            "description": "<p>사업자등록번호</p>\n",
+            "description": "사업자등록번호\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -9668,35 +9668,35 @@
           {
             "name": "documentKeyType",
             "in": "query",
-            "description": "<p>문서 번호 유형</p>\n<p>path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.</p>\n",
+            "description": "문서 번호 유형\npath 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.\n",
             "required": false,
             "schema": {
               "$ref": "#/components/schemas/B2bTaxInvoiceDocumentKeyType"
             },
             "x-portone-title": "문서 번호 유형",
-            "x-portone-description": "<p>path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.</p>\n"
+            "x-portone-description": "path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.\n"
           },
           {
             "name": "includeMenu",
             "in": "query",
-            "description": "<p>메뉴 포함 여부</p>\n<p>팝업 URL에 메뉴 레이아웃을 포함 여부를 결정합니다. 기본 값은 true입니다.</p>\n",
+            "description": "메뉴 포함 여부\n팝업 URL에 메뉴 레이아웃을 포함 여부를 결정합니다. 기본 값은 true입니다.\n",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "메뉴 포함 여부",
-            "x-portone-description": "<p>팝업 URL에 메뉴 레이아웃을 포함 여부를 결정합니다. 기본 값은 true입니다.</p>\n"
+            "x-portone-description": "팝업 URL에 메뉴 레이아웃을 포함 여부를 결정합니다. 기본 값은 true입니다.\n"
           },
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n"
           }
         ],
         "responses": {
@@ -9771,7 +9771,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "세금 계산서 팝업 URL 조회",
-        "x-portone-description": "<p>등록된 세금 계산서 팝업 URL을 공급자 혹은 공급받는자 문서번호로 조회합니다.</p>\n",
+        "x-portone-description": "등록된 세금 계산서 팝업 URL을 공급자 혹은 공급받는자 문서번호로 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetB2bTaxInvoicePopupUrlError"
         },
@@ -9780,14 +9780,14 @@
     },
     "/b2b-preview/tax-invoices/{documentKey}/print-url": {
       "get": {
-        "summary": "<p>세금 계산서 프린트 URL 조회</p>\n",
-        "description": "<p>세금 계산서 프린트 URL 조회</p>\n<p>등록된 세금 계산서 프린트 URL을 공급자 혹은 공급받는자 문서번호로 조회합니다.</p>\n",
+        "summary": "세금 계산서 프린트 URL 조회\n",
+        "description": "세금 계산서 프린트 URL 조회\n등록된 세금 계산서 프린트 URL을 공급자 혹은 공급받는자 문서번호로 조회합니다.\n",
         "operationId": "getB2bTaxInvoicePrintUrl",
         "parameters": [
           {
             "name": "documentKey",
             "in": "path",
-            "description": "<p>세금계산서 문서 번호</p>\n",
+            "description": "세금계산서 문서 번호\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -9797,7 +9797,7 @@
           {
             "name": "brn",
             "in": "query",
-            "description": "<p>사업자등록번호</p>\n",
+            "description": "사업자등록번호\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -9807,24 +9807,24 @@
           {
             "name": "documentKeyType",
             "in": "query",
-            "description": "<p>문서 번호 유형</p>\n<p>path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.</p>\n",
+            "description": "문서 번호 유형\npath 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.\n",
             "required": false,
             "schema": {
               "$ref": "#/components/schemas/B2bTaxInvoiceDocumentKeyType"
             },
             "x-portone-title": "문서 번호 유형",
-            "x-portone-description": "<p>path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.</p>\n"
+            "x-portone-description": "path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.\n"
           },
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n"
           }
         ],
         "responses": {
@@ -9899,7 +9899,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "세금 계산서 프린트 URL 조회",
-        "x-portone-description": "<p>등록된 세금 계산서 프린트 URL을 공급자 혹은 공급받는자 문서번호로 조회합니다.</p>\n",
+        "x-portone-description": "등록된 세금 계산서 프린트 URL을 공급자 혹은 공급받는자 문서번호로 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetB2bTaxInvoicePrintUrlError"
         },
@@ -9908,14 +9908,14 @@
     },
     "/b2b-preview/tax-invoices/{documentKey}/pdf-download-url": {
       "get": {
-        "summary": "<p>세금 계산서 PDF 다운로드 URL 조회</p>\n",
-        "description": "<p>세금 계산서 PDF 다운로드 URL 조회</p>\n<p>등록된 세금 계산서 PDF 다운로드 URL을 공급자 혹은 공급받는자 문서번호로 조회합니다.</p>\n",
+        "summary": "세금 계산서 PDF 다운로드 URL 조회\n",
+        "description": "세금 계산서 PDF 다운로드 URL 조회\n등록된 세금 계산서 PDF 다운로드 URL을 공급자 혹은 공급받는자 문서번호로 조회합니다.\n",
         "operationId": "getB2bTaxInvoicePdfDownloadUrl",
         "parameters": [
           {
             "name": "documentKey",
             "in": "path",
-            "description": "<p>세금계산서 문서 번호</p>\n",
+            "description": "세금계산서 문서 번호\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -9925,7 +9925,7 @@
           {
             "name": "brn",
             "in": "query",
-            "description": "<p>사업자등록번호</p>\n",
+            "description": "사업자등록번호\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -9935,24 +9935,24 @@
           {
             "name": "documentKeyType",
             "in": "query",
-            "description": "<p>문서 번호 유형</p>\n<p>path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.</p>\n",
+            "description": "문서 번호 유형\npath 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.\n",
             "required": false,
             "schema": {
               "$ref": "#/components/schemas/B2bTaxInvoiceDocumentKeyType"
             },
             "x-portone-title": "문서 번호 유형",
-            "x-portone-description": "<p>path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.</p>\n"
+            "x-portone-description": "path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.\n"
           },
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n"
           }
         ],
         "responses": {
@@ -10027,7 +10027,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "세금 계산서 PDF 다운로드 URL 조회",
-        "x-portone-description": "<p>등록된 세금 계산서 PDF 다운로드 URL을 공급자 혹은 공급받는자 문서번호로 조회합니다.</p>\n",
+        "x-portone-description": "등록된 세금 계산서 PDF 다운로드 URL을 공급자 혹은 공급받는자 문서번호로 조회합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetB2bTaxInvoicePdfDownloadUrlError"
         },
@@ -10036,20 +10036,20 @@
     },
     "/b2b-preview/tax-invoices/register": {
       "post": {
-        "summary": "<p>세금계산서 임시 저장</p>\n",
-        "description": "<p>세금계산서 임시 저장</p>\n<p>세금계산서 임시 저장을 요청합니다.</p>\n",
+        "summary": "세금계산서 임시 저장\n",
+        "description": "세금계산서 임시 저장\n세금계산서 임시 저장을 요청합니다.\n",
         "operationId": "requestB2bTaxInvoiceRegister",
         "parameters": [
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n"
           }
         ],
         "requestBody": {
@@ -10064,7 +10064,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 세금계산서를 반환합니다.</p>\n",
+            "description": "성공 응답으로 세금계산서를 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -10072,7 +10072,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 세금계산서를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 세금계산서를 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
@@ -10135,7 +10135,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "세금계산서 임시 저장",
-        "x-portone-description": "<p>세금계산서 임시 저장을 요청합니다.</p>\n",
+        "x-portone-description": "세금계산서 임시 저장을 요청합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/RequestB2bTaxInvoiceRegisterError"
         },
@@ -10144,20 +10144,20 @@
     },
     "/b2b-preview/tax-invoices/request": {
       "post": {
-        "summary": "<p>세금계산서 역발행 요청</p>\n",
-        "description": "<p>세금계산서 역발행 요청</p>\n<p>임시저장(REGISTERED) 상태의 역발행 세금계산서를 공급자에게 발행 요청합니다.</p>\n",
+        "summary": "세금계산서 역발행 요청\n",
+        "description": "세금계산서 역발행 요청\n임시저장(REGISTERED) 상태의 역발행 세금계산서를 공급자에게 발행 요청합니다.\n",
         "operationId": "requestB2bTaxInvoice",
         "parameters": [
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.\n"
           }
         ],
         "requestBody": {
@@ -10172,7 +10172,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 세금계산서를 반환합니다.</p>\n",
+            "description": "성공 응답으로 세금계산서를 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -10180,7 +10180,7 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 세금계산서를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 세금계산서를 반환합니다.\n"
           },
           "400": {
             "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n<li><code>B2bTaxInvoiceNotRegisteredStatusError</code>: 세금계산서가 임시저장 상태가 아닌 경우</li>\n<li><code>B2bTaxInvoiceNoRecipientDocumentKeyError</code>: 세금계산서에 공급받는자 문서 번호가 기입되지 않은 경우</li>\n</ul>\n",
@@ -10243,7 +10243,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "세금계산서 역발행 요청",
-        "x-portone-description": "<p>임시저장(REGISTERED) 상태의 역발행 세금계산서를 공급자에게 발행 요청합니다.</p>\n",
+        "x-portone-description": "임시저장(REGISTERED) 상태의 역발행 세금계산서를 공급자에게 발행 요청합니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/requestB2bTaxInvoiceError"
         },
@@ -10252,14 +10252,14 @@
     },
     "/kakaopay/payment/order": {
       "get": {
-        "summary": "<p>카카오페이 주문 조회 API</p>\n",
-        "description": "<p>카카오페이 주문 조회 API</p>\n<p>주어진 아이디에 대응되는 카카오페이 주문 건을 조회합니다.\n해당 API 사용이 필요한 경우 포트원 기술지원팀으로 문의 주시길 바랍니다.</p>\n",
+        "summary": "카카오페이 주문 조회 API\n",
+        "description": "카카오페이 주문 조회 API\n주어진 아이디에 대응되는 카카오페이 주문 건을 조회합니다.\n해당 API 사용이 필요한 경우 포트원 기술지원팀으로 문의 주시길 바랍니다.\n",
         "operationId": "GetKakaopayPaymentOrder",
         "parameters": [
           {
             "name": "pgTxId",
             "in": "query",
-            "description": "<p>카카오페이 주문 번호 (tid)</p>\n",
+            "description": "카카오페이 주문 번호 (tid)\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -10269,7 +10269,7 @@
           {
             "name": "channelKey",
             "in": "query",
-            "description": "<p>채널키</p>\n",
+            "description": "채널키\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -10279,7 +10279,7 @@
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 카카오페이 주문 조회 응답 객체를 반환합니다.</p>\n",
+            "description": "성공 응답으로 카카오페이 주문 조회 응답 객체를 반환합니다.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -10320,7 +10320,7 @@
         ],
         "x-portone-category": "pgSpecific",
         "x-portone-title": "카카오페이 주문 조회 API",
-        "x-portone-description": "<p>주어진 아이디에 대응되는 카카오페이 주문 건을 조회합니다.\n해당 API 사용이 필요한 경우 포트원 기술지원팀으로 문의 주시길 바랍니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 카카오페이 주문 건을 조회합니다.\n해당 API 사용이 필요한 경우 포트원 기술지원팀으로 문의 주시길 바랍니다.\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetKakaopayPaymentOrderError"
         }
@@ -10328,14 +10328,14 @@
     },
     "/payments/{paymentId}/register-store-receipt": {
       "post": {
-        "summary": "<p>영수증 내 하위 상점 거래 등록 API</p>\n",
-        "description": "<p>영수증 내 하위 상점 거래 등록 API</p>\n<p>결제 내역 매출전표에 하위 상점의 거래를 등록할 수 있는 API입니다.\n지원되는 PG사:\nKG이니시스(이용 전 콘솔 -&gt; 결제연동 탭에서 INIApi Key 등록 필요)</p>\n",
+        "summary": "영수증 내 하위 상점 거래 등록 API\n",
+        "description": "영수증 내 하위 상점 거래 등록 API\n결제 내역 매출전표에 하위 상점의 거래를 등록할 수 있는 API입니다.\n지원되는 PG사:\nKG이니시스(이용 전 콘솔 -&gt; 결제연동 탭에서 INIApi Key 등록 필요)\n",
         "operationId": "registerStoreReceipt",
         "parameters": [
           {
             "name": "paymentId",
             "in": "path",
-            "description": "<p>등록할 하위 상점 결제 건 아이디</p>\n",
+            "description": "등록할 하위 상점 결제 건 아이디\n",
             "required": true,
             "schema": {
               "type": "string"
@@ -10355,7 +10355,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -10436,7 +10436,7 @@
         ],
         "x-portone-category": "payment",
         "x-portone-title": "영수증 내 하위 상점 거래 등록 API",
-        "x-portone-description": "<p>결제 내역 매출전표에 하위 상점의 거래를 등록할 수 있는 API입니다.\n지원되는 PG사:\nKG이니시스(이용 전 콘솔 -&gt; 결제연동 탭에서 INIApi Key 등록 필요)</p>\n",
+        "x-portone-description": "결제 내역 매출전표에 하위 상점의 거래를 등록할 수 있는 API입니다.\n지원되는 PG사:\nKG이니시스(이용 전 콘솔 -&gt; 결제연동 탭에서 INIApi Key 등록 필요)\n",
         "x-portone-error": {
           "$ref": "#/components/schemas/RegisterStoreReceiptError"
         }
@@ -10447,7 +10447,7 @@
     "schemas": {
       "Address": {
         "title": "분리 형식 주소",
-        "description": "<p>분리 형식 주소</p>\n<p>oneLine(한 줄 형식 주소) 필드는 항상 존재합니다.</p>\n",
+        "description": "분리 형식 주소\noneLine(한 줄 형식 주소) 필드는 항상 존재합니다.\n",
         "oneOf": [
           {
             "$ref": "#/components/schemas/OneLineAddress"
@@ -10464,7 +10464,7 @@
           }
         },
         "x-portone-title": "분리 형식 주소",
-        "x-portone-description": "<p>oneLine(한 줄 형식 주소) 필드는 항상 존재합니다.</p>\n",
+        "x-portone-description": "oneLine(한 줄 형식 주소) 필드는 항상 존재합니다.\n",
         "x-portone-discriminator": {
           "ONE_LINE": {
             "title": "한 줄 형식"
@@ -10488,7 +10488,7 @@
             "type": "string"
           }
         },
-        "description": "<p>결제가 이미 완료된 경우</p>\n",
+        "description": "결제가 이미 완료된 경우\n",
         "x-portone-title": "결제가 이미 완료된 경우",
         "x-portone-status-code": 409
       },
@@ -10506,7 +10506,7 @@
             "type": "string"
           }
         },
-        "description": "<p>결제가 이미 완료되었거나 대기중인 경우</p>\n",
+        "description": "결제가 이미 완료되었거나 대기중인 경우\n",
         "x-portone-title": "결제가 이미 완료되었거나 대기중인 경우",
         "x-portone-status-code": 409
       },
@@ -10531,7 +10531,7 @@
             "$ref": "#/components/schemas/AnalyticsAverageAmountChartSummary"
           }
         },
-        "description": "<p>고객사의 평균 거래액 현황 조회 응답</p>\n",
+        "description": "고객사의 평균 거래액 현황 조회 응답\n",
         "x-portone-title": "고객사의 평균 거래액 현황 조회 응답"
       },
       "AnalyticsAverageAmountChartStat": {
@@ -10558,8 +10558,8 @@
             "title": "고객 당 평균 거래액"
           }
         },
-        "description": "<p>특정 시점의 건별 평균 거래액, 고객 당 평균 거래액을 나타냅니다.</p>\n",
-        "x-portone-description": "<p>특정 시점의 건별 평균 거래액, 고객 당 평균 거래액을 나타냅니다.</p>\n"
+        "description": "특정 시점의 건별 평균 거래액, 고객 당 평균 거래액을 나타냅니다.\n",
+        "x-portone-description": "특정 시점의 건별 평균 거래액, 고객 당 평균 거래액을 나타냅니다.\n"
       },
       "AnalyticsAverageAmountChartSummary": {
         "required": [
@@ -10579,8 +10579,8 @@
             "title": "고객 당 평균 거래액"
           }
         },
-        "description": "<p>전체 구간의 건별 평균 거래액, 고객 당 평균 거래액을 나타냅니다.</p>\n",
-        "x-portone-description": "<p>전체 구간의 건별 평균 거래액, 고객 당 평균 거래액을 나타냅니다.</p>\n"
+        "description": "전체 구간의 건별 평균 거래액, 고객 당 평균 거래액을 나타냅니다.\n",
+        "x-portone-description": "전체 구간의 건별 평균 거래액, 고객 당 평균 거래액을 나타냅니다.\n"
       },
       "AnalyticsCancellationRate": {
         "title": "고객사의 환불율 정보",
@@ -10594,7 +10594,7 @@
             "format": "double"
           }
         },
-        "description": "<p>고객사의 환불율 정보</p>\n",
+        "description": "고객사의 환불율 정보\n",
         "x-portone-title": "고객사의 환불율 정보"
       },
       "AnalyticsCardChart": {
@@ -10611,7 +10611,7 @@
             }
           }
         },
-        "description": "<p>고객사의 카드결제 현황 차트 정보</p>\n",
+        "description": "고객사의 카드결제 현황 차트 정보\n",
         "x-portone-title": "고객사의 카드결제 현황 차트 정보"
       },
       "AnalyticsCardChartStat": {
@@ -10638,8 +10638,8 @@
             "title": "거래 건수"
           }
         },
-        "description": "<p>특정 시점의 카드결제 거래 건 수와 금액을 나타냅니다.</p>\n",
-        "x-portone-description": "<p>특정 시점의 카드결제 거래 건 수와 금액을 나타냅니다.</p>\n"
+        "description": "특정 시점의 카드결제 거래 건 수와 금액을 나타냅니다.\n",
+        "x-portone-description": "특정 시점의 카드결제 거래 건 수와 금액을 나타냅니다.\n"
       },
       "AnalyticsCardCompanyChart": {
         "title": "고객사의 카드사별 결제 현황 조회 응답",
@@ -10666,7 +10666,7 @@
             "$ref": "#/components/schemas/AnalyticsCardCompanyChartSummary"
           }
         },
-        "description": "<p>고객사의 카드사별 결제 현황 조회 응답</p>\n",
+        "description": "고객사의 카드사별 결제 현황 조회 응답\n",
         "x-portone-title": "고객사의 카드사별 결제 현황 조회 응답"
       },
       "AnalyticsCardCompanyChartRemainderStat": {
@@ -10693,8 +10693,8 @@
             "title": "결제 건수"
           }
         },
-        "description": "<p>특정 시점의 나머지 카드사들의 결제금액, 결제 건수를 나타냅니다.</p>\n",
-        "x-portone-description": "<p>특정 시점의 나머지 카드사들의 결제금액, 결제 건수를 나타냅니다.</p>\n"
+        "description": "특정 시점의 나머지 카드사들의 결제금액, 결제 건수를 나타냅니다.\n",
+        "x-portone-description": "특정 시점의 나머지 카드사들의 결제금액, 결제 건수를 나타냅니다.\n"
       },
       "AnalyticsCardCompanyChartStat": {
         "required": [
@@ -10725,8 +10725,8 @@
             "title": "결제 건수"
           }
         },
-        "description": "<p>특정 시점의 카드사 별 결제금액, 결제 건수를 나타냅니다.</p>\n",
-        "x-portone-description": "<p>특정 시점의 카드사 별 결제금액, 결제 건수를 나타냅니다.</p>\n"
+        "description": "특정 시점의 카드사 별 결제금액, 결제 건수를 나타냅니다.\n",
+        "x-portone-description": "특정 시점의 카드사 별 결제금액, 결제 건수를 나타냅니다.\n"
       },
       "AnalyticsCardCompanyChartSummary": {
         "required": [
@@ -10746,8 +10746,8 @@
             "title": "결제 건수 합"
           }
         },
-        "description": "<p>결제금액, 결제 건수의 총합을 나타냅니다.</p>\n",
-        "x-portone-description": "<p>결제금액, 결제 건수의 총합을 나타냅니다.</p>\n"
+        "description": "결제금액, 결제 건수의 총합을 나타냅니다.\n",
+        "x-portone-description": "결제금액, 결제 건수의 총합을 나타냅니다.\n"
       },
       "AnalyticsEasyPayChart": {
         "title": "고객사의 간편결제 현황 차트 정보",
@@ -10763,7 +10763,7 @@
             }
           }
         },
-        "description": "<p>고객사의 간편결제 현황 차트 정보</p>\n",
+        "description": "고객사의 간편결제 현황 차트 정보\n",
         "x-portone-title": "고객사의 간편결제 현황 차트 정보"
       },
       "AnalyticsEasyPayChartStat": {
@@ -10790,8 +10790,8 @@
             "title": "거래 건수"
           }
         },
-        "description": "<p>특정 시점의 간편결제 거래 건수와 금액을 나타냅니다.</p>\n",
-        "x-portone-description": "<p>특정 시점의 간편결제 거래 건수와 금액을 나타냅니다.</p>\n"
+        "description": "특정 시점의 간편결제 거래 건수와 금액을 나타냅니다.\n",
+        "x-portone-description": "특정 시점의 간편결제 거래 건수와 금액을 나타냅니다.\n"
       },
       "AnalyticsEasyPayProviderChart": {
         "title": "고객사의 간편결제사별 결제 현황 차트 정보",
@@ -10818,7 +10818,7 @@
             "$ref": "#/components/schemas/AnalyticsEasyPayProviderChartSummary"
           }
         },
-        "description": "<p>고객사의 간편결제사별 결제 현황 차트 정보</p>\n",
+        "description": "고객사의 간편결제사별 결제 현황 차트 정보\n",
         "x-portone-title": "고객사의 간편결제사별 결제 현황 차트 정보"
       },
       "AnalyticsEasyPayProviderChartRemainderStat": {
@@ -10845,8 +10845,8 @@
             "title": "결제 건수"
           }
         },
-        "description": "<p>특정 시점의 나머지 간편결제사들의 결제금액, 결제 건수를 나타냅니다.</p>\n",
-        "x-portone-description": "<p>특정 시점의 나머지 간편결제사들의 결제금액, 결제 건수를 나타냅니다.</p>\n"
+        "description": "특정 시점의 나머지 간편결제사들의 결제금액, 결제 건수를 나타냅니다.\n",
+        "x-portone-description": "특정 시점의 나머지 간편결제사들의 결제금액, 결제 건수를 나타냅니다.\n"
       },
       "AnalyticsEasyPayProviderChartStat": {
         "required": [
@@ -10877,8 +10877,8 @@
             "title": "결제 건수"
           }
         },
-        "description": "<p>특정 시점의 간편결제사별 결제금액, 결제 건수를 나타냅니다.</p>\n",
-        "x-portone-description": "<p>특정 시점의 간편결제사별 결제금액, 결제 건수를 나타냅니다.</p>\n"
+        "description": "특정 시점의 간편결제사별 결제금액, 결제 건수를 나타냅니다.\n",
+        "x-portone-description": "특정 시점의 간편결제사별 결제금액, 결제 건수를 나타냅니다.\n"
       },
       "AnalyticsEasyPayProviderChartSummary": {
         "required": [
@@ -10898,8 +10898,8 @@
             "title": "결제 건수의 합"
           }
         },
-        "description": "<p>결제금액, 결제 건수의 총합을 나타냅니다.</p>\n",
-        "x-portone-description": "<p>결제금액, 결제 건수의 총합을 나타냅니다.</p>\n"
+        "description": "결제금액, 결제 건수의 총합을 나타냅니다.\n",
+        "x-portone-description": "결제금액, 결제 건수의 총합을 나타냅니다.\n"
       },
       "AnalyticsOverseasPaymentUsage": {
         "title": "고객사의 해외 결제 사용 여부",
@@ -10912,7 +10912,7 @@
             "type": "boolean"
           }
         },
-        "description": "<p>고객사의 해외 결제 사용 여부</p>\n",
+        "description": "고객사의 해외 결제 사용 여부\n",
         "x-portone-title": "고객사의 해외 결제 사용 여부"
       },
       "AnalyticsPaymentChart": {
@@ -10929,7 +10929,7 @@
             }
           }
         },
-        "description": "<p>고객사의 결제 현황 차트 정보</p>\n",
+        "description": "고객사의 결제 현황 차트 정보\n",
         "x-portone-title": "고객사의 결제 현황 차트 정보"
       },
       "AnalyticsPaymentChartInsight": {
@@ -10969,7 +10969,7 @@
             "title": "일간 최저 거래액 발생 시간"
           }
         },
-        "description": "<p>고객사의 결제 현황 인사이트 정보</p>\n",
+        "description": "고객사의 결제 현황 인사이트 정보\n",
         "x-portone-title": "고객사의 결제 현황 인사이트 정보"
       },
       "AnalyticsPaymentChartStat": {
@@ -10996,8 +10996,8 @@
             "title": "거래 건수"
           }
         },
-        "description": "<p>특정 시점의 거래 건 수와 금액을 나타냅니다.</p>\n",
-        "x-portone-description": "<p>특정 시점의 거래 건 수와 금액을 나타냅니다.</p>\n"
+        "description": "특정 시점의 거래 건 수와 금액을 나타냅니다.\n",
+        "x-portone-description": "특정 시점의 거래 건 수와 금액을 나타냅니다.\n"
       },
       "AnalyticsPaymentMethodChart": {
         "title": "고객사의 결제수단 현황 차트 정보",
@@ -11013,7 +11013,7 @@
             }
           }
         },
-        "description": "<p>고객사의 결제수단 현황 차트 정보</p>\n",
+        "description": "고객사의 결제수단 현황 차트 정보\n",
         "x-portone-title": "고객사의 결제수단 현황 차트 정보"
       },
       "AnalyticsPaymentMethodChartStat": {
@@ -11038,8 +11038,8 @@
             "title": "결제수단별 결제 건수"
           }
         },
-        "description": "<p>결제수단별 결제금액, 결제 건수를 나타냅니다.</p>\n",
-        "x-portone-description": "<p>결제수단별 결제금액, 결제 건수를 나타냅니다.</p>\n"
+        "description": "결제수단별 결제금액, 결제 건수를 나타냅니다.\n",
+        "x-portone-description": "결제수단별 결제금액, 결제 건수를 나타냅니다.\n"
       },
       "AnalyticsPaymentMethodTrendChart": {
         "title": "고객사의 결제수단 트렌드 차트 정보",
@@ -11054,10 +11054,10 @@
               "$ref": "#/components/schemas/AnalyticsPaymentMethodTrendChartStat"
             },
             "title": "결제수단별 결제금액, 결제 건수 데이터",
-            "description": "<p>(timestamp, paymentMethod) 를 기준으로 오름차순 정렬되어 주어집니다.</p>\n"
+            "description": "(timestamp, paymentMethod) 를 기준으로 오름차순 정렬되어 주어집니다.\n"
           }
         },
-        "description": "<p>고객사의 결제수단 트렌드 차트 정보</p>\n",
+        "description": "고객사의 결제수단 트렌드 차트 정보\n",
         "x-portone-title": "고객사의 결제수단 트렌드 차트 정보"
       },
       "AnalyticsPaymentMethodTrendChartStat": {
@@ -11088,8 +11088,8 @@
             "title": "결제 건수"
           }
         },
-        "description": "<p>특정 시점의 결제수단별 결제금액, 결제 건수를 나타냅니다.</p>\n",
-        "x-portone-description": "<p>특정 시점의 결제수단별 결제금액, 결제 건수를 나타냅니다.</p>\n"
+        "description": "특정 시점의 결제수단별 결제금액, 결제 건수를 나타냅니다.\n",
+        "x-portone-description": "특정 시점의 결제수단별 결제금액, 결제 건수를 나타냅니다.\n"
       },
       "AnalyticsPaymentStatusByPaymentClientChart": {
         "title": "고객사의 결제 환경 별 결제 상태 차트 정보",
@@ -11105,7 +11105,7 @@
             }
           }
         },
-        "description": "<p>고객사의 결제 환경 별 결제 상태 차트 정보</p>\n",
+        "description": "고객사의 결제 환경 별 결제 상태 차트 정보\n",
         "x-portone-title": "고객사의 결제 환경 별 결제 상태 차트 정보"
       },
       "AnalyticsPaymentStatusByPaymentClientChartStat": {
@@ -11136,8 +11136,8 @@
             "title": "거래 건수"
           }
         },
-        "description": "<p>고객사의 결제 환경 별 결제 상태 차트 정보</p>\n",
-        "x-portone-description": "<p>고객사의 결제 환경 별 결제 상태 차트 정보</p>\n"
+        "description": "고객사의 결제 환경 별 결제 상태 차트 정보\n",
+        "x-portone-description": "고객사의 결제 환경 별 결제 상태 차트 정보\n"
       },
       "AnalyticsPaymentStatusByPaymentMethodChart": {
         "title": "고객사의 결제 수단 별 결제 상태 차트 정보",
@@ -11153,7 +11153,7 @@
             }
           }
         },
-        "description": "<p>고객사의 결제 수단 별 결제 상태 차트 정보</p>\n",
+        "description": "고객사의 결제 수단 별 결제 상태 차트 정보\n",
         "x-portone-title": "고객사의 결제 수단 별 결제 상태 차트 정보"
       },
       "AnalyticsPaymentStatusByPaymentMethodChartStat": {
@@ -11183,8 +11183,8 @@
             "title": "거래 건수"
           }
         },
-        "description": "<p>각 결제수단, 상태 별 건수와 금액을 나타냅니다.</p>\n",
-        "x-portone-description": "<p>각 결제수단, 상태 별 건수와 금액을 나타냅니다.</p>\n"
+        "description": "각 결제수단, 상태 별 건수와 금액을 나타냅니다.\n",
+        "x-portone-description": "각 결제수단, 상태 별 건수와 금액을 나타냅니다.\n"
       },
       "AnalyticsPaymentStatusByPgCompanyChart": {
         "title": "고객사의 PG사 별 결제 상태 차트 정보",
@@ -11200,7 +11200,7 @@
             }
           }
         },
-        "description": "<p>고객사의 PG사 별 결제 상태 차트 정보</p>\n",
+        "description": "고객사의 PG사 별 결제 상태 차트 정보\n",
         "x-portone-title": "고객사의 PG사 별 결제 상태 차트 정보"
       },
       "AnalyticsPaymentStatusByPgCompanyChartStat": {
@@ -11231,8 +11231,8 @@
             "title": "거래 건수"
           }
         },
-        "description": "<p>각 상태의 건수와 금액, 사분위수를 나타냅니다.</p>\n",
-        "x-portone-description": "<p>각 상태의 건수와 금액, 사분위수를 나타냅니다.</p>\n"
+        "description": "각 상태의 건수와 금액, 사분위수를 나타냅니다.\n",
+        "x-portone-description": "각 상태의 건수와 금액, 사분위수를 나타냅니다.\n"
       },
       "AnalyticsPaymentStatusChart": {
         "title": "고객사의 결제 상태 차트 정보",
@@ -11248,7 +11248,7 @@
             }
           }
         },
-        "description": "<p>고객사의 결제 상태 차트 정보</p>\n",
+        "description": "고객사의 결제 상태 차트 정보\n",
         "x-portone-title": "고객사의 결제 상태 차트 정보"
       },
       "AnalyticsPaymentStatusChartStat": {
@@ -11298,8 +11298,8 @@
             "title": "3 사분위수"
           }
         },
-        "description": "<p>각 상태의 건수와 금액, 사분위수를 나타냅니다.</p>\n",
-        "x-portone-description": "<p>각 상태의 건수와 금액, 사분위수를 나타냅니다.</p>\n"
+        "description": "각 상태의 건수와 금액, 사분위수를 나타냅니다.\n",
+        "x-portone-description": "각 상태의 건수와 금액, 사분위수를 나타냅니다.\n"
       },
       "AnalyticsPgCompanyChart": {
         "title": "가맹점의 결제대행사 현황 차트 정보",
@@ -11315,7 +11315,7 @@
             }
           }
         },
-        "description": "<p>가맹점의 결제대행사 현황 차트 정보</p>\n",
+        "description": "가맹점의 결제대행사 현황 차트 정보\n",
         "x-portone-title": "가맹점의 결제대행사 현황 차트 정보"
       },
       "AnalyticsPgCompanyChartStat": {
@@ -11341,8 +11341,8 @@
             "title": "결제대행사별 결제 건수"
           }
         },
-        "description": "<p>결제대행사별 결제금액, 결제 건수를 나타냅니다.</p>\n",
-        "x-portone-description": "<p>결제대행사별 결제금액, 결제 건수를 나타냅니다.</p>\n"
+        "description": "결제대행사별 결제금액, 결제 건수를 나타냅니다.\n",
+        "x-portone-description": "결제대행사별 결제금액, 결제 건수를 나타냅니다.\n"
       },
       "AnalyticsPgCompanyTrendChart": {
         "title": "가맹점의 결제대행사별 거래 추이 차트 정보",
@@ -11358,7 +11358,7 @@
             }
           }
         },
-        "description": "<p>가맹점의 결제대행사별 거래 추이 차트 정보</p>\n",
+        "description": "가맹점의 결제대행사별 거래 추이 차트 정보\n",
         "x-portone-title": "가맹점의 결제대행사별 거래 추이 차트 정보"
       },
       "AnalyticsPgCompanyTrendChartStat": {
@@ -11390,8 +11390,8 @@
             "title": "결제 건수"
           }
         },
-        "description": "<p>특정 시점의 결제대행사 별 결제금액, 결제 건수를 나타냅니다.</p>\n",
-        "x-portone-description": "<p>특정 시점의 결제대행사 별 결제금액, 결제 건수를 나타냅니다.</p>\n"
+        "description": "특정 시점의 결제대행사 별 결제금액, 결제 건수를 나타냅니다.\n",
+        "x-portone-description": "특정 시점의 결제대행사 별 결제금액, 결제 건수를 나타냅니다.\n"
       },
       "AnalyticsTimeGranularity": {
         "title": "조회 시간 단위",
@@ -11413,9 +11413,9 @@
             "$ref": "#/components/schemas/AnalyticsTimeGranularityMonth"
           }
         },
-        "description": "<p>조회 시간 단위</p>\n<p>하나의 단위 필드만 선택하여 입력합니다.</p>\n",
+        "description": "조회 시간 단위\n하나의 단위 필드만 선택하여 입력합니다.\n",
         "x-portone-title": "조회 시간 단위",
-        "x-portone-description": "<p>하나의 단위 필드만 선택하여 입력합니다.</p>\n"
+        "x-portone-description": "하나의 단위 필드만 선택하여 입력합니다.\n"
       },
       "AnalyticsTimeGranularityDay": {
         "title": "일",
@@ -11429,19 +11429,19 @@
             "format": "int32"
           }
         },
-        "description": "<p>일</p>\n",
+        "description": "일\n",
         "x-portone-title": "일"
       },
       "AnalyticsTimeGranularityHour": {
         "title": "시간",
         "type": "object",
-        "description": "<p>시간</p>\n",
+        "description": "시간\n",
         "x-portone-title": "시간"
       },
       "AnalyticsTimeGranularityMinute": {
         "title": "분",
         "type": "object",
-        "description": "<p>분</p>\n",
+        "description": "분\n",
         "x-portone-title": "분"
       },
       "AnalyticsTimeGranularityMonth": {
@@ -11456,7 +11456,7 @@
             "format": "int32"
           }
         },
-        "description": "<p>월</p>\n",
+        "description": "월\n",
         "x-portone-title": "월"
       },
       "AnalyticsTimeGranularityWeek": {
@@ -11471,7 +11471,7 @@
             "format": "int32"
           }
         },
-        "description": "<p>주</p>\n",
+        "description": "주\n",
         "x-portone-title": "주"
       },
       "ApplyEscrowLogisticsError": {
@@ -11531,7 +11531,7 @@
             "title": "에스크로 정보 등록 시점"
           }
         },
-        "description": "<p>에스크로 배송 정보 등록 성공 응답</p>\n",
+        "description": "에스크로 배송 정보 등록 성공 응답\n",
         "x-portone-title": "에스크로 배송 정보 등록 성공 응답"
       },
       "ApprovePlatformPartnerBody": {
@@ -11543,7 +11543,7 @@
             "title": "파트너 메모. 값이 명시되지 않은 경우 업데이트하지 않습니다."
           }
         },
-        "description": "<p>파트너 상태를 승인 완료로 변경하기 위한 입력 정보</p>\n",
+        "description": "파트너 상태를 승인 완료로 변경하기 위한 입력 정보\n",
         "x-portone-title": "파트너 상태를 승인 완료로 변경하기 위한 입력 정보"
       },
       "ApprovePlatformPartnerError": {
@@ -11587,7 +11587,7 @@
             "title": "승인된 파트너"
           }
         },
-        "description": "<p>파트너 승인 성공 응답</p>\n",
+        "description": "파트너 승인 성공 응답\n",
         "x-portone-title": "파트너 승인 성공 응답"
       },
       "ArchivePlatformAdditionalFeePolicyError": {
@@ -11631,7 +11631,7 @@
             "title": "보관된 추가 수수료 정책"
           }
         },
-        "description": "<p>추가 수수료 정책 보관 성공 응답</p>\n",
+        "description": "추가 수수료 정책 보관 성공 응답\n",
         "x-portone-title": "추가 수수료 정책 보관 성공 응답"
       },
       "ArchivePlatformContractError": {
@@ -11675,7 +11675,7 @@
             "title": "보관된 계약"
           }
         },
-        "description": "<p>계약 보관 성공 응답</p>\n",
+        "description": "계약 보관 성공 응답\n",
         "x-portone-title": "계약 보관 성공 응답"
       },
       "ArchivePlatformDiscountSharePolicyError": {
@@ -11719,7 +11719,7 @@
             "title": "보관된 할인 분담"
           }
         },
-        "description": "<p>할인 분담 보관 성공 응답</p>\n",
+        "description": "할인 분담 보관 성공 응답\n",
         "x-portone-title": "할인 분담 보관 성공 응답"
       },
       "ArchivePlatformPartnerError": {
@@ -11763,7 +11763,7 @@
             "title": "보관된 파트너"
           }
         },
-        "description": "<p>파트너 보관 성공 응답</p>\n",
+        "description": "파트너 보관 성공 응답\n",
         "x-portone-title": "파트너 보관 성공 응답"
       },
       "B2bBankAccountNotFoundError": {
@@ -11780,7 +11780,7 @@
             "type": "string"
           }
         },
-        "description": "<p>계좌가 존재하지 않는 경우</p>\n",
+        "description": "계좌가 존재하지 않는 경우\n",
         "x-portone-title": "계좌가 존재하지 않는 경우",
         "x-portone-status-code": 404
       },
@@ -11836,7 +11836,7 @@
       "B2bCertificateType": {
         "title": "인증서 타입",
         "type": "string",
-        "description": "<p>인증서 타입</p>\n",
+        "description": "인증서 타입\n",
         "enum": [
           "ETC",
           "E_TAX",
@@ -11869,7 +11869,7 @@
             "type": "string"
           }
         },
-        "description": "<p>인증서가 등록되어 있지 않은 경우</p>\n",
+        "description": "인증서가 등록되어 있지 않은 경우\n",
         "x-portone-title": "인증서가 등록되어 있지 않은 경우",
         "x-portone-status-code": 404
       },
@@ -11887,7 +11887,7 @@
           "id": {
             "type": "string",
             "title": "담당자 ID",
-            "description": "<p>팝빌 로그인 계정으로 사용됩니다.</p>\n"
+            "description": "팝빌 로그인 계정으로 사용됩니다.\n"
           },
           "name": {
             "type": "string",
@@ -11909,7 +11909,7 @@
           "isManager": {
             "type": "boolean",
             "title": "관리자 여부",
-            "description": "<p>true일 경우 관리자, false일 경우 담당자입니다.</p>\n"
+            "description": "true일 경우 관리자, false일 경우 담당자입니다.\n"
           }
         }
       },
@@ -11926,7 +11926,7 @@
           "id": {
             "type": "string",
             "title": "담당자 ID",
-            "description": "<p>팝빌 로그인 계정으로 사용됩니다.</p>\n"
+            "description": "팝빌 로그인 계정으로 사용됩니다.\n"
           },
           "password": {
             "type": "string",
@@ -11960,7 +11960,7 @@
             "type": "string"
           }
         },
-        "description": "<p>사업자가 존재하지 않는 경우</p>\n",
+        "description": "사업자가 존재하지 않는 경우\n",
         "x-portone-title": "사업자가 존재하지 않는 경우",
         "x-portone-status-code": 404
       },
@@ -11974,8 +11974,8 @@
           },
           "taxationTypeDate": {
             "type": "string",
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
             "title": "과세 유형 변경 일자"
           },
           "businessStatus": {
@@ -11984,18 +11984,18 @@
           },
           "closedSuspendedDate": {
             "type": "string",
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
             "title": "휴폐업 일자"
           }
         },
-        "description": "<p>사업자 상태</p>\n",
+        "description": "사업자 상태\n",
         "x-portone-title": "사업자 상태"
       },
       "B2bCompanyStateBusinessStatus": {
         "title": "영업 상태",
         "type": "string",
-        "description": "<p>영업 상태</p>\n",
+        "description": "영업 상태\n",
         "enum": [
           "CLOSED",
           "IN_BUSINESS",
@@ -12017,7 +12017,7 @@
       "B2bCompanyStateTaxationType": {
         "title": "사업자 과세 유형",
         "type": "string",
-        "description": "<p>사업자 과세 유형</p>\n",
+        "description": "사업자 과세 유형\n",
         "enum": [
           "ASSIGNED_ID_NUMBER",
           "NORMAL",
@@ -12058,7 +12058,7 @@
             "type": "string"
           }
         },
-        "description": "<p>담당자가 존재하지 않는 경우</p>\n",
+        "description": "담당자가 존재하지 않는 경우\n",
         "x-portone-title": "담당자가 존재하지 않는 경우",
         "x-portone-status-code": 404
       },
@@ -12077,7 +12077,7 @@
             "type": "string"
           }
         },
-        "description": "<p>외부 서비스에서 에러가 발생한 경우</p>\n",
+        "description": "외부 서비스에서 에러가 발생한 경우\n",
         "x-portone-title": "외부 서비스에서 에러가 발생한 경우",
         "x-portone-status-code": 502
       },
@@ -12095,7 +12095,7 @@
             "type": "string"
           }
         },
-        "description": "<p>금융기관과의 통신에 실패한 경우</p>\n",
+        "description": "금융기관과의 통신에 실패한 경우\n",
         "x-portone-title": "금융기관과의 통신에 실패한 경우",
         "x-portone-status-code": 503
       },
@@ -12113,7 +12113,7 @@
             "type": "string"
           }
         },
-        "description": "<p>금융기관 장애</p>\n",
+        "description": "금융기관 장애\n",
         "x-portone-title": "금융기관 장애",
         "x-portone-status-code": 503
       },
@@ -12131,7 +12131,7 @@
             "type": "string"
           }
         },
-        "description": "<p>금융기관 시스템이 점검 중인 경우</p>\n",
+        "description": "금융기관 시스템이 점검 중인 경우\n",
         "x-portone-title": "금융기관 시스템이 점검 중인 경우",
         "x-portone-status-code": 503
       },
@@ -12149,7 +12149,7 @@
             "type": "string"
           }
         },
-        "description": "<p>계좌 정보 조회가 불가능한 외화 계좌인 경우</p>\n",
+        "description": "계좌 정보 조회가 불가능한 외화 계좌인 경우\n",
         "x-portone-title": "계좌 정보 조회가 불가능한 외화 계좌인 경우",
         "x-portone-status-code": 404
       },
@@ -12205,7 +12205,7 @@
             "type": "string"
           }
         },
-        "description": "<p>연동 사업자가 존재하지 않는 경우</p>\n",
+        "description": "연동 사업자가 존재하지 않는 경우\n",
         "x-portone-title": "연동 사업자가 존재하지 않는 경우",
         "x-portone-status-code": 404
       },
@@ -12226,7 +12226,7 @@
             "title": "수정 대상 원본 세금계산서 국세청 승인 번호"
           }
         },
-        "description": "<p>세금 계산서 수정</p>\n",
+        "description": "세금 계산서 수정\n",
         "x-portone-title": "세금 계산서 수정"
       },
       "B2bNotEnabledError": {
@@ -12243,7 +12243,7 @@
             "type": "string"
           }
         },
-        "description": "<p>B2B 기능이 활성화되지 않은 경우</p>\n",
+        "description": "B2B 기능이 활성화되지 않은 경우\n",
         "x-portone-title": "B2B 기능이 활성화되지 않은 경우",
         "x-portone-status-code": 403
       },
@@ -12261,7 +12261,7 @@
             "type": "string"
           }
         },
-        "description": "<p>공급받는자가 존재하지 않은 경우</p>\n",
+        "description": "공급받는자가 존재하지 않은 경우\n",
         "x-portone-title": "공급받는자가 존재하지 않은 경우",
         "x-portone-status-code": 404
       },
@@ -12279,14 +12279,14 @@
             "type": "string"
           }
         },
-        "description": "<p>금융기관 시스템이 정기 점검 중인 경우</p>\n",
+        "description": "금융기관 시스템이 정기 점검 중인 경우\n",
         "x-portone-title": "금융기관 시스템이 정기 점검 중인 경우",
         "x-portone-status-code": 503
       },
       "B2bSearchDateType": {
         "title": "조회 기준",
         "type": "string",
-        "description": "<p>조회 기준</p>\n",
+        "description": "조회 기준\n",
         "enum": [
           "ISSUE",
           "REGISTER",
@@ -12319,7 +12319,7 @@
             "type": "string"
           }
         },
-        "description": "<p>공급자가 존재하지 않은 경우</p>\n",
+        "description": "공급자가 존재하지 않은 경우\n",
         "x-portone-title": "공급자가 존재하지 않은 경우",
         "x-portone-status-code": 404
       },
@@ -12337,7 +12337,7 @@
             "type": "string"
           }
         },
-        "description": "<p>정지 계좌인 경우</p>\n",
+        "description": "정지 계좌인 경우\n",
         "x-portone-title": "정지 계좌인 경우",
         "x-portone-status-code": 404
       },
@@ -12439,14 +12439,14 @@
           "name": {
             "type": "string",
             "title": "성명",
-            "description": "<p>최대 100자</p>\n"
+            "description": "최대 100자\n"
           },
           "email": {
             "type": "string",
             "title": "이메일"
           }
         },
-        "description": "<p>추가 담당자</p>\n",
+        "description": "추가 담당자\n",
         "x-portone-title": "추가 담당자"
       },
       "B2bTaxInvoiceBeforeSending": {
@@ -12486,18 +12486,18 @@
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 권",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999\n"
           },
           "bookIssue": {
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 호",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999\n"
           },
           "writeDate": {
             "type": "string",
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
             "title": "작성일"
           },
           "purposeType": {
@@ -12545,7 +12545,7 @@
               "type": "string"
             },
             "title": "비고",
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개\n"
           },
           "supplierDocumentKey": {
             "type": "string",
@@ -12577,7 +12577,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceItem"
             },
-            "description": "<p>최대 99개</p>\n"
+            "description": "최대 99개\n"
           },
           "contacts": {
             "title": "추가 담당자",
@@ -12585,7 +12585,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceAdditionalContact"
             },
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개\n"
           },
           "statusUpdatedAt": {
             "type": "string",
@@ -12600,7 +12600,7 @@
           "ntsApproveNumber": {
             "type": "string",
             "title": "국세청 승인번호",
-            "description": "<p>세금계산서 발행(전자서명) 시점에 자동으로 부여</p>\n"
+            "description": "세금계산서 발행(전자서명) 시점에 자동으로 부여\n"
           }
         }
       },
@@ -12618,32 +12618,32 @@
           "taxRegistrationId": {
             "type": "string",
             "title": "종사업자 식별 번호",
-            "description": "<p>4자리 고정</p>\n"
+            "description": "4자리 고정\n"
           },
           "name": {
             "type": "string",
             "title": "상호명",
-            "description": "<p>최대 200자</p>\n"
+            "description": "최대 200자\n"
           },
           "ceoName": {
             "type": "string",
             "title": "대표자 성명",
-            "description": "<p>최대 100자</p>\n"
+            "description": "최대 100자\n"
           },
           "address": {
             "type": "string",
             "title": "주소",
-            "description": "<p>최대 300자</p>\n"
+            "description": "최대 300자\n"
           },
           "businessType": {
             "type": "string",
             "title": "업태",
-            "description": "<p>최대 100자</p>\n"
+            "description": "최대 100자\n"
           },
           "businessClass": {
             "type": "string",
             "title": "종목",
-            "description": "<p>최대 100자</p>\n"
+            "description": "최대 100자\n"
           },
           "contact": {
             "$ref": "#/components/schemas/B2bTaxInvoiceContact",
@@ -12676,13 +12676,13 @@
             "title": "이메일"
           }
         },
-        "description": "<p>세금계산서 담당자</p>\n",
+        "description": "세금계산서 담당자\n",
         "x-portone-title": "세금계산서 담당자"
       },
       "B2bTaxInvoiceDocumentKeyType": {
         "title": "문서번호 유형",
         "type": "string",
-        "description": "<p>문서번호 유형</p>\n",
+        "description": "문서번호 유형\n",
         "enum": [
           "RECIPIENT",
           "SUPPLIER"
@@ -12731,8 +12731,8 @@
           },
           "writeDate": {
             "type": "string",
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
             "title": "작성일"
           },
           "purposeType": {
@@ -12780,12 +12780,12 @@
               "type": "string"
             },
             "title": "비고",
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개\n"
           },
           "supplierDocumentKey": {
             "type": "string",
             "title": "공급자 문서번호",
-            "description": "<p>영문 대소문자, 숫자, 특수문자('-','_')만 이용 가능</p>\n"
+            "description": "영문 대소문자, 숫자, 특수문자('-','_')만 이용 가능\n"
           },
           "supplier": {
             "$ref": "#/components/schemas/B2bTaxInvoiceCompany",
@@ -12794,7 +12794,7 @@
           "recipientDocumentKey": {
             "type": "string",
             "title": "공급받는자 문서번호",
-            "description": "<p>영문 대소문자, 숫자, 특수문자('-','_')만 이용 가능</p>\n"
+            "description": "영문 대소문자, 숫자, 특수문자('-','_')만 이용 가능\n"
           },
           "recipient": {
             "$ref": "#/components/schemas/B2bTaxInvoiceCompany",
@@ -12803,7 +12803,7 @@
           "sendSms": {
             "type": "boolean",
             "title": "문자 전송 여부",
-            "description": "<p>공급자 담당자 휴대폰번호 {supplier.contact.mobile_phone_number} 값으로 문자 전송 전송시 포인트 차감되며, 실패시 환불 처리 기본값은 false</p>\n"
+            "description": "공급자 담당자 휴대폰번호 {supplier.contact.mobile_phone_number} 값으로 문자 전송 전송시 포인트 차감되며, 실패시 환불 처리 기본값은 false\n"
           },
           "modification": {
             "$ref": "#/components/schemas/B2bModification",
@@ -12815,7 +12815,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceItem"
             },
-            "description": "<p>최대 99개</p>\n"
+            "description": "최대 99개\n"
           },
           "contacts": {
             "title": "추가 담당자",
@@ -12823,10 +12823,10 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceAdditionalContact"
             },
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개\n"
           }
         },
-        "description": "<p>세금계산서 생성 요청 정보</p>\n",
+        "description": "세금계산서 생성 요청 정보\n",
         "x-portone-title": "세금계산서 생성 요청 정보"
       },
       "B2bTaxInvoiceIssuanceCancelled": {
@@ -12866,18 +12866,18 @@
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 권",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999\n"
           },
           "bookIssue": {
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 호",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999\n"
           },
           "writeDate": {
             "type": "string",
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
             "title": "작성일"
           },
           "purposeType": {
@@ -12925,7 +12925,7 @@
               "type": "string"
             },
             "title": "비고",
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개\n"
           },
           "supplierDocumentKey": {
             "type": "string",
@@ -12957,7 +12957,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceItem"
             },
-            "description": "<p>최대 99개</p>\n"
+            "description": "최대 99개\n"
           },
           "contacts": {
             "title": "추가 담당자",
@@ -12965,7 +12965,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceAdditionalContact"
             },
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개\n"
           },
           "statusUpdatedAt": {
             "type": "string",
@@ -12980,7 +12980,7 @@
           "ntsApproveNumber": {
             "type": "string",
             "title": "국세청 승인번호",
-            "description": "<p>세금계산서 발행(전자서명) 시점에 자동으로 부여</p>\n"
+            "description": "세금계산서 발행(전자서명) 시점에 자동으로 부여\n"
           },
           "recipientBusinessStatus": {
             "$ref": "#/components/schemas/B2bCompanyStateBusinessStatus",
@@ -12988,8 +12988,8 @@
           },
           "recipientClosedSuspendedDate": {
             "type": "string",
-            "description": "<p>상태가 CLOSED, SUSPENDED 상태인 경우에만 결과값 반환</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "상태가 CLOSED, SUSPENDED 상태인 경우에만 결과값 반환\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
             "title": "공급받는자 휴폐업일자"
           }
         }
@@ -13031,18 +13031,18 @@
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 권",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999\n"
           },
           "bookIssue": {
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 호",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999\n"
           },
           "writeDate": {
             "type": "string",
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
             "title": "작성일"
           },
           "purposeType": {
@@ -13090,7 +13090,7 @@
               "type": "string"
             },
             "title": "비고",
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개\n"
           },
           "supplierDocumentKey": {
             "type": "string",
@@ -13122,7 +13122,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceItem"
             },
-            "description": "<p>최대 99개</p>\n"
+            "description": "최대 99개\n"
           },
           "contacts": {
             "title": "추가 담당자",
@@ -13130,7 +13130,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceAdditionalContact"
             },
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개\n"
           },
           "statusUpdatedAt": {
             "type": "string",
@@ -13145,7 +13145,7 @@
           "ntsApproveNumber": {
             "type": "string",
             "title": "국세청 승인번호",
-            "description": "<p>세금계산서 발행(전자서명) 시점에 자동으로 부여</p>\n"
+            "description": "세금계산서 발행(전자서명) 시점에 자동으로 부여\n"
           }
         }
       },
@@ -13155,43 +13155,43 @@
         "properties": {
           "purchaseDate": {
             "type": "string",
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
             "title": "결제일"
           },
           "name": {
             "type": "string",
             "title": "품명",
-            "description": "<p>최대 100자</p>\n"
+            "description": "최대 100자\n"
           },
           "spec": {
             "type": "string",
             "title": "규격",
-            "description": "<p>최대 100자</p>\n"
+            "description": "최대 100자\n"
           },
           "quantity": {
             "type": "integer",
             "format": "int64",
             "title": "수량",
-            "description": "<p>입력 범위 : -99999999.99 ~ 999999999.99, 10^-quantityScale 단위로 치환됨</p>\n"
+            "description": "입력 범위 : -99999999.99 ~ 999999999.99, 10^-quantityScale 단위로 치환됨\n"
           },
           "quantityScale": {
             "type": "integer",
             "format": "int32",
             "title": "수량 단위",
-            "description": "<p>입력 범위 : 0 ~ 2, 기본값: 0</p>\n"
+            "description": "입력 범위 : 0 ~ 2, 기본값: 0\n"
           },
           "unitCostAmount": {
             "type": "integer",
             "format": "int64",
             "title": "단가",
-            "description": "<p>입력 범위 : -99999999999999.99 ~ 999999999999999.99</p>\n"
+            "description": "입력 범위 : -99999999999999.99 ~ 999999999999999.99\n"
           },
           "unitCostAmountScale": {
             "type": "integer",
             "format": "int32",
             "title": "단가 단위",
-            "description": "<p>입력 범위 : 0 ~ 2, 기본값: 0</p>\n"
+            "description": "입력 범위 : 0 ~ 2, 기본값: 0\n"
           },
           "supplyCostAmount": {
             "type": "integer",
@@ -13208,13 +13208,13 @@
             "title": "비고"
           }
         },
-        "description": "<p>품목</p>\n",
+        "description": "품목\n",
         "x-portone-title": "품목"
       },
       "B2bTaxInvoiceModificationType": {
         "title": "수정 사유",
         "type": "string",
-        "description": "<p>수정 사유</p>\n",
+        "description": "수정 사유\n",
         "enum": [
           "CANCELLATION_OF_CONTRACT",
           "CHANGE_IN_SUPPLY_COST",
@@ -13259,7 +13259,7 @@
             "type": "string"
           }
         },
-        "description": "<p>세금계산서에 공급받는자 문서 번호가 기입되지 않은 경우</p>\n",
+        "description": "세금계산서에 공급받는자 문서 번호가 기입되지 않은 경우\n",
         "x-portone-title": "세금계산서에 공급받는자 문서 번호가 기입되지 않은 경우",
         "x-portone-status-code": 400
       },
@@ -13277,7 +13277,7 @@
             "type": "string"
           }
         },
-        "description": "<p>세금계산서에 공급자 문서 번호가 기입되지 않은 경우</p>\n",
+        "description": "세금계산서에 공급자 문서 번호가 기입되지 않은 경우\n",
         "x-portone-title": "세금계산서에 공급자 문서 번호가 기입되지 않은 경우",
         "x-portone-status-code": 400
       },
@@ -13295,9 +13295,9 @@
             "type": "string"
           }
         },
-        "description": "<p>세금계산서가 삭제 가능한 상태가 아닌 경우</p>\n<p>삭제 가능한 상태는 <code>REGISTERED</code>, <code>ISSUE_REFUSED</code>, <code>REQUEST_CANCELLED_BY_RECIPIENT</code>, <code>ISSUE_CANCELLED_BY_SUPPLIER</code>, <code>SENDING_FAILED</code> 입니다.</p>\n",
+        "description": "세금계산서가 삭제 가능한 상태가 아닌 경우\n삭제 가능한 상태는 <code>REGISTERED</code>, <code>ISSUE_REFUSED</code>, <code>REQUEST_CANCELLED_BY_RECIPIENT</code>, <code>ISSUE_CANCELLED_BY_SUPPLIER</code>, <code>SENDING_FAILED</code> 입니다.\n",
         "x-portone-title": "세금계산서가 삭제 가능한 상태가 아닌 경우",
-        "x-portone-description": "<p>삭제 가능한 상태는 <code>REGISTERED</code>, <code>ISSUE_REFUSED</code>, <code>REQUEST_CANCELLED_BY_RECIPIENT</code>, <code>ISSUE_CANCELLED_BY_SUPPLIER</code>, <code>SENDING_FAILED</code> 입니다.</p>\n",
+        "x-portone-description": "삭제 가능한 상태는 <code>REGISTERED</code>, <code>ISSUE_REFUSED</code>, <code>REQUEST_CANCELLED_BY_RECIPIENT</code>, <code>ISSUE_CANCELLED_BY_SUPPLIER</code>, <code>SENDING_FAILED</code> 입니다.\n",
         "x-portone-status-code": 400
       },
       "B2bTaxInvoiceNotFoundError": {
@@ -13314,7 +13314,7 @@
             "type": "string"
           }
         },
-        "description": "<p>세금계산서가 존재하지 않은 경우</p>\n",
+        "description": "세금계산서가 존재하지 않은 경우\n",
         "x-portone-title": "세금계산서가 존재하지 않은 경우",
         "x-portone-status-code": 404
       },
@@ -13332,7 +13332,7 @@
             "type": "string"
           }
         },
-        "description": "<p>세금계산서가 발행된(ISSUED) 상태가 아닌 경우</p>\n",
+        "description": "세금계산서가 발행된(ISSUED) 상태가 아닌 경우\n",
         "x-portone-title": "세금계산서가 발행된(ISSUED) 상태가 아닌 경우",
         "x-portone-status-code": 400
       },
@@ -13350,7 +13350,7 @@
             "type": "string"
           }
         },
-        "description": "<p>세금계산서가 임시저장 상태가 아닌 경우</p>\n",
+        "description": "세금계산서가 임시저장 상태가 아닌 경우\n",
         "x-portone-title": "세금계산서가 임시저장 상태가 아닌 경우",
         "x-portone-status-code": 400
       },
@@ -13368,14 +13368,14 @@
             "type": "string"
           }
         },
-        "description": "<p>세금계산서가 역발행 대기 상태가 아닌 경우</p>\n",
+        "description": "세금계산서가 역발행 대기 상태가 아닌 경우\n",
         "x-portone-title": "세금계산서가 역발행 대기 상태가 아닌 경우",
         "x-portone-status-code": 400
       },
       "B2bTaxInvoicePurposeType": {
         "title": "영수/청구",
         "type": "string",
-        "description": "<p>영수/청구</p>\n",
+        "description": "영수/청구\n",
         "enum": [
           "INVOICE",
           "NONE",
@@ -13423,18 +13423,18 @@
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 권",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999\n"
           },
           "bookIssue": {
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 호",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999\n"
           },
           "writeDate": {
             "type": "string",
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
             "title": "작성일"
           },
           "purposeType": {
@@ -13482,7 +13482,7 @@
               "type": "string"
             },
             "title": "비고",
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개\n"
           },
           "supplierDocumentKey": {
             "type": "string",
@@ -13514,7 +13514,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceItem"
             },
-            "description": "<p>최대 99개</p>\n"
+            "description": "최대 99개\n"
           },
           "contacts": {
             "title": "추가 담당자",
@@ -13522,7 +13522,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceAdditionalContact"
             },
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개\n"
           },
           "statusUpdatedAt": {
             "type": "string",
@@ -13566,18 +13566,18 @@
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 권",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999\n"
           },
           "bookIssue": {
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 호",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999\n"
           },
           "writeDate": {
             "type": "string",
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
             "title": "작성일"
           },
           "purposeType": {
@@ -13625,7 +13625,7 @@
               "type": "string"
             },
             "title": "비고",
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개\n"
           },
           "supplierDocumentKey": {
             "type": "string",
@@ -13657,7 +13657,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceItem"
             },
-            "description": "<p>최대 99개</p>\n"
+            "description": "최대 99개\n"
           },
           "contacts": {
             "title": "추가 담당자",
@@ -13665,7 +13665,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceAdditionalContact"
             },
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개\n"
           },
           "statusUpdatedAt": {
             "type": "string",
@@ -13709,18 +13709,18 @@
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 권",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999\n"
           },
           "bookIssue": {
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 호",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999\n"
           },
           "writeDate": {
             "type": "string",
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
             "title": "작성일"
           },
           "purposeType": {
@@ -13768,7 +13768,7 @@
               "type": "string"
             },
             "title": "비고",
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개\n"
           },
           "supplierDocumentKey": {
             "type": "string",
@@ -13800,7 +13800,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceItem"
             },
-            "description": "<p>최대 99개</p>\n"
+            "description": "최대 99개\n"
           },
           "contacts": {
             "title": "추가 담당자",
@@ -13808,7 +13808,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceAdditionalContact"
             },
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개\n"
           },
           "statusUpdatedAt": {
             "type": "string",
@@ -13852,18 +13852,18 @@
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 권",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999\n"
           },
           "bookIssue": {
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 호",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999\n"
           },
           "writeDate": {
             "type": "string",
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
             "title": "작성일"
           },
           "purposeType": {
@@ -13911,7 +13911,7 @@
               "type": "string"
             },
             "title": "비고",
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개\n"
           },
           "supplierDocumentKey": {
             "type": "string",
@@ -13943,7 +13943,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceItem"
             },
-            "description": "<p>최대 99개</p>\n"
+            "description": "최대 99개\n"
           },
           "contacts": {
             "title": "추가 담당자",
@@ -13951,7 +13951,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceAdditionalContact"
             },
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개\n"
           },
           "statusUpdatedAt": {
             "type": "string",
@@ -13998,18 +13998,18 @@
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 권",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999\n"
           },
           "bookIssue": {
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 호",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999\n"
           },
           "writeDate": {
             "type": "string",
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
             "title": "작성일"
           },
           "purposeType": {
@@ -14057,7 +14057,7 @@
               "type": "string"
             },
             "title": "비고",
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개\n"
           },
           "supplierDocumentKey": {
             "type": "string",
@@ -14089,7 +14089,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceItem"
             },
-            "description": "<p>최대 99개</p>\n"
+            "description": "최대 99개\n"
           },
           "contacts": {
             "title": "추가 담당자",
@@ -14097,7 +14097,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceAdditionalContact"
             },
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개\n"
           },
           "statusUpdatedAt": {
             "type": "string",
@@ -14112,7 +14112,7 @@
           "ntsApproveNumber": {
             "type": "string",
             "title": "국세청 승인번호",
-            "description": "<p>세금계산서 발행(전자서명) 시점에 자동으로 부여</p>\n"
+            "description": "세금계산서 발행(전자서명) 시점에 자동으로 부여\n"
           },
           "ntsSentAt": {
             "type": "string",
@@ -14160,18 +14160,18 @@
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 권",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999\n"
           },
           "bookIssue": {
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 호",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999\n"
           },
           "writeDate": {
             "type": "string",
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
             "title": "작성일"
           },
           "purposeType": {
@@ -14219,7 +14219,7 @@
               "type": "string"
             },
             "title": "비고",
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개\n"
           },
           "supplierDocumentKey": {
             "type": "string",
@@ -14251,7 +14251,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceItem"
             },
-            "description": "<p>최대 99개</p>\n"
+            "description": "최대 99개\n"
           },
           "contacts": {
             "title": "추가 담당자",
@@ -14259,7 +14259,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceAdditionalContact"
             },
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개\n"
           },
           "statusUpdatedAt": {
             "type": "string",
@@ -14274,7 +14274,7 @@
           "ntsApproveNumber": {
             "type": "string",
             "title": "국세청 승인번호",
-            "description": "<p>세금계산서 발행(전자서명) 시점에 자동으로 부여</p>\n"
+            "description": "세금계산서 발행(전자서명) 시점에 자동으로 부여\n"
           },
           "ntsSentAt": {
             "type": "string",
@@ -14288,7 +14288,7 @@
           "ntsResultCode": {
             "type": "string",
             "title": "국세청 결과 코드",
-            "description": "<p>국세청 발급 결과 코드로 영문 3자리 + 숫자 3자리로 구성됨</p>\n"
+            "description": "국세청 발급 결과 코드로 영문 3자리 + 숫자 3자리로 구성됨\n"
           },
           "ntsResultReceivedAt": {
             "type": "string",
@@ -14336,18 +14336,18 @@
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 권",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999\n"
           },
           "bookIssue": {
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 호",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999\n"
           },
           "writeDate": {
             "type": "string",
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
             "title": "작성일"
           },
           "purposeType": {
@@ -14395,7 +14395,7 @@
               "type": "string"
             },
             "title": "비고",
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개\n"
           },
           "supplierDocumentKey": {
             "type": "string",
@@ -14427,7 +14427,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceItem"
             },
-            "description": "<p>최대 99개</p>\n"
+            "description": "최대 99개\n"
           },
           "contacts": {
             "title": "추가 담당자",
@@ -14435,7 +14435,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceAdditionalContact"
             },
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개\n"
           },
           "statusUpdatedAt": {
             "type": "string",
@@ -14450,7 +14450,7 @@
           "ntsApproveNumber": {
             "type": "string",
             "title": "국세청 승인번호",
-            "description": "<p>세금계산서 발행(전자서명) 시점에 자동으로 부여</p>\n"
+            "description": "세금계산서 발행(전자서명) 시점에 자동으로 부여\n"
           },
           "ntsSentAt": {
             "type": "string",
@@ -14464,7 +14464,7 @@
           "ntsResultCode": {
             "type": "string",
             "title": "국세청 결과 코드",
-            "description": "<p>국세청 발급 결과 코드로 영문 3자리 + 숫자 3자리로 구성됨</p>\n"
+            "description": "국세청 발급 결과 코드로 영문 3자리 + 숫자 3자리로 구성됨\n"
           },
           "ntsResultReceivedAt": {
             "type": "string",
@@ -14588,8 +14588,8 @@
           },
           "recipientClosedSuspendedDate": {
             "type": "string",
-            "description": "<p>상태가 CLOSED, SUSPENDED 상태인 경우에만 결과값 반환</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "상태가 CLOSED, SUSPENDED 상태인 경우에만 결과값 반환\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
             "title": "공급받는자 휴폐업일자"
           },
           "issuedAt": {
@@ -14614,7 +14614,7 @@
           "ntsApproveNumber": {
             "type": "string",
             "title": "국세청 승인번호",
-            "description": "<p>세금계산서 발행(전자서명) 시점에 자동으로 부여</p>\n"
+            "description": "세금계산서 발행(전자서명) 시점에 자동으로 부여\n"
           },
           "ntsResult": {
             "type": "string",
@@ -14633,10 +14633,10 @@
           "ntsResultCode": {
             "type": "string",
             "title": "국세청 결과 코드",
-            "description": "<p>국세청 발급 결과 코드로 영문 3자리 + 숫자 3자리로 구성됨</p>\n"
+            "description": "국세청 발급 결과 코드로 영문 3자리 + 숫자 3자리로 구성됨\n"
           }
         },
-        "description": "<p>세금계산서 요약</p>\n",
+        "description": "세금계산서 요약\n",
         "x-portone-title": "세금계산서 요약"
       },
       "B2bTaxInvoiceWaitingSending": {
@@ -14676,18 +14676,18 @@
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 권",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999\n"
           },
           "bookIssue": {
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 호",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999\n"
           },
           "writeDate": {
             "type": "string",
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
             "title": "작성일"
           },
           "purposeType": {
@@ -14735,7 +14735,7 @@
               "type": "string"
             },
             "title": "비고",
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개\n"
           },
           "supplierDocumentKey": {
             "type": "string",
@@ -14767,7 +14767,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceItem"
             },
-            "description": "<p>최대 99개</p>\n"
+            "description": "최대 99개\n"
           },
           "contacts": {
             "title": "추가 담당자",
@@ -14775,7 +14775,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceAdditionalContact"
             },
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개\n"
           },
           "statusUpdatedAt": {
             "type": "string",
@@ -14790,14 +14790,14 @@
           "ntsApproveNumber": {
             "type": "string",
             "title": "국세청 승인번호",
-            "description": "<p>세금계산서 발행(전자서명) 시점에 자동으로 부여</p>\n"
+            "description": "세금계산서 발행(전자서명) 시점에 자동으로 부여\n"
           }
         }
       },
       "B2bTaxType": {
         "title": "과세 유형",
         "type": "string",
-        "description": "<p>과세 유형</p>\n",
+        "description": "과세 유형\n",
         "enum": [
           "FREE",
           "TAXABLE",
@@ -14819,7 +14819,7 @@
       "Bank": {
         "title": "은행",
         "type": "string",
-        "description": "<p>은행</p>\n",
+        "description": "은행\n",
         "enum": [
           "BANK_OF_AMERICA",
           "BANK_OF_CHINA",
@@ -15122,7 +15122,7 @@
             "title": "에스크로 상태"
           }
         },
-        "description": "<p>배송 정보 등록 전</p>\n",
+        "description": "배송 정보 등록 전\n",
         "x-portone-title": "배송 정보 등록 전"
       },
       "BillingKeyAlreadyDeletedError": {
@@ -15139,7 +15139,7 @@
             "type": "string"
           }
         },
-        "description": "<p>빌링키가 이미 삭제된 경우</p>\n",
+        "description": "빌링키가 이미 삭제된 경우\n",
         "x-portone-title": "빌링키가 이미 삭제된 경우",
         "x-portone-status-code": 409
       },
@@ -15173,7 +15173,7 @@
             "items": {
               "$ref": "#/components/schemas/BillingKeyPaymentMethod"
             },
-            "description": "<p>추후 슈퍼빌링키 기능 제공 시 여러 결제수단 정보가 담길 수 있습니다.</p>\n"
+            "description": "추후 슈퍼빌링키 기능 제공 시 여러 결제수단 정보가 담길 수 있습니다.\n"
           },
           "channels": {
             "title": "빌링키 발급 시 사용된 채널",
@@ -15181,7 +15181,7 @@
             "items": {
               "$ref": "#/components/schemas/SelectedChannel"
             },
-            "description": "<p>추후 슈퍼빌링키 기능 제공 시 여러 채널 정보가 담길 수 있습니다.</p>\n"
+            "description": "추후 슈퍼빌링키 기능 제공 시 여러 채널 정보가 담길 수 있습니다.\n"
           },
           "customer": {
             "$ref": "#/components/schemas/Customer",
@@ -15205,7 +15205,7 @@
             "title": "발급 시점"
           }
         },
-        "description": "<p>빌링키 정보</p>\n",
+        "description": "빌링키 정보\n",
         "x-portone-title": "빌링키 정보"
       },
       "BillingKeyInfoSummary": {
@@ -15240,7 +15240,7 @@
             "type": "string"
           }
         },
-        "description": "<p>빌링키가 존재하지 않는 경우</p>\n",
+        "description": "빌링키가 존재하지 않는 경우\n",
         "x-portone-title": "빌링키가 존재하지 않는 경우",
         "x-portone-status-code": 404
       },
@@ -15272,7 +15272,7 @@
           "storeId": {
             "type": "string",
             "title": "상점 아이디",
-            "description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.\n"
           },
           "billingKey": {
             "type": "string",
@@ -15325,7 +15325,7 @@
               "type": "string"
             },
             "title": "웹훅 주소",
-            "description": "<p>결제 승인/실패 시 요청을 받을 웹훅 주소입니다.\n상점에 설정되어 있는 값보다 우선적으로 적용됩니다.\n입력된 값이 없을 경우에는 빈 배열로 해석됩니다.</p>\n"
+            "description": "결제 승인/실패 시 요청을 받을 웹훅 주소입니다.\n상점에 설정되어 있는 값보다 우선적으로 적용됩니다.\n입력된 값이 없을 경우에는 빈 배열로 해석됩니다.\n"
           },
           "products": {
             "title": "상품 정보",
@@ -15333,7 +15333,7 @@
             "items": {
               "$ref": "#/components/schemas/PaymentProduct"
             },
-            "description": "<p>입력된 값이 없을 경우에는 빈 배열로 해석됩니다.</p>\n"
+            "description": "입력된 값이 없을 경우에는 빈 배열로 해석됩니다.\n"
           },
           "productCount": {
             "type": "integer",
@@ -15353,12 +15353,12 @@
             "title": "PG사별 추가 파라미터 (\"PG사별 연동 가이드\" 참고)"
           }
         },
-        "description": "<p>빌링키 결제 요청 입력 정보</p>\n",
+        "description": "빌링키 결제 요청 입력 정보\n",
         "x-portone-title": "빌링키 결제 요청 입력 정보"
       },
       "BillingKeyPaymentMethod": {
         "title": "빌링키 발급 수단 정보",
-        "description": "<p>빌링키 발급 수단 정보</p>\n",
+        "description": "빌링키 발급 수단 정보\n",
         "oneOf": [
           {
             "$ref": "#/components/schemas/BillingKeyPaymentMethodCard"
@@ -15420,7 +15420,7 @@
             "title": "카드 상세 정보"
           }
         },
-        "description": "<p>카드 정보</p>\n",
+        "description": "카드 정보\n",
         "x-portone-title": "카드 정보"
       },
       "BillingKeyPaymentMethodEasyPay": {
@@ -15442,7 +15442,7 @@
             "title": "간편 결제 수단"
           }
         },
-        "description": "<p>간편 결제 정보</p>\n",
+        "description": "간편 결제 정보\n",
         "x-portone-title": "간편 결제 정보"
       },
       "BillingKeyPaymentMethodEasyPayCharge": {
@@ -15456,12 +15456,12 @@
             "type": "string"
           }
         },
-        "description": "<p>충전식 포인트 결제 정보</p>\n",
+        "description": "충전식 포인트 결제 정보\n",
         "x-portone-title": "충전식 포인트 결제 정보"
       },
       "BillingKeyPaymentMethodEasyPayMethod": {
         "title": "간편 결제 수단",
-        "description": "<p>간편 결제 수단</p>\n",
+        "description": "간편 결제 수단\n",
         "oneOf": [
           {
             "$ref": "#/components/schemas/BillingKeyPaymentMethodCard"
@@ -15509,7 +15509,7 @@
             "title": "전화번호"
           }
         },
-        "description": "<p>모바일 정보</p>\n",
+        "description": "모바일 정보\n",
         "x-portone-title": "모바일 정보"
       },
       "BillingKeyPaymentMethodPaypal": {
@@ -15523,7 +15523,7 @@
             "type": "string"
           }
         },
-        "description": "<p>페이팔 정보</p>\n",
+        "description": "페이팔 정보\n",
         "x-portone-title": "페이팔 정보"
       },
       "BillingKeyPaymentMethodTransfer": {
@@ -15545,7 +15545,7 @@
             "title": "계좌번호"
           }
         },
-        "description": "<p>계좌이체 정보</p>\n",
+        "description": "계좌이체 정보\n",
         "x-portone-title": "계좌이체 정보"
       },
       "BillingKeyPaymentSummary": {
@@ -15566,7 +15566,7 @@
             "title": "결제 완료 시점"
           }
         },
-        "description": "<p>빌링키 결제 완료된 결제 건 요약 정보</p>\n",
+        "description": "빌링키 결제 완료된 결제 건 요약 정보\n",
         "x-portone-title": "빌링키 결제 완료된 결제 건 요약 정보"
       },
       "CancelAmountExceedsCancellableAmountError": {
@@ -15583,7 +15583,7 @@
             "type": "string"
           }
         },
-        "description": "<p>결제 취소 금액이 취소 가능 금액을 초과한 경우</p>\n",
+        "description": "결제 취소 금액이 취소 가능 금액을 초과한 경우\n",
         "x-portone-title": "결제 취소 금액이 취소 가능 금액을 초과한 경우",
         "x-portone-status-code": 409
       },
@@ -15606,14 +15606,14 @@
           "documentKeyType": {
             "$ref": "#/components/schemas/B2bTaxInvoiceDocumentKeyType",
             "title": "문서 번호 유형",
-            "description": "<p>기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.</p>\n"
+            "description": "기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.\n"
           },
           "memo": {
             "type": "string",
             "title": "메모"
           }
         },
-        "description": "<p>세금계산서 역발행 취소 정보</p>\n",
+        "description": "세금계산서 역발행 취소 정보\n",
         "x-portone-title": "세금계산서 역발행 취소 정보"
       },
       "CancelB2bTaxInvoiceIssuanceError": {
@@ -15664,14 +15664,14 @@
           "documentKeyType": {
             "$ref": "#/components/schemas/B2bTaxInvoiceDocumentKeyType",
             "title": "문서 번호 유형",
-            "description": "<p>기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.</p>\n"
+            "description": "기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.\n"
           },
           "memo": {
             "type": "string",
             "title": "메모"
           }
         },
-        "description": "<p>세금계산서 역발행 요청 취소 정보</p>\n",
+        "description": "세금계산서 역발행 요청 취소 정보\n",
         "x-portone-title": "세금계산서 역발행 요청 취소 정보"
       },
       "CancelB2bTaxInvoiceRequestError": {
@@ -15763,7 +15763,7 @@
             "title": "현금 영수증 취소 완료 시점"
           }
         },
-        "description": "<p>현금 영수증 취소 성공 응답</p>\n",
+        "description": "현금 영수증 취소 성공 응답\n",
         "x-portone-title": "현금 영수증 취소 성공 응답"
       },
       "CancelPaymentBody": {
@@ -15776,25 +15776,25 @@
           "storeId": {
             "type": "string",
             "title": "상점 아이디",
-            "description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.\n"
           },
           "amount": {
             "type": "integer",
             "format": "int64",
             "title": "취소 총 금액",
-            "description": "<p>값을 입력하지 않으면 전액 취소됩니다.</p>\n"
+            "description": "값을 입력하지 않으면 전액 취소됩니다.\n"
           },
           "taxFreeAmount": {
             "type": "integer",
             "format": "int64",
             "title": "취소 금액 중 면세 금액",
-            "description": "<p>값을 입력하지 않으면 전액 과세 취소됩니다.</p>\n"
+            "description": "값을 입력하지 않으면 전액 과세 취소됩니다.\n"
           },
           "vatAmount": {
             "type": "integer",
             "format": "int64",
             "title": "취소 금액 중 부가세액",
-            "description": "<p>값을 입력하지 않으면 자동 계산됩니다.</p>\n"
+            "description": "값을 입력하지 않으면 자동 계산됩니다.\n"
           },
           "reason": {
             "type": "string",
@@ -15804,15 +15804,15 @@
             "type": "integer",
             "format": "int64",
             "title": "결제 건의 취소 가능 잔액",
-            "description": "<p>본 취소 요청 이전의 취소 가능 잔액으로써, 값을 입력하면 잔액이 일치하는 경우에만 취소가 진행됩니다. 값을 입력하지 않으면 별도의 검증 처리를 수행하지 않습니다.</p>\n"
+            "description": "본 취소 요청 이전의 취소 가능 잔액으로써, 값을 입력하면 잔액이 일치하는 경우에만 취소가 진행됩니다. 값을 입력하지 않으면 별도의 검증 처리를 수행하지 않습니다.\n"
           },
           "refundAccount": {
             "$ref": "#/components/schemas/CancelPaymentBodyRefundAccount",
             "title": "환불 계좌",
-            "description": "<p>계좌 환불일 경우 입력합니다. 계좌 환불이 필요한 경우는 가상계좌 환불, 휴대폰 익월 환불 등이 있습니다.</p>\n"
+            "description": "계좌 환불일 경우 입력합니다. 계좌 환불이 필요한 경우는 가상계좌 환불, 휴대폰 익월 환불 등이 있습니다.\n"
           }
         },
-        "description": "<p>결제 취소 요청 입력 정보</p>\n",
+        "description": "결제 취소 요청 입력 정보\n",
         "x-portone-title": "결제 취소 요청 입력 정보"
       },
       "CancelPaymentBodyRefundAccount": {
@@ -15841,7 +15841,7 @@
             "title": "예금주 연락처 - 스마트로 가상계좌 결제인 경우에 필요합니다."
           }
         },
-        "description": "<p>고객 정보 입력 형식</p>\n",
+        "description": "고객 정보 입력 형식\n",
         "x-portone-title": "고객 정보 입력 형식"
       },
       "CancelPaymentError": {
@@ -15913,7 +15913,7 @@
             "title": "결체 취소 내역"
           }
         },
-        "description": "<p>결제 취소 성공 응답</p>\n",
+        "description": "결제 취소 성공 응답\n",
         "x-portone-title": "결제 취소 성공 응답"
       },
       "CancelPlatformAdditionalFeePolicyScheduleError": {
@@ -15944,7 +15944,7 @@
       "CancelPlatformAdditionalFeePolicyScheduleResponse": {
         "title": "추가 수수료 정책 예약 업데이트 취소 성공 응답",
         "type": "object",
-        "description": "<p>추가 수수료 정책 예약 업데이트 취소 성공 응답</p>\n",
+        "description": "추가 수수료 정책 예약 업데이트 취소 성공 응답\n",
         "x-portone-title": "추가 수수료 정책 예약 업데이트 취소 성공 응답"
       },
       "CancelPlatformContractScheduleError": {
@@ -15975,7 +15975,7 @@
       "CancelPlatformContractScheduleResponse": {
         "title": "계약 예약 업데이트 취소 성공 응답",
         "type": "object",
-        "description": "<p>계약 예약 업데이트 취소 성공 응답</p>\n",
+        "description": "계약 예약 업데이트 취소 성공 응답\n",
         "x-portone-title": "계약 예약 업데이트 취소 성공 응답"
       },
       "CancelPlatformDiscountSharePolicyScheduleError": {
@@ -16006,7 +16006,7 @@
       "CancelPlatformDiscountSharePolicyScheduleResponse": {
         "title": "할인 분담 정책 예약 업데이트 취소 성공 응답",
         "type": "object",
-        "description": "<p>할인 분담 정책 예약 업데이트 취소 성공 응답</p>\n",
+        "description": "할인 분담 정책 예약 업데이트 취소 성공 응답\n",
         "x-portone-title": "할인 분담 정책 예약 업데이트 취소 성공 응답"
       },
       "CancelPlatformPartnerScheduleError": {
@@ -16037,7 +16037,7 @@
       "CancelPlatformPartnerScheduleResponse": {
         "title": "파트너 예약 업데이트 취소 성공 응답",
         "type": "object",
-        "description": "<p>파트너 예약 업데이트 취소 성공 응답</p>\n",
+        "description": "파트너 예약 업데이트 취소 성공 응답\n",
         "x-portone-title": "파트너 예약 업데이트 취소 성공 응답"
       },
       "CancelTaxAmountExceedsCancellableTaxAmountError": {
@@ -16054,7 +16054,7 @@
             "type": "string"
           }
         },
-        "description": "<p>취소 과세 금액이 취소 가능한 과세 금액을 초과한 경우</p>\n",
+        "description": "취소 과세 금액이 취소 가능한 과세 금액을 초과한 경우\n",
         "x-portone-title": "취소 과세 금액이 취소 가능한 과세 금액을 초과한 경우",
         "x-portone-status-code": 409
       },
@@ -16072,7 +16072,7 @@
             "type": "string"
           }
         },
-        "description": "<p>취소 면세 금액이 취소 가능한 면세 금액을 초과한 경우</p>\n",
+        "description": "취소 면세 금액이 취소 가능한 면세 금액을 초과한 경우\n",
         "x-portone-title": "취소 면세 금액이 취소 가능한 면세 금액을 초과한 경우",
         "x-portone-status-code": 409
       },
@@ -16090,7 +16090,7 @@
             "type": "string"
           }
         },
-        "description": "<p>취소 가능 잔액 검증에 실패한 경우</p>\n",
+        "description": "취소 가능 잔액 검증에 실패한 경우\n",
         "x-portone-title": "취소 가능 잔액 검증에 실패한 경우",
         "x-portone-status-code": 409
       },
@@ -16186,7 +16186,7 @@
             "title": "취소 시점"
           }
         },
-        "description": "<p>발급 취소</p>\n",
+        "description": "발급 취소\n",
         "x-portone-title": "발급 취소"
       },
       "CancelledPayment": {
@@ -16222,7 +16222,7 @@
           "transactionId": {
             "type": "string",
             "title": "결제 건 포트원 채번 아이디",
-            "description": "<p>V1 결제 건의 경우 imp_uid에 해당합니다.</p>\n"
+            "description": "V1 결제 건의 경우 imp_uid에 해당합니다.\n"
           },
           "merchantId": {
             "type": "string",
@@ -16247,12 +16247,12 @@
           "scheduleId": {
             "type": "string",
             "title": "결제 예약 건 아이디",
-            "description": "<p>결제 예약을 이용한 경우에만 존재</p>\n"
+            "description": "결제 예약을 이용한 경우에만 존재\n"
           },
           "billingKey": {
             "type": "string",
             "title": "결제 시 사용된 빌링키",
-            "description": "<p>빌링키 결제인 경우에만 존재</p>\n"
+            "description": "빌링키 결제인 경우에만 존재\n"
           },
           "webhooks": {
             "title": "웹훅 발송 내역",
@@ -16303,7 +16303,7 @@
           "escrow": {
             "$ref": "#/components/schemas/PaymentEscrow",
             "title": "에스크로 결제 정보",
-            "description": "<p>에스크로 결제인 경우 존재합니다.</p>\n"
+            "description": "에스크로 결제인 경우 존재합니다.\n"
           },
           "products": {
             "title": "상품 정보",
@@ -16351,7 +16351,7 @@
             "title": "결제 취소 시점"
           }
         },
-        "description": "<p>결제 취소 상태 건</p>\n",
+        "description": "결제 취소 상태 건\n",
         "x-portone-title": "결제 취소 상태 건"
       },
       "CancelledPaymentCashReceipt": {
@@ -16411,7 +16411,7 @@
             "title": "취소 시점"
           }
         },
-        "description": "<p>취소된 현금영수증</p>\n",
+        "description": "취소된 현금영수증\n",
         "x-portone-title": "취소된 현금영수증"
       },
       "CancelledPaymentEscrow": {
@@ -16446,7 +16446,7 @@
             "title": "배송등록 처리 일자"
           }
         },
-        "description": "<p>거래 취소</p>\n",
+        "description": "거래 취소\n",
         "x-portone-title": "거래 취소"
       },
       "Card": {
@@ -16486,13 +16486,13 @@
             "title": "마스킹된 카드 번호"
           }
         },
-        "description": "<p>카드 상세 정보</p>\n",
+        "description": "카드 상세 정보\n",
         "x-portone-title": "카드 상세 정보"
       },
       "CardBrand": {
         "title": "카드 브랜드",
         "type": "string",
-        "description": "<p>카드 브랜드</p>\n",
+        "description": "카드 브랜드\n",
         "enum": [
           "AMEX",
           "DINERS",
@@ -16516,7 +16516,7 @@
       "CardCompany": {
         "title": "카드사",
         "type": "string",
-        "description": "<p>카드사</p>\n",
+        "description": "카드사\n",
         "enum": [
           "BC_CARD",
           "CITI_CARD",
@@ -16645,13 +16645,13 @@
             "title": "비밀번호 앞 두자리"
           }
         },
-        "description": "<p>카드 인증 관련 정보</p>\n",
+        "description": "카드 인증 관련 정보\n",
         "x-portone-title": "카드 인증 관련 정보"
       },
       "CardOwnerType": {
         "title": "카드 소유주 유형",
         "type": "string",
-        "description": "<p>카드 소유주 유형</p>\n",
+        "description": "카드 소유주 유형\n",
         "enum": [
           "CORPORATE",
           "PERSONAL"
@@ -16669,7 +16669,7 @@
       "CardType": {
         "title": "카드 유형",
         "type": "string",
-        "description": "<p>카드 유형</p>\n",
+        "description": "카드 유형\n",
         "enum": [
           "CREDIT",
           "DEBIT",
@@ -16690,7 +16690,7 @@
       },
       "CashReceipt": {
         "title": "현금영수증 내역",
-        "description": "<p>현금영수증 내역</p>\n",
+        "description": "현금영수증 내역\n",
         "oneOf": [
           {
             "$ref": "#/components/schemas/CancelledCashReceipt"
@@ -16737,7 +16737,7 @@
             "type": "string"
           }
         },
-        "description": "<p>현금영수증이 이미 발급된 경우</p>\n",
+        "description": "현금영수증이 이미 발급된 경우\n",
         "x-portone-title": "현금영수증이 이미 발급된 경우",
         "x-portone-status-code": 409
       },
@@ -16755,16 +16755,16 @@
           "customerIdentityNumber": {
             "type": "string",
             "title": "사용자 식별 번호",
-            "description": "<p>미발행 유형 선택 시 입력하지 않습니다.</p>\n"
+            "description": "미발행 유형 선택 시 입력하지 않습니다.\n"
           }
         },
-        "description": "<p>현금영수증 입력 정보</p>\n",
+        "description": "현금영수증 입력 정보\n",
         "x-portone-title": "현금영수증 입력 정보"
       },
       "CashReceiptInputType": {
         "title": "입력 시 발급 유형",
         "type": "string",
-        "description": "<p>입력 시 발급 유형</p>\n",
+        "description": "입력 시 발급 유형\n",
         "enum": [
           "CORPORATE",
           "NO_RECEIPT",
@@ -16780,7 +16780,7 @@
           },
           "NO_RECEIPT": {
             "title": "미발행",
-            "description": "<p>PG사 설정에 따라 PG사가 자동으로 자진발급 처리할 수 있습니다.</p>\n"
+            "description": "PG사 설정에 따라 PG사가 자동으로 자진발급 처리할 수 있습니다.\n"
           }
         }
       },
@@ -16798,7 +16798,7 @@
             "type": "string"
           }
         },
-        "description": "<p>현금영수증이 존재하지 않는 경우</p>\n",
+        "description": "현금영수증이 존재하지 않는 경우\n",
         "x-portone-title": "현금영수증이 존재하지 않는 경우",
         "x-portone-status-code": 404
       },
@@ -16816,7 +16816,7 @@
             "type": "string"
           }
         },
-        "description": "<p>현금영수증이 발급되지 않은 경우</p>\n",
+        "description": "현금영수증이 발급되지 않은 경우\n",
         "x-portone-title": "현금영수증이 발급되지 않은 경우",
         "x-portone-status-code": 404
       },
@@ -16842,13 +16842,13 @@
             "title": "PG사 현금영수증 아이디"
           }
         },
-        "description": "<p>현금영수증 내역</p>\n",
+        "description": "현금영수증 내역\n",
         "x-portone-title": "현금영수증 내역"
       },
       "CashReceiptType": {
         "title": "발급 유형",
         "type": "string",
-        "description": "<p>발급 유형</p>\n",
+        "description": "발급 유형\n",
         "enum": [
           "CORPORATE",
           "PERSONAL"
@@ -16914,7 +16914,7 @@
             "title": "PG사 인증 정보"
           }
         },
-        "description": "<p>채널 정보</p>\n",
+        "description": "채널 정보\n",
         "x-portone-title": "채널 정보"
       },
       "ChannelDanalCredential": {
@@ -16934,7 +16934,7 @@
             "type": "string"
           }
         },
-        "description": "<p>다날 인증 정보</p>\n",
+        "description": "다날 인증 정보\n",
         "x-portone-title": "다날 인증 정보"
       },
       "ChannelKsnetCredential": {
@@ -16951,7 +16951,7 @@
             "type": "string"
           }
         },
-        "description": "<p>KSNET 인증 정보</p>\n",
+        "description": "KSNET 인증 정보\n",
         "x-portone-title": "KSNET 인증 정보"
       },
       "ChannelNaverPayCredential": {
@@ -16974,7 +16974,7 @@
             "type": "string"
           }
         },
-        "description": "<p>네이버페이 인증 정보</p>\n",
+        "description": "네이버페이 인증 정보\n",
         "x-portone-title": "네이버페이 인증 정보"
       },
       "ChannelNotFoundError": {
@@ -16991,13 +16991,13 @@
             "type": "string"
           }
         },
-        "description": "<p>요청된 채널이 존재하지 않는 경우</p>\n",
+        "description": "요청된 채널이 존재하지 않는 경우\n",
         "x-portone-title": "요청된 채널이 존재하지 않는 경우",
         "x-portone-status-code": 404
       },
       "ChannelPgCredential": {
         "title": "PG사 인증 정보",
-        "description": "<p>PG사 인증 정보</p>\n",
+        "description": "PG사 인증 정보\n",
         "oneOf": [
           {
             "$ref": "#/components/schemas/ChannelDanalCredential"
@@ -17067,7 +17067,7 @@
             "type": "string"
           }
         },
-        "description": "<p>스마트로V2 인증 정보</p>\n",
+        "description": "스마트로V2 인증 정보\n",
         "x-portone-title": "스마트로V2 인증 정보"
       },
       "ChannelTossPaymentsCredential": {
@@ -17087,13 +17087,13 @@
             "type": "string"
           }
         },
-        "description": "<p>토스페이먼츠 인증 정보</p>\n",
+        "description": "토스페이먼츠 인증 정보\n",
         "x-portone-title": "토스페이먼츠 인증 정보"
       },
       "ChannelType": {
         "title": "채널 유형",
         "type": "string",
-        "description": "<p>채널 유형</p>\n",
+        "description": "채널 유형\n",
         "enum": [
           "LIVE",
           "MERCHANT_TEST",
@@ -17158,7 +17158,7 @@
             "title": "가상계좌 말소 시점"
           }
         },
-        "description": "<p>가상계좌 말소 성공 응답</p>\n",
+        "description": "가상계좌 말소 성공 응답\n",
         "x-portone-title": "가상계좌 말소 성공 응답"
       },
       "CompletePlatformPayoutError": {
@@ -17216,15 +17216,15 @@
           "storeId": {
             "type": "string",
             "title": "상점 아이디",
-            "description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.\n"
           },
           "fromStore": {
             "type": "boolean",
             "title": "확인 주체가 상점인지 여부",
-            "description": "<p>구매확정요청 주체가 가맹점 관리자인지 구매자인지 구분하기 위한 필드입니다.\n네이버페이 전용 파라미터이며, 구분이 모호한 경우 가맹점 관리자(true)로 입력합니다.</p>\n"
+            "description": "구매확정요청 주체가 가맹점 관리자인지 구매자인지 구분하기 위한 필드입니다.\n네이버페이 전용 파라미터이며, 구분이 모호한 경우 가맹점 관리자(true)로 입력합니다.\n"
           }
         },
-        "description": "<p>에스크로 구매 확정 입력 정보</p>\n",
+        "description": "에스크로 구매 확정 입력 정보\n",
         "x-portone-title": "에스크로 구매 확정 입력 정보"
       },
       "ConfirmEscrowError": {
@@ -17273,7 +17273,7 @@
             "title": "에스크로 구매 확정 시점"
           }
         },
-        "description": "<p>에스크로 구매 확정 성공 응답</p>\n",
+        "description": "에스크로 구매 확정 성공 응답\n",
         "x-portone-title": "에스크로 구매 확정 성공 응답"
       },
       "ConfirmIdentityVerificationBody": {
@@ -17283,15 +17283,15 @@
           "storeId": {
             "type": "string",
             "title": "상점 아이디",
-            "description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.\n"
           },
           "otp": {
             "type": "string",
             "title": "OTP (One-Time Password)",
-            "description": "<p>SMS 방식에서만 사용됩니다.</p>\n"
+            "description": "SMS 방식에서만 사용됩니다.\n"
           }
         },
-        "description": "<p>본인인증 확인을 위한 입력 정보</p>\n",
+        "description": "본인인증 확인을 위한 입력 정보\n",
         "x-portone-title": "본인인증 확인을 위한 입력 정보"
       },
       "ConfirmIdentityVerificationError": {
@@ -17343,7 +17343,7 @@
             "title": "완료된 본인인증 내역"
           }
         },
-        "description": "<p>본인인증 확인 성공 응답</p>\n",
+        "description": "본인인증 확인 성공 응답\n",
         "x-portone-title": "본인인증 확인 성공 응답"
       },
       "ConfirmedPaymentEscrow": {
@@ -17383,13 +17383,13 @@
             "title": "자동 구매 확정 처리 여부"
           }
         },
-        "description": "<p>구매 확정</p>\n",
+        "description": "구매 확정\n",
         "x-portone-title": "구매 확정"
       },
       "Country": {
         "title": "국가",
         "type": "string",
-        "description": "<p>국가</p>\n",
+        "description": "국가\n",
         "enum": [
           "AD",
           "AE",
@@ -18443,7 +18443,7 @@
             "title": "결제 예정 시점"
           }
         },
-        "description": "<p>결제 예약 요청 입력 정보</p>\n",
+        "description": "결제 예약 요청 입력 정보\n",
         "x-portone-title": "결제 예약 요청 입력 정보"
       },
       "CreatePaymentScheduleError": {
@@ -18503,7 +18503,7 @@
             "title": "결제 예약 건"
           }
         },
-        "description": "<p>결제 예약 성공 응답</p>\n",
+        "description": "결제 예약 성공 응답\n",
         "x-portone-title": "결제 예약 성공 응답"
       },
       "CreatePlatformAdditionalFeePolicyBody": {
@@ -18518,7 +18518,7 @@
           "id": {
             "type": "string",
             "title": "생성할 추가 수수료 정책 아이디",
-            "description": "<p>명시하지 않으면 id 가 임의로 생성됩니다.</p>\n"
+            "description": "명시하지 않으면 id 가 임의로 생성됩니다.\n"
           },
           "name": {
             "type": "string",
@@ -18537,7 +18537,7 @@
             "title": "부가세 부담 주체"
           }
         },
-        "description": "<p>추가 수수료 정책 생성을 위한 입력 정보</p>\n",
+        "description": "추가 수수료 정책 생성을 위한 입력 정보\n",
         "x-portone-title": "추가 수수료 정책 생성을 위한 입력 정보"
       },
       "CreatePlatformAdditionalFeePolicyError": {
@@ -18577,7 +18577,7 @@
             "title": "생성된 추가 수수료 정책"
           }
         },
-        "description": "<p>플랫폼 생성 성공 응답 정보</p>\n",
+        "description": "플랫폼 생성 성공 응답 정보\n",
         "x-portone-title": "플랫폼 생성 성공 응답 정보"
       },
       "CreatePlatformContractBody": {
@@ -18594,7 +18594,7 @@
           "id": {
             "type": "string",
             "title": "계약에 부여할 고유 아이디",
-            "description": "<p>명시하지 않는 경우 포트원이 임의의 아이디를 발급해드립니다.</p>\n"
+            "description": "명시하지 않는 경우 포트원이 임의의 아이디를 발급해드립니다.\n"
           },
           "name": {
             "type": "string",
@@ -18621,7 +18621,7 @@
             "title": "정산 시 결제금액 부가세 감액 여부"
           }
         },
-        "description": "<p>계약 객체 생성을 위한 입력 정보</p>\n",
+        "description": "계약 객체 생성을 위한 입력 정보\n",
         "x-portone-title": "계약 객체 생성을 위한 입력 정보"
       },
       "CreatePlatformContractError": {
@@ -18661,7 +18661,7 @@
             "title": "생성된 계약 객체"
           }
         },
-        "description": "<p>계약 객체 생성 성공 응답</p>\n",
+        "description": "계약 객체 생성 성공 응답\n",
         "x-portone-title": "계약 객체 생성 성공 응답"
       },
       "CreatePlatformDiscountSharePolicyBody": {
@@ -18675,7 +18675,7 @@
           "id": {
             "type": "string",
             "title": "할인 분담에 부여할 고유 아이디",
-            "description": "<p>명시하지 않는 경우 포트원이 임의의 아이디를 발급해드립니다.</p>\n"
+            "description": "명시하지 않는 경우 포트원이 임의의 아이디를 발급해드립니다.\n"
           },
           "name": {
             "type": "string",
@@ -18691,7 +18691,7 @@
             "title": "해당 할인 분담에 대한 메모 ex) 파트너 브랜드 쿠폰"
           }
         },
-        "description": "<p>할인 분담 정책 생성을 위한 입력 정보</p>\n",
+        "description": "할인 분담 정책 생성을 위한 입력 정보\n",
         "x-portone-title": "할인 분담 정책 생성을 위한 입력 정보"
       },
       "CreatePlatformDiscountSharePolicyError": {
@@ -18731,7 +18731,7 @@
             "title": "생성된 할인 분담 정책"
           }
         },
-        "description": "<p>할인 분담 정책 생성 성공 응답</p>\n",
+        "description": "할인 분담 정책 생성 성공 응답\n",
         "x-portone-title": "할인 분담 정책 생성 성공 응답"
       },
       "CreatePlatformManualTransferBody": {
@@ -18754,8 +18754,8 @@
           },
           "settlementDate": {
             "type": "string",
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n"
+            "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n"
           },
           "isForTest": {
             "type": "boolean"
@@ -18825,8 +18825,8 @@
           },
           "settlementStartDate": {
             "type": "string",
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n"
+            "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n"
           },
           "externalCancellationDetail": {
             "$ref": "#/components/schemas/CreatePlatformOrderCancelTransferBodyExternalCancellationDetail"
@@ -18835,9 +18835,9 @@
             "type": "boolean"
           }
         },
-        "description": "<p>취소 정산 등록을 위한 입력 정보</p>\n<p>하나의 payment에 하나의 정산 건만 존재하는 경우에는 (partnerId, paymentId)로 취소 정산을 등록하실 수 있습니다.\n하나의 payment에 여러 개의 정산 건이 존재하는 경우에는 transferId를 필수로 입력해야 합니다.\ntransferId를 입력한 경우 (partnerId, paymentId)는 생략 가능합니다.</p>\n",
+        "description": "취소 정산 등록을 위한 입력 정보\n하나의 payment에 하나의 정산 건만 존재하는 경우에는 (partnerId, paymentId)로 취소 정산을 등록하실 수 있습니다.\n하나의 payment에 여러 개의 정산 건이 존재하는 경우에는 transferId를 필수로 입력해야 합니다.\ntransferId를 입력한 경우 (partnerId, paymentId)는 생략 가능합니다.\n",
         "x-portone-title": "취소 정산 등록을 위한 입력 정보",
-        "x-portone-description": "<p>하나의 payment에 하나의 정산 건만 존재하는 경우에는 (partnerId, paymentId)로 취소 정산을 등록하실 수 있습니다.\n하나의 payment에 여러 개의 정산 건이 존재하는 경우에는 transferId를 필수로 입력해야 합니다.\ntransferId를 입력한 경우 (partnerId, paymentId)는 생략 가능합니다.</p>\n"
+        "x-portone-description": "하나의 payment에 하나의 정산 건만 존재하는 경우에는 (partnerId, paymentId)로 취소 정산을 등록하실 수 있습니다.\n하나의 payment에 여러 개의 정산 건이 존재하는 경우에는 transferId를 필수로 입력해야 합니다.\ntransferId를 입력한 경우 (partnerId, paymentId)는 생략 가능합니다.\n"
       },
       "CreatePlatformOrderCancelTransferBodyDiscount": {
         "required": [
@@ -19020,8 +19020,8 @@
           },
           "settlementStartDate": {
             "type": "string",
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n"
+            "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n"
           },
           "discounts": {
             "type": "array",
@@ -19237,7 +19237,7 @@
           "id": {
             "type": "string",
             "title": "파트너에 부여할 고유 아이디",
-            "description": "<p>가맹점 서버에 등록된 파트너 지칭 아이디와 동일하게 설정하는 것을 권장합니다. 명시하지 않는 경우 포트원이 임의의 아이디를 발급해드립니다.</p>\n"
+            "description": "가맹점 서버에 등록된 파트너 지칭 아이디와 동일하게 설정하는 것을 권장합니다. 명시하지 않는 경우 포트원이 임의의 아이디를 발급해드립니다.\n"
           },
           "name": {
             "type": "string",
@@ -19250,17 +19250,17 @@
           "account": {
             "$ref": "#/components/schemas/CreatePlatformPartnerBodyAccount",
             "title": "정산 계좌",
-            "description": "<p>파트너의 사업자등록번호가 존재하는 경우 명시합니다. 별도로 검증하지는 않으며, 번호와 기호 모두 입력 가능합니다.</p>\n"
+            "description": "파트너의 사업자등록번호가 존재하는 경우 명시합니다. 별도로 검증하지는 않으며, 번호와 기호 모두 입력 가능합니다.\n"
           },
           "defaultContractId": {
             "type": "string",
             "title": "기본 계약 아이디",
-            "description": "<p>이미 존재하는 계약 아이디를 등록해야 합니다.</p>\n"
+            "description": "이미 존재하는 계약 아이디를 등록해야 합니다.\n"
           },
           "memo": {
             "type": "string",
             "title": "파트너에 대한 메모",
-            "description": "<p>총 256자까지 입력할 수 있습니다.</p>\n"
+            "description": "총 256자까지 입력할 수 있습니다.\n"
           },
           "tags": {
             "type": "array",
@@ -19268,15 +19268,15 @@
               "type": "string"
             },
             "title": "파트너에 부여할 태그 리스트",
-            "description": "<p>최대 10개까지 입력할 수 있습니다.</p>\n"
+            "description": "최대 10개까지 입력할 수 있습니다.\n"
           },
           "type": {
             "$ref": "#/components/schemas/CreatePlatformPartnerBodyType",
             "title": "파트너 유형별 추가 정보",
-            "description": "<p>사업자/원천징수대상자 중 추가할 파트너의 유형에 따른 정보를 입력해야 합니다.</p>\n"
+            "description": "사업자/원천징수대상자 중 추가할 파트너의 유형에 따른 정보를 입력해야 합니다.\n"
           }
         },
-        "description": "<p>파트너 생성을 위한 입력 정보</p>\n",
+        "description": "파트너 생성을 위한 입력 정보\n",
         "x-portone-title": "파트너 생성을 위한 입력 정보"
       },
       "CreatePlatformPartnerBodyAccount": {
@@ -19306,7 +19306,7 @@
             "title": "예금주명"
           }
         },
-        "description": "<p>파트너 계좌 등록을 위한 정보</p>\n",
+        "description": "파트너 계좌 등록을 위한 정보\n",
         "x-portone-title": "파트너 계좌 등록을 위한 정보"
       },
       "CreatePlatformPartnerBodyContact": {
@@ -19331,7 +19331,7 @@
             "title": "담당자 이메일"
           }
         },
-        "description": "<p>파트너 담당자 정보</p>\n",
+        "description": "파트너 담당자 정보\n",
         "x-portone-title": "파트너 담당자 정보"
       },
       "CreatePlatformPartnerBodyType": {
@@ -19347,7 +19347,7 @@
             "title": "원천징수대상자 추가 정보"
           }
         },
-        "description": "<p>파트너 생성을 위한 유형별 추가 정보</p>\n",
+        "description": "파트너 생성을 위한 유형별 추가 정보\n",
         "x-portone-title": "파트너 생성을 위한 유형별 추가 정보"
       },
       "CreatePlatformPartnerBodyTypeBusiness": {
@@ -19437,7 +19437,7 @@
             "title": "생성된 파트너"
           }
         },
-        "description": "<p>파트너 생성 성공 응답</p>\n",
+        "description": "파트너 생성 성공 응답\n",
         "x-portone-title": "파트너 생성 성공 응답"
       },
       "CreatePlatformPartnersBody": {
@@ -19455,7 +19455,7 @@
             }
           }
         },
-        "description": "<p>파트너 다건 생성을 위한 입력 정보</p>\n",
+        "description": "파트너 다건 생성을 위한 입력 정보\n",
         "x-portone-title": "파트너 다건 생성을 위한 입력 정보"
       },
       "CreatePlatformPartnersError": {
@@ -19506,7 +19506,7 @@
             }
           }
         },
-        "description": "<p>파트너 다건 생성 성공 응답</p>\n",
+        "description": "파트너 다건 생성 성공 응답\n",
         "x-portone-title": "파트너 다건 생성 성공 응답"
       },
       "CreatePlatformPayoutBody": {
@@ -19567,7 +19567,7 @@
       "Currency": {
         "title": "통화 단위",
         "type": "string",
-        "description": "<p>통화 단위</p>\n",
+        "description": "통화 단위\n",
         "enum": [
           "AED",
           "AFN",
@@ -20305,7 +20305,7 @@
           "id": {
             "type": "string",
             "title": "고객 아이디",
-            "description": "<p>가맹점이 지정한 고객의 고유 식별자입니다.</p>\n"
+            "description": "가맹점이 지정한 고객의 고유 식별자입니다.\n"
           },
           "name": {
             "type": "string",
@@ -20336,7 +20336,7 @@
             "title": "우편번호"
           }
         },
-        "description": "<p>고객 정보</p>\n",
+        "description": "고객 정보\n",
         "x-portone-title": "고객 정보"
       },
       "CustomerInput": {
@@ -20346,7 +20346,7 @@
           "id": {
             "type": "string",
             "title": "고객 아이디",
-            "description": "<p>가맹점이 지정한 고객의 고유 식별자입니다.</p>\n"
+            "description": "가맹점이 지정한 고객의 고유 식별자입니다.\n"
           },
           "name": {
             "$ref": "#/components/schemas/CustomerNameInput",
@@ -20393,7 +20393,7 @@
             "title": "사업자 등록 번호"
           }
         },
-        "description": "<p>고객 정보 입력 정보</p>\n",
+        "description": "고객 정보 입력 정보\n",
         "x-portone-title": "고객 정보 입력 정보"
       },
       "CustomerNameInput": {
@@ -20409,9 +20409,9 @@
             "title": "분리형 이름 형식"
           }
         },
-        "description": "<p>고객 이름 입력 정보</p>\n<p>두 개의 이름 형식 중 한 가지만 선택하여 입력해주세요.</p>\n",
+        "description": "고객 이름 입력 정보\n두 개의 이름 형식 중 한 가지만 선택하여 입력해주세요.\n",
         "x-portone-title": "고객 이름 입력 정보",
-        "x-portone-description": "<p>두 개의 이름 형식 중 한 가지만 선택하여 입력해주세요.</p>\n"
+        "x-portone-description": "두 개의 이름 형식 중 한 가지만 선택하여 입력해주세요.\n"
       },
       "CustomerSeparatedName": {
         "title": "고객 분리형 이름",
@@ -20430,7 +20430,7 @@
             "title": "성"
           }
         },
-        "description": "<p>고객 분리형 이름</p>\n",
+        "description": "고객 분리형 이름\n",
         "x-portone-title": "고객 분리형 이름"
       },
       "DateRange": {
@@ -20442,13 +20442,13 @@
         "properties": {
           "from": {
             "type": "string",
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n"
+            "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n"
           },
           "until": {
             "type": "string",
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n"
+            "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n"
           }
         }
       },
@@ -20469,13 +20469,13 @@
             "format": "date-time"
           }
         },
-        "description": "<p>시간 범위</p>\n",
+        "description": "시간 범위\n",
         "x-portone-title": "시간 범위"
       },
       "DayOfWeek": {
         "title": "요일",
         "type": "string",
-        "description": "<p>요일</p>\n",
+        "description": "요일\n",
         "enum": [
           "FRI",
           "MON",
@@ -20583,7 +20583,7 @@
             "title": "빌링키 삭제 완료 시점"
           }
         },
-        "description": "<p>빌링키 삭제 성공 응답</p>\n",
+        "description": "빌링키 삭제 성공 응답\n",
         "x-portone-title": "빌링키 삭제 성공 응답"
       },
       "DeletePlatformPayoutError": {
@@ -20694,7 +20694,7 @@
             "title": "배송등록 처리 일자"
           }
         },
-        "description": "<p>배송 완료</p>\n",
+        "description": "배송 완료\n",
         "x-portone-title": "배송 완료"
       },
       "DownloadPlatformPayoutSheetError": {
@@ -20729,7 +20729,7 @@
       "EasyPayMethodType": {
         "title": "간편 결제 수단",
         "type": "string",
-        "description": "<p>간편 결제 수단</p>\n",
+        "description": "간편 결제 수단\n",
         "enum": [
           "CARD",
           "CHARGE",
@@ -20745,7 +20745,7 @@
       "EasyPayProvider": {
         "title": "간편 결제사",
         "type": "string",
-        "description": "<p>간편 결제사</p>\n",
+        "description": "간편 결제사\n",
         "enum": [
           "ALIPAY",
           "APPLEPAY",
@@ -20832,7 +20832,7 @@
             "title": "상태 업데이트 시점"
           }
         },
-        "description": "<p>실패한 본인인증 내역</p>\n",
+        "description": "실패한 본인인증 내역\n",
         "x-portone-title": "실패한 본인인증 내역"
       },
       "FailedPayment": {
@@ -20866,7 +20866,7 @@
           "transactionId": {
             "type": "string",
             "title": "결제 건 포트원 채번 아이디",
-            "description": "<p>V1 결제 건의 경우 imp_uid에 해당합니다.</p>\n"
+            "description": "V1 결제 건의 경우 imp_uid에 해당합니다.\n"
           },
           "merchantId": {
             "type": "string",
@@ -20891,12 +20891,12 @@
           "scheduleId": {
             "type": "string",
             "title": "결제 예약 건 아이디",
-            "description": "<p>결제 예약을 이용한 경우에만 존재</p>\n"
+            "description": "결제 예약을 이용한 경우에만 존재\n"
           },
           "billingKey": {
             "type": "string",
             "title": "결제 시 사용된 빌링키",
-            "description": "<p>빌링키 결제인 경우에만 존재</p>\n"
+            "description": "빌링키 결제인 경우에만 존재\n"
           },
           "webhooks": {
             "title": "웹훅 발송 내역",
@@ -20947,7 +20947,7 @@
           "escrow": {
             "$ref": "#/components/schemas/PaymentEscrow",
             "title": "에스크로 결제 정보",
-            "description": "<p>에스크로 결제인 경우 존재합니다.</p>\n"
+            "description": "에스크로 결제인 경우 존재합니다.\n"
           },
           "products": {
             "title": "상품 정보",
@@ -20975,7 +20975,7 @@
             "title": "결제 실패 시점"
           }
         },
-        "description": "<p>결제 실패 상태 건</p>\n",
+        "description": "결제 실패 상태 건\n",
         "x-portone-title": "결제 실패 상태 건"
       },
       "FailedPaymentCancellation": {
@@ -21038,7 +21038,7 @@
             "title": "취소 요청 시점"
           }
         },
-        "description": "<p>취소 실패 상태</p>\n",
+        "description": "취소 실패 상태\n",
         "x-portone-title": "취소 실패 상태"
       },
       "FailedPaymentSchedule": {
@@ -21156,7 +21156,7 @@
             "title": "결제 완료 시점"
           }
         },
-        "description": "<p>결제 실패 상태</p>\n",
+        "description": "결제 실패 상태\n",
         "x-portone-title": "결제 실패 상태"
       },
       "ForbiddenError": {
@@ -21173,14 +21173,14 @@
             "type": "string"
           }
         },
-        "description": "<p>요청이 거절된 경우</p>\n",
+        "description": "요청이 거절된 경우\n",
         "x-portone-title": "요청이 거절된 경우",
         "x-portone-status-code": 403
       },
       "Gender": {
         "title": "성별",
         "type": "string",
-        "description": "<p>성별</p>\n",
+        "description": "성별\n",
         "enum": [
           "FEMALE",
           "MALE",
@@ -21205,34 +21205,34 @@
           "storeId": {
             "type": "string",
             "title": "상점 아이디",
-            "description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.\n"
           },
           "from": {
             "type": "string",
             "format": "date-time",
             "title": "결제 건 생성시점 범위 조건의 시작",
-            "description": "<p>값을 입력하지 않으면 end의 90일 전으로 설정됩니다.</p>\n"
+            "description": "값을 입력하지 않으면 end의 90일 전으로 설정됩니다.\n"
           },
           "until": {
             "type": "string",
             "format": "date-time",
             "title": "결제 건 생성시점 범위 조건의 끝",
-            "description": "<p>값을 입력하지 않으면 현재 시점으로 설정됩니다.</p>\n"
+            "description": "값을 입력하지 않으면 현재 시점으로 설정됩니다.\n"
           },
           "cursor": {
             "type": "string",
             "title": "커서",
-            "description": "<p>결제 건 리스트 중 어디서부터 읽어야 할지 가리키는 값입니다. 최초 요청일 경우 값을 입력하지 마시되, 두번째 요청 부터는 이전 요청 응답값의 cursor를 입력해주시면 됩니다.</p>\n"
+            "description": "결제 건 리스트 중 어디서부터 읽어야 할지 가리키는 값입니다. 최초 요청일 경우 값을 입력하지 마시되, 두번째 요청 부터는 이전 요청 응답값의 cursor를 입력해주시면 됩니다.\n"
           },
           "size": {
             "type": "integer",
             "format": "int32",
             "title": "페이지 크기",
-            "description": "<p>미입력 시 기본값은 10 이며 최대 1000까지 허용</p>\n"
+            "description": "미입력 시 기본값은 10 이며 최대 1000까지 허용\n"
           }
         },
-        "description": "<p>결제 건 커서 기반 대용량 다건 조회를 위한 입력 정보</p>\n",
-        "x-portone-description": "<p>결제 건 커서 기반 대용량 다건 조회를 위한 입력 정보</p>\n"
+        "description": "결제 건 커서 기반 대용량 다건 조회를 위한 입력 정보\n",
+        "x-portone-description": "결제 건 커서 기반 대용량 다건 조회를 위한 입력 정보\n"
       },
       "GetAllPaymentsByCursorResponse": {
         "title": "결제 건 커서 기반 대용량 다건 조회 성공 응답 정보",
@@ -21249,7 +21249,7 @@
             }
           }
         },
-        "description": "<p>결제 건 커서 기반 대용량 다건 조회 성공 응답 정보</p>\n",
+        "description": "결제 건 커서 기반 대용량 다건 조회 성공 응답 정보\n",
         "x-portone-title": "결제 건 커서 기반 대용량 다건 조회 성공 응답 정보"
       },
       "GetAllPaymentsError": {
@@ -21297,20 +21297,20 @@
           "currency": {
             "$ref": "#/components/schemas/Currency",
             "title": "조회할 결제 통화",
-            "description": "<p>입력된 통화로 발생한 결제내역만 응답에 포함됩니다.</p>\n"
+            "description": "입력된 통화로 발생한 결제내역만 응답에 포함됩니다.\n"
           },
           "excludeCancelled": {
             "type": "boolean",
             "title": "결제취소건 제외 여부",
-            "description": "<p>true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다.</p>\n"
+            "description": "true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다.\n"
           },
           "timeGranularity": {
             "$ref": "#/components/schemas/AnalyticsTimeGranularity",
             "title": "평균 거래액 현황 조회 단위",
-            "description": "<p>시간별, 월별 단위만 지원됩니다.</p>\n"
+            "description": "시간별, 월별 단위만 지원됩니다.\n"
           }
         },
-        "description": "<p>가맹점의 평균 거래액 현황 조회를 위한 입력 정보</p>\n",
+        "description": "가맹점의 평균 거래액 현황 조회를 위한 입력 정보\n",
         "x-portone-title": "가맹점의 평균 거래액 현황 조회를 위한 입력 정보"
       },
       "GetAnalyticsCancellationRateBody": {
@@ -21335,10 +21335,10 @@
           "currency": {
             "$ref": "#/components/schemas/Currency",
             "title": "조회할 결제 통화",
-            "description": "<p>입력된 통화로 발생한 결제내역만 응답에 포함됩니다.</p>\n"
+            "description": "입력된 통화로 발생한 결제내역만 응답에 포함됩니다.\n"
           }
         },
-        "description": "<p>가맹점의 환불율 조회를 위한 입력 정보</p>\n",
+        "description": "가맹점의 환불율 조회를 위한 입력 정보\n",
         "x-portone-title": "가맹점의 환불율 조회를 위한 입력 정보"
       },
       "GetAnalyticsCancellationRateError": {
@@ -21386,20 +21386,20 @@
           "currency": {
             "$ref": "#/components/schemas/Currency",
             "title": "조회할 결제 통화",
-            "description": "<p>입력된 통화로 발생한 결제내역만 응답에 포함됩니다.</p>\n"
+            "description": "입력된 통화로 발생한 결제내역만 응답에 포함됩니다.\n"
           },
           "excludeCancelled": {
             "type": "boolean",
             "title": "결제취소건 제외 여부",
-            "description": "<p>true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다.</p>\n"
+            "description": "true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다.\n"
           },
           "timeGranularity": {
             "$ref": "#/components/schemas/AnalyticsTimeGranularity",
             "title": "카드결제 현황 조회 단위",
-            "description": "<p>시간별, 월별 단위만 지원됩니다.</p>\n"
+            "description": "시간별, 월별 단위만 지원됩니다.\n"
           }
         },
-        "description": "<p>가맹점의 카드결제 현황 조회를 위한 입력 정보</p>\n",
+        "description": "가맹점의 카드결제 현황 조회를 위한 입력 정보\n",
         "x-portone-title": "가맹점의 카드결제 현황 조회를 위한 입력 정보"
       },
       "GetAnalyticsCardChartError": {
@@ -21449,17 +21449,17 @@
           "currency": {
             "$ref": "#/components/schemas/Currency",
             "title": "조회할 결제 통화",
-            "description": "<p>입력된 통화로 발생한 결제내역만 응답에 포함됩니다.</p>\n"
+            "description": "입력된 통화로 발생한 결제내역만 응답에 포함됩니다.\n"
           },
           "excludeCancelled": {
             "type": "boolean",
             "title": "결제취소건 제외 여부",
-            "description": "<p>true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다.</p>\n"
+            "description": "true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다.\n"
           },
           "timeGranularity": {
             "$ref": "#/components/schemas/AnalyticsTimeGranularity",
             "title": "카드사별 결제 현황 조회 단위",
-            "description": "<p>시간별, 월별 단위만 지원됩니다.</p>\n"
+            "description": "시간별, 월별 단위만 지원됩니다.\n"
           },
           "cardCompanies": {
             "title": "조회할 카드사",
@@ -21476,7 +21476,7 @@
             }
           }
         },
-        "description": "<p>가맹점의 카드사별 결제 현황 조회를 위한 입력 정보</p>\n",
+        "description": "가맹점의 카드사별 결제 현황 조회를 위한 입력 정보\n",
         "x-portone-title": "가맹점의 카드사별 결제 현황 조회를 위한 입력 정보"
       },
       "GetAnalyticsCardCompanyChartError": {
@@ -21524,20 +21524,20 @@
           "currency": {
             "$ref": "#/components/schemas/Currency",
             "title": "조회할 결제 통화",
-            "description": "<p>입력된 통화로 발생한 결제내역만 응답에 포함됩니다.</p>\n"
+            "description": "입력된 통화로 발생한 결제내역만 응답에 포함됩니다.\n"
           },
           "excludeCancelled": {
             "type": "boolean",
             "title": "결제취소건 제외 여부",
-            "description": "<p>true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다.</p>\n"
+            "description": "true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다.\n"
           },
           "timeGranularity": {
             "$ref": "#/components/schemas/AnalyticsTimeGranularity",
             "title": "간편결제 현황 조회 단위",
-            "description": "<p>시간별, 월별 단위만 지원됩니다.</p>\n"
+            "description": "시간별, 월별 단위만 지원됩니다.\n"
           }
         },
-        "description": "<p>가맹점의 간편결제 현황 조회를 위한 입력 정보</p>\n",
+        "description": "가맹점의 간편결제 현황 조회를 위한 입력 정보\n",
         "x-portone-title": "가맹점의 간편결제 현황 조회를 위한 입력 정보"
       },
       "GetAnalyticsEasyPayChartError": {
@@ -21587,17 +21587,17 @@
           "currency": {
             "$ref": "#/components/schemas/Currency",
             "title": "조회할 결제 통화",
-            "description": "<p>입력된 통화로 발생한 결제내역만 응답에 포함됩니다.</p>\n"
+            "description": "입력된 통화로 발생한 결제내역만 응답에 포함됩니다.\n"
           },
           "excludeCancelled": {
             "type": "boolean",
             "title": "결제취소건 제외 여부",
-            "description": "<p>true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다.</p>\n"
+            "description": "true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다.\n"
           },
           "timeGranularity": {
             "$ref": "#/components/schemas/AnalyticsTimeGranularity",
             "title": "간편결제사별 결제 현황 조회 단위",
-            "description": "<p>시간별, 월별 단위만 지원됩니다.</p>\n"
+            "description": "시간별, 월별 단위만 지원됩니다.\n"
           },
           "easyPayProviders": {
             "title": "조회할 간편결제사",
@@ -21614,7 +21614,7 @@
             }
           }
         },
-        "description": "<p>가맹점의 간편결제사별 결제 현황 조회를 위한 입력 정보</p>\n",
+        "description": "가맹점의 간편결제사별 결제 현황 조회를 위한 입력 정보\n",
         "x-portone-title": "가맹점의 간편결제사별 결제 현황 조회를 위한 입력 정보"
       },
       "GetAnalyticsEasyPayProviderChartError": {
@@ -21678,20 +21678,20 @@
           "currency": {
             "$ref": "#/components/schemas/Currency",
             "title": "조회할 결제 통화",
-            "description": "<p>입력된 통화로 발생한 결제내역만 응답에 포함됩니다.</p>\n"
+            "description": "입력된 통화로 발생한 결제내역만 응답에 포함됩니다.\n"
           },
           "excludeCancelled": {
             "type": "boolean",
             "title": "결제취소건 제외 여부",
-            "description": "<p>true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다.</p>\n"
+            "description": "true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다.\n"
           },
           "timeGranularity": {
             "$ref": "#/components/schemas/AnalyticsTimeGranularity",
             "title": "결제 현황 조회 단위",
-            "description": "<p>시간별, 월별 단위만 지원됩니다.</p>\n"
+            "description": "시간별, 월별 단위만 지원됩니다.\n"
           }
         },
-        "description": "<p>가맹점의 결제 현황 조회를 위한 입력 정보</p>\n",
+        "description": "가맹점의 결제 현황 조회를 위한 입력 정보\n",
         "x-portone-title": "가맹점의 결제 현황 조회를 위한 입력 정보"
       },
       "GetAnalyticsPaymentChartError": {
@@ -21738,21 +21738,21 @@
           "currency": {
             "$ref": "#/components/schemas/Currency",
             "title": "조회할 결제 통화",
-            "description": "<p>입력된 통화로 발생한 결제내역만 응답에 포함됩니다.</p>\n"
+            "description": "입력된 통화로 발생한 결제내역만 응답에 포함됩니다.\n"
           },
           "excludeCancelled": {
             "type": "boolean",
             "title": "결제취소건 제외 여부",
-            "description": "<p>true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다.</p>\n"
+            "description": "true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다.\n"
           },
           "timezoneHourOffset": {
             "type": "integer",
             "format": "int32",
             "title": "타임존 시간 오프셋",
-            "description": "<p>입력된 시간 오프셋 기준으로 일, 주, 월이 집계 됩니다.</p>\n"
+            "description": "입력된 시간 오프셋 기준으로 일, 주, 월이 집계 됩니다.\n"
           }
         },
-        "description": "<p>가맹점의 결제 현황 인사이트 조회를 위한 입력 정보</p>\n",
+        "description": "가맹점의 결제 현황 인사이트 조회를 위한 입력 정보\n",
         "x-portone-title": "가맹점의 결제 현황 인사이트 조회를 위한 입력 정보"
       },
       "GetAnalyticsPaymentChartInsightError": {
@@ -21799,15 +21799,15 @@
           "currency": {
             "$ref": "#/components/schemas/Currency",
             "title": "조회할 결제 통화",
-            "description": "<p>입력된 통화로 발생한 결제내역만 응답에 포함됩니다.</p>\n"
+            "description": "입력된 통화로 발생한 결제내역만 응답에 포함됩니다.\n"
           },
           "excludeCancelled": {
             "type": "boolean",
             "title": "결제취소건 제외 여부",
-            "description": "<p>true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다.</p>\n"
+            "description": "true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다.\n"
           }
         },
-        "description": "<p>가맹점의 결제수단 현황 조회를 위한 입력 정보</p>\n",
+        "description": "가맹점의 결제수단 현황 조회를 위한 입력 정보\n",
         "x-portone-title": "가맹점의 결제수단 현황 조회를 위한 입력 정보"
       },
       "GetAnalyticsPaymentMethodTrendChartBody": {
@@ -21834,20 +21834,20 @@
           "currency": {
             "$ref": "#/components/schemas/Currency",
             "title": "조회할 결제 통화",
-            "description": "<p>입력된 통화로 발생한 결제내역만 응답에 포함됩니다.</p>\n"
+            "description": "입력된 통화로 발생한 결제내역만 응답에 포함됩니다.\n"
           },
           "excludeCancelled": {
             "type": "boolean",
             "title": "결제취소건 제외 여부",
-            "description": "<p>true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다.</p>\n"
+            "description": "true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다.\n"
           },
           "timeGranularity": {
             "$ref": "#/components/schemas/AnalyticsTimeGranularity",
             "title": "결제 결제수단 트렌드 조회 단위",
-            "description": "<p>시간별, 월별 단위만 지원됩니다.</p>\n"
+            "description": "시간별, 월별 단위만 지원됩니다.\n"
           }
         },
-        "description": "<p>가맹점의 결제수단 트렌드 조회를 위한 입력 정보</p>\n",
+        "description": "가맹점의 결제수단 트렌드 조회를 위한 입력 정보\n",
         "x-portone-title": "가맹점의 결제수단 트렌드 조회를 위한 입력 정보"
       },
       "GetAnalyticsPaymentStatusByPaymentClientChartBody": {
@@ -21872,10 +21872,10 @@
           "currency": {
             "$ref": "#/components/schemas/Currency",
             "title": "조회할 결제 통화",
-            "description": "<p>입력된 통화로 발생한 결제내역만 응답에 포함됩니다.</p>\n"
+            "description": "입력된 통화로 발생한 결제내역만 응답에 포함됩니다.\n"
           }
         },
-        "description": "<p>가맹점의 결제환경별 결제전환율 조회를 위한 입력 정보</p>\n",
+        "description": "가맹점의 결제환경별 결제전환율 조회를 위한 입력 정보\n",
         "x-portone-title": "가맹점의 결제환경별 결제전환율 조회를 위한 입력 정보"
       },
       "GetAnalyticsPaymentStatusByPaymentMethodChartBody": {
@@ -21900,10 +21900,10 @@
           "currency": {
             "$ref": "#/components/schemas/Currency",
             "title": "조회할 결제 통화",
-            "description": "<p>입력된 통화로 발생한 결제내역만 응답에 포함됩니다.</p>\n"
+            "description": "입력된 통화로 발생한 결제내역만 응답에 포함됩니다.\n"
           }
         },
-        "description": "<p>가맹점의 결제수단별 결제전환율 조회를 위한 입력 정보</p>\n",
+        "description": "가맹점의 결제수단별 결제전환율 조회를 위한 입력 정보\n",
         "x-portone-title": "가맹점의 결제수단별 결제전환율 조회를 위한 입력 정보"
       },
       "GetAnalyticsPaymentStatusByPgCompanyChartBody": {
@@ -21928,10 +21928,10 @@
           "currency": {
             "$ref": "#/components/schemas/Currency",
             "title": "조회할 결제 통화",
-            "description": "<p>입력된 통화로 발생한 결제내역만 응답에 포함됩니다.</p>\n"
+            "description": "입력된 통화로 발생한 결제내역만 응답에 포함됩니다.\n"
           }
         },
-        "description": "<p>가맹점의 PG사별 결제전환율 조회를 위한 입력 정보</p>\n",
+        "description": "가맹점의 PG사별 결제전환율 조회를 위한 입력 정보\n",
         "x-portone-title": "가맹점의 PG사별 결제전환율 조회를 위한 입력 정보"
       },
       "GetAnalyticsPaymentStatusChartBody": {
@@ -21956,10 +21956,10 @@
           "currency": {
             "$ref": "#/components/schemas/Currency",
             "title": "조회할 결제 통화",
-            "description": "<p>입력된 통화로 발생한 결제내역만 응답에 포함됩니다.</p>\n"
+            "description": "입력된 통화로 발생한 결제내역만 응답에 포함됩니다.\n"
           }
         },
-        "description": "<p>가맹점의 결제상태 이력 집계 조회를 위한 입력 정보</p>\n",
+        "description": "가맹점의 결제상태 이력 집계 조회를 위한 입력 정보\n",
         "x-portone-title": "가맹점의 결제상태 이력 집계 조회를 위한 입력 정보"
       },
       "GetAnalyticsPgCompanyChartBody": {
@@ -21985,15 +21985,15 @@
           "currency": {
             "$ref": "#/components/schemas/Currency",
             "title": "조회할 결제 통화",
-            "description": "<p>입력된 통화로 발생한 결제내역만 응답에 포함됩니다.</p>\n"
+            "description": "입력된 통화로 발생한 결제내역만 응답에 포함됩니다.\n"
           },
           "excludeCancelled": {
             "type": "boolean",
             "title": "결제취소건 제외 여부",
-            "description": "<p>true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다.</p>\n"
+            "description": "true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다.\n"
           }
         },
-        "description": "<p>가맹점의 결제대행사 현황 조회를 위한 입력 정보</p>\n",
+        "description": "가맹점의 결제대행사 현황 조회를 위한 입력 정보\n",
         "x-portone-title": "가맹점의 결제대행사 현황 조회를 위한 입력 정보"
       },
       "GetAnalyticsPgCompanyTrendChartBody": {
@@ -22021,17 +22021,17 @@
           "currency": {
             "$ref": "#/components/schemas/Currency",
             "title": "조회할 결제 통화",
-            "description": "<p>입력된 통화로 발생한 결제내역만 응답에 포함됩니다.</p>\n"
+            "description": "입력된 통화로 발생한 결제내역만 응답에 포함됩니다.\n"
           },
           "excludeCancelled": {
             "type": "boolean",
             "title": "결제취소건 제외 여부",
-            "description": "<p>true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다.</p>\n"
+            "description": "true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다.\n"
           },
           "timeGranularity": {
             "$ref": "#/components/schemas/AnalyticsTimeGranularity",
             "title": "결제 결제대행사별 거래 추이 조회 단위",
-            "description": "<p>시간별, 월별 단위만 지원됩니다.</p>\n"
+            "description": "시간별, 월별 단위만 지원됩니다.\n"
           },
           "pgCompanies": {
             "title": "조회할 결제대행사",
@@ -22041,7 +22041,7 @@
             }
           }
         },
-        "description": "<p>가맹점의 결제대행사별 거래 추이 조회를 위한 입력 정보</p>\n",
+        "description": "가맹점의 결제대행사별 거래 추이 조회를 위한 입력 정보\n",
         "x-portone-title": "가맹점의 결제대행사별 거래 추이 조회를 위한 입력 정보"
       },
       "GetAverageAmountChartError": {
@@ -22130,7 +22130,7 @@
             "title": "예금주"
           }
         },
-        "description": "<p>예금주 조회 응답 정보</p>\n",
+        "description": "예금주 조회 응답 정보\n",
         "x-portone-title": "예금주 조회 응답 정보"
       },
       "GetB2bCertificateError": {
@@ -22207,7 +22207,7 @@
             "title": "인증서 등록 URL"
           }
         },
-        "description": "<p>인증서 등록 URL 조회 응답 정보</p>\n",
+        "description": "인증서 등록 URL 조회 응답 정보\n",
         "x-portone-title": "인증서 등록 URL 조회 응답 정보"
       },
       "GetB2bCompanyStateError": {
@@ -22251,7 +22251,7 @@
             "title": "존재 여부"
           }
         },
-        "description": "<p>담당자 ID 존재 여부 응답 정보</p>\n",
+        "description": "담당자 ID 존재 여부 응답 정보\n",
         "x-portone-title": "담당자 ID 존재 여부 응답 정보"
       },
       "GetB2bMemberCompanyContactError": {
@@ -22386,7 +22386,7 @@
             "title": "세금계산서 PDF 다운로드 URL"
           }
         },
-        "description": "<p>세금계산서 PDF 다운로드 URL 성공 응답</p>\n",
+        "description": "세금계산서 PDF 다운로드 URL 성공 응답\n",
         "x-portone-title": "세금계산서 PDF 다운로드 URL 성공 응답"
       },
       "GetB2bTaxInvoicePopupUrlError": {
@@ -22430,7 +22430,7 @@
             "title": "세금계산서 팝업 URL"
           }
         },
-        "description": "<p>세금계산서 팝업 URL 성공 응답</p>\n",
+        "description": "세금계산서 팝업 URL 성공 응답\n",
         "x-portone-title": "세금계산서 팝업 URL 성공 응답"
       },
       "GetB2bTaxInvoicePrintUrlError": {
@@ -22474,7 +22474,7 @@
             "title": "세금계산서 프린트 URL"
           }
         },
-        "description": "<p>세금계산서 프린트 URL 성공 응답</p>\n",
+        "description": "세금계산서 프린트 URL 성공 응답\n",
         "x-portone-title": "세금계산서 프린트 URL 성공 응답"
       },
       "GetB2bTaxInvoicesError": {
@@ -22522,7 +22522,7 @@
             "title": "조회된 페이지 정보"
           }
         },
-        "description": "<p>세금계산서 다건 조회 성공 응답</p>\n",
+        "description": "세금계산서 다건 조회 성공 응답\n",
         "x-portone-title": "세금계산서 다건 조회 성공 응답"
       },
       "GetBillingKeyInfoError": {
@@ -22611,7 +22611,7 @@
             }
           }
         },
-        "description": "<p>채널 다건 조회 성공 응답 정보</p>\n",
+        "description": "채널 다건 조회 성공 응답 정보\n",
         "x-portone-title": "채널 다건 조회 성공 응답 정보"
       },
       "GetIdentityVerificationError": {
@@ -22674,7 +22674,7 @@
             "title": "HTTP 응답 본문 (JSON)"
           }
         },
-        "description": "<p>카카오페이 주문 조회 응답</p>\n",
+        "description": "카카오페이 주문 조회 응답\n",
         "x-portone-title": "카카오페이 주문 조회 응답"
       },
       "GetMerchantError": {
@@ -22789,16 +22789,16 @@
           "page": {
             "$ref": "#/components/schemas/PageInput",
             "title": "요청할 페이지 정보",
-            "description": "<p>미 입력 시 number: 0, size: 10 으로 기본값이 적용됩니다.</p>\n"
+            "description": "미 입력 시 number: 0, size: 10 으로 기본값이 적용됩니다.\n"
           },
           "filter": {
             "$ref": "#/components/schemas/PaymentScheduleFilterInput",
             "title": "조회할 결제 예약 건의 조건 필터"
           }
         },
-        "description": "<p>결제 예약 다건 조회를 위한 입력 정보</p>\n<p>조회 결과는 결제 예정 시점(timeToPay) 기준 최신 순으로 정렬됩니다.</p>\n",
+        "description": "결제 예약 다건 조회를 위한 입력 정보\n조회 결과는 결제 예정 시점(timeToPay) 기준 최신 순으로 정렬됩니다.\n",
         "x-portone-title": "결제 예약 다건 조회를 위한 입력 정보",
-        "x-portone-description": "<p>조회 결과는 결제 예정 시점(timeToPay) 기준 최신 순으로 정렬됩니다.</p>\n"
+        "x-portone-description": "조회 결과는 결제 예정 시점(timeToPay) 기준 최신 순으로 정렬됩니다.\n"
       },
       "GetPaymentSchedulesError": {
         "oneOf": [
@@ -22841,7 +22841,7 @@
             "title": "조회된 페이지 정보"
           }
         },
-        "description": "<p>결제 예약 다건 조회 성공 응답 정보</p>\n",
+        "description": "결제 예약 다건 조회 성공 응답 정보\n",
         "x-portone-title": "결제 예약 다건 조회 성공 응답 정보"
       },
       "GetPaymentStatusByPaymentClientChartError": {
@@ -22934,16 +22934,16 @@
           "page": {
             "$ref": "#/components/schemas/PageInput",
             "title": "요청할 페이지 정보",
-            "description": "<p>미 입력 시 number: 0, size: 10 으로 기본값이 적용됩니다.</p>\n"
+            "description": "미 입력 시 number: 0, size: 10 으로 기본값이 적용됩니다.\n"
           },
           "filter": {
             "$ref": "#/components/schemas/PaymentFilterInput",
             "title": "조회할 결제 건 조건 필터",
-            "description": "<p>V1 결제 건의 경우 일부 필드에 대해 필터가 적용되지 않을 수 있습니다.</p>\n"
+            "description": "V1 결제 건의 경우 일부 필드에 대해 필터가 적용되지 않을 수 있습니다.\n"
           }
         },
-        "description": "<p>결제 건 다건 조회를 위한 입력 정보</p>\n",
-        "x-portone-description": "<p>결제 건 다건 조회를 위한 입력 정보</p>\n"
+        "description": "결제 건 다건 조회를 위한 입력 정보\n",
+        "x-portone-description": "결제 건 다건 조회를 위한 입력 정보\n"
       },
       "GetPaymentsError": {
         "oneOf": [
@@ -22986,7 +22986,7 @@
             "title": "조회된 페이지 정보"
           }
         },
-        "description": "<p>결제 건 다건 조회 성공 응답 정보</p>\n",
+        "description": "결제 건 다건 조회 성공 응답 정보\n",
         "x-portone-title": "결제 건 다건 조회 성공 응답 정보"
       },
       "GetPgCompanyChartError": {
@@ -23076,7 +23076,7 @@
             "title": "조회할 추가 수수료 정책 조건 필터"
           }
         },
-        "description": "<p>추가 수수료 정책 다건 조회를 위한 입력 정보</p>\n",
+        "description": "추가 수수료 정책 다건 조회를 위한 입력 정보\n",
         "x-portone-title": "추가 수수료 정책 다건 조회를 위한 입력 정보"
       },
       "GetPlatformAdditionalFeePoliciesError": {
@@ -23120,7 +23120,7 @@
             "title": "조회된 페이지 정보"
           }
         },
-        "description": "<p>추가 수수료 정책 다건 조회 성공 응답 정보</p>\n",
+        "description": "추가 수수료 정책 다건 조회 성공 응답 정보\n",
         "x-portone-title": "추가 수수료 정책 다건 조회 성공 응답 정보"
       },
       "GetPlatformAdditionalFeePolicyError": {
@@ -23236,7 +23236,7 @@
             "title": "조회할 계약 조건 필터"
           }
         },
-        "description": "<p>계약 다건 조회를 위한 입력 정보</p>\n",
+        "description": "계약 다건 조회를 위한 입력 정보\n",
         "x-portone-title": "계약 다건 조회를 위한 입력 정보"
       },
       "GetPlatformContractsError": {
@@ -23280,7 +23280,7 @@
             "title": "조회된 페이지 정보"
           }
         },
-        "description": "<p>계약 다건 조회 성공 응답</p>\n",
+        "description": "계약 다건 조회 성공 응답\n",
         "x-portone-title": "계약 다건 조회 성공 응답"
       },
       "GetPlatformDiscountSharePoliciesBody": {
@@ -23296,7 +23296,7 @@
             "title": "조회할 할인 분담 정책 조건 필터"
           }
         },
-        "description": "<p>할인 분담 정책 다건 조회를 위한 입력 정보</p>\n",
+        "description": "할인 분담 정책 다건 조회를 위한 입력 정보\n",
         "x-portone-title": "할인 분담 정책 다건 조회를 위한 입력 정보"
       },
       "GetPlatformDiscountSharePoliciesError": {
@@ -23340,7 +23340,7 @@
             "title": "조회된 페이지 정보"
           }
         },
-        "description": "<p>할인 분담 정책 다건 조회 성공 응답 정보</p>\n",
+        "description": "할인 분담 정책 다건 조회 성공 응답 정보\n",
         "x-portone-title": "할인 분담 정책 다건 조회 성공 응답 정보"
       },
       "GetPlatformDiscountSharePolicyError": {
@@ -23442,10 +23442,10 @@
           "isForTest": {
             "type": "boolean",
             "title": "테스트 조회 여부",
-            "description": "<p>true 이면 isForTest 가 true 인 파트너들을 조회하고, false 이면 isForTest 가 false 인 파트너들을 조회합니다. 아무 값도 넘기지 않을 경우 기본값은 false 입니다.</p>\n"
+            "description": "true 이면 isForTest 가 true 인 파트너들을 조회하고, false 이면 isForTest 가 false 인 파트너들을 조회합니다. 아무 값도 넘기지 않을 경우 기본값은 false 입니다.\n"
           }
         },
-        "description": "<p>파트너 현황 조회를 위한 입력 정보</p>\n",
+        "description": "파트너 현황 조회를 위한 입력 정보\n",
         "x-portone-title": "파트너 현황 조회를 위한 입력 정보"
       },
       "GetPlatformPartnerDashboardError": {
@@ -23577,7 +23577,7 @@
             "title": "조회할 정산내역 조건 필터"
           }
         },
-        "description": "<p>정산내역 다건 조회를 위한 입력 정보</p>\n",
+        "description": "정산내역 다건 조회를 위한 입력 정보\n",
         "x-portone-title": "정산내역 다건 조회를 위한 입력 정보"
       },
       "GetPlatformPartnerSettlementsError": {
@@ -23621,7 +23621,7 @@
             "title": "조회된 페이지 정보"
           }
         },
-        "description": "<p>정산내역 다건 조회 성공 응답 정보</p>\n",
+        "description": "정산내역 다건 조회 성공 응답 정보\n",
         "x-portone-title": "정산내역 다건 조회 성공 응답 정보"
       },
       "GetPlatformPartnersBody": {
@@ -23637,7 +23637,7 @@
             "title": "조회할 파트너 조건 필터"
           }
         },
-        "description": "<p>파트너 다건 조회를 위한 입력 정보</p>\n",
+        "description": "파트너 다건 조회를 위한 입력 정보\n",
         "x-portone-title": "파트너 다건 조회를 위한 입력 정보"
       },
       "GetPlatformPartnersError": {
@@ -23681,7 +23681,7 @@
             "title": "조회된 페이지 정보"
           }
         },
-        "description": "<p>파트너 다건 조회 성공 응답 정보</p>\n",
+        "description": "파트너 다건 조회 성공 응답 정보\n",
         "x-portone-title": "파트너 다건 조회 성공 응답 정보"
       },
       "GetPlatformPayableSettlementDatesError": {
@@ -23716,13 +23716,13 @@
             "type": "array",
             "items": {
               "type": "string",
-              "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-              "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n"
+              "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+              "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n"
             },
             "title": "IN_PROCESS, SETTLED 상태의 Transfer가 등록되어 있는 정산일 리스트"
           }
         },
-        "description": "<p>지급 가능한 정산일 리스트 조회 성공 응답 정보</p>\n",
+        "description": "지급 가능한 정산일 리스트 조회 성공 응답 정보\n",
         "x-portone-title": "지급 가능한 정산일 리스트 조회 성공 응답 정보"
       },
       "GetPlatformPayoutError": {
@@ -23880,8 +23880,8 @@
         "properties": {
           "settlementDate": {
             "type": "string",
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n"
+            "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n"
           },
           "isForTest": {
             "type": "boolean"
@@ -24007,7 +24007,7 @@
       },
       "IdentityVerification": {
         "title": "본인인증 내역",
-        "description": "<p>본인인증 내역</p>\n",
+        "description": "본인인증 내역\n",
         "oneOf": [
           {
             "$ref": "#/components/schemas/FailedIdentityVerification"
@@ -24054,7 +24054,7 @@
             "type": "string"
           }
         },
-        "description": "<p>본인인증 건이 이미 API로 요청된 상태인 경우</p>\n",
+        "description": "본인인증 건이 이미 API로 요청된 상태인 경우\n",
         "x-portone-title": "본인인증 건이 이미 API로 요청된 상태인 경우",
         "x-portone-status-code": 409
       },
@@ -24072,14 +24072,14 @@
             "type": "string"
           }
         },
-        "description": "<p>본인인증 건이 이미 인증 완료된 상태인 경우</p>\n",
+        "description": "본인인증 건이 이미 인증 완료된 상태인 경우\n",
         "x-portone-title": "본인인증 건이 이미 인증 완료된 상태인 경우",
         "x-portone-status-code": 409
       },
       "IdentityVerificationMethod": {
         "title": "본인인증 방식",
         "type": "string",
-        "description": "<p>본인인증 방식</p>\n",
+        "description": "본인인증 방식\n",
         "enum": [
           "APP",
           "SMS"
@@ -24104,7 +24104,7 @@
             "type": "string"
           }
         },
-        "description": "<p>요청된 본인인증 건이 존재하지 않는 경우</p>\n",
+        "description": "요청된 본인인증 건이 존재하지 않는 경우\n",
         "x-portone-title": "요청된 본인인증 건이 존재하지 않는 경우",
         "x-portone-status-code": 404
       },
@@ -24122,14 +24122,14 @@
             "type": "string"
           }
         },
-        "description": "<p>본인인증 건이 API로 요청된 상태가 아닌 경우</p>\n",
+        "description": "본인인증 건이 API로 요청된 상태가 아닌 경우\n",
         "x-portone-title": "본인인증 건이 API로 요청된 상태가 아닌 경우",
         "x-portone-status-code": 404
       },
       "IdentityVerificationOperator": {
         "title": "본인인증 통신사",
         "type": "string",
-        "description": "<p>본인인증 통신사</p>\n",
+        "description": "본인인증 통신사\n",
         "enum": [
           "KT",
           "KT_MVNO",
@@ -24175,10 +24175,10 @@
           "phoneNumber": {
             "type": "string",
             "title": "전화번호",
-            "description": "<p>특수 문자(-) 없이 숫자로만 이루어진 번호 형식입니다.</p>\n"
+            "description": "특수 문자(-) 없이 숫자로만 이루어진 번호 형식입니다.\n"
           }
         },
-        "description": "<p>요청 시 고객 정보</p>\n",
+        "description": "요청 시 고객 정보\n",
         "x-portone-title": "요청 시 고객 정보"
       },
       "IdentityVerificationVerifiedCustomer": {
@@ -24203,12 +24203,12 @@
           "phoneNumber": {
             "type": "string",
             "title": "전화번호",
-            "description": "<p>특수 문자(-) 없이 숫자로만 이루어진 번호 형식입니다.</p>\n"
+            "description": "특수 문자(-) 없이 숫자로만 이루어진 번호 형식입니다.\n"
           },
           "birthDate": {
             "type": "string",
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
             "title": "생년월일 (yyyy-MM-dd)"
           },
           "gender": {
@@ -24228,7 +24228,7 @@
             "title": "DI (사이트별 개인 고유 식별키)"
           }
         },
-        "description": "<p>인증된 고객 정보</p>\n",
+        "description": "인증된 고객 정보\n",
         "x-portone-title": "인증된 고객 정보"
       },
       "InstantBillingKeyPaymentMethodInput": {
@@ -24239,7 +24239,7 @@
             "$ref": "#/components/schemas/InstantBillingKeyPaymentMethodInputCard"
           }
         },
-        "description": "<p>빌링키 발급 시 결제 수단 입력 양식</p>\n",
+        "description": "빌링키 발급 시 결제 수단 입력 양식\n",
         "x-portone-title": "빌링키 발급 시 결제 수단 입력 양식"
       },
       "InstantBillingKeyPaymentMethodInputCard": {
@@ -24253,7 +24253,7 @@
             "$ref": "#/components/schemas/CardCredential"
           }
         },
-        "description": "<p>카드 수단 정보 입력 양식</p>\n",
+        "description": "카드 수단 정보 입력 양식\n",
         "x-portone-title": "카드 수단 정보 입력 양식"
       },
       "InstantPaymentInput": {
@@ -24270,7 +24270,7 @@
           "storeId": {
             "type": "string",
             "title": "상점 아이디",
-            "description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.\n"
           },
           "channelKey": {
             "type": "string",
@@ -24287,12 +24287,12 @@
           "isCulturalExpense": {
             "type": "boolean",
             "title": "문화비 지출 여부",
-            "description": "<p>기본값은 false 입니다.</p>\n"
+            "description": "기본값은 false 입니다.\n"
           },
           "isEscrow": {
             "type": "boolean",
             "title": "에스크로 결제 여부",
-            "description": "<p>기본값은 false 입니다.</p>\n"
+            "description": "기본값은 false 입니다.\n"
           },
           "customer": {
             "$ref": "#/components/schemas/CustomerInput",
@@ -24320,7 +24320,7 @@
               "type": "string"
             },
             "title": "웹훅 주소",
-            "description": "<p>결제 승인/실패 시 요청을 받을 웹훅 주소입니다.\n상점에 설정되어 있는 값보다 우선적으로 적용됩니다.\n입력된 값이 없을 경우에는 빈 배열로 해석됩니다.</p>\n"
+            "description": "결제 승인/실패 시 요청을 받을 웹훅 주소입니다.\n상점에 설정되어 있는 값보다 우선적으로 적용됩니다.\n입력된 값이 없을 경우에는 빈 배열로 해석됩니다.\n"
           },
           "products": {
             "title": "상품 정보",
@@ -24328,7 +24328,7 @@
             "items": {
               "$ref": "#/components/schemas/PaymentProduct"
             },
-            "description": "<p>입력된 값이 없을 경우에는 빈 배열로 해석됩니다.</p>\n"
+            "description": "입력된 값이 없을 경우에는 빈 배열로 해석됩니다.\n"
           },
           "productCount": {
             "type": "integer",
@@ -24344,7 +24344,7 @@
             "title": "배송지 주소"
           }
         },
-        "description": "<p>수기 결제 요청 정보</p>\n",
+        "description": "수기 결제 요청 정보\n",
         "x-portone-title": "수기 결제 요청 정보"
       },
       "InstantPaymentMethodInput": {
@@ -24360,9 +24360,9 @@
             "title": "가상계좌"
           }
         },
-        "description": "<p>수기 결제 수단 입력 정보</p>\n<p>하나의 필드만 입력합니다.</p>\n",
+        "description": "수기 결제 수단 입력 정보\n하나의 필드만 입력합니다.\n",
         "x-portone-title": "수기 결제 수단 입력 정보",
-        "x-portone-description": "<p>하나의 필드만 입력합니다.</p>\n"
+        "x-portone-description": "하나의 필드만 입력합니다.\n"
       },
       "InstantPaymentMethodInputCard": {
         "title": "카드 수단 정보 입력 정보",
@@ -24393,7 +24393,7 @@
             "title": "카드 포인트 사용 여부"
           }
         },
-        "description": "<p>카드 수단 정보 입력 정보</p>\n",
+        "description": "카드 수단 정보 입력 정보\n",
         "x-portone-title": "카드 수단 정보 입력 정보"
       },
       "InstantPaymentMethodInputVirtualAccount": {
@@ -24427,7 +24427,7 @@
             "title": "예금주명"
           }
         },
-        "description": "<p>가상계좌 수단 정보 입력 정보</p>\n",
+        "description": "가상계좌 수단 정보 입력 정보\n",
         "x-portone-title": "가상계좌 수단 정보 입력 정보"
       },
       "InstantPaymentMethodInputVirtualAccountCashReceiptInfo": {
@@ -24447,7 +24447,7 @@
             "title": "사용자 식별 번호"
           }
         },
-        "description": "<p>가상계좌 결제 시 현금영수증 정보</p>\n",
+        "description": "가상계좌 결제 시 현금영수증 정보\n",
         "x-portone-title": "가상계좌 결제 시 현금영수증 정보"
       },
       "InstantPaymentMethodInputVirtualAccountExpiry": {
@@ -24458,7 +24458,7 @@
             "type": "integer",
             "format": "int32",
             "title": "유효 시간",
-            "description": "<p>시간 단위로 입력합니다.</p>\n"
+            "description": "시간 단위로 입력합니다.\n"
           },
           "dueDate": {
             "type": "string",
@@ -24466,9 +24466,9 @@
             "title": "만료 시점"
           }
         },
-        "description": "<p>입금 만료 기한</p>\n<p>validHours와 dueDate 둘 중 하나의 필드만 입력합니다.</p>\n",
+        "description": "입금 만료 기한\nvalidHours와 dueDate 둘 중 하나의 필드만 입력합니다.\n",
         "x-portone-title": "입금 만료 기한",
-        "x-portone-description": "<p>validHours와 dueDate 둘 중 하나의 필드만 입력합니다.</p>\n"
+        "x-portone-description": "validHours와 dueDate 둘 중 하나의 필드만 입력합니다.\n"
       },
       "InstantPaymentMethodInputVirtualAccountOption": {
         "title": "가상계좌 발급 방식",
@@ -24484,10 +24484,10 @@
           "fixed": {
             "$ref": "#/components/schemas/InstantPaymentMethodInputVirtualAccountOptionFixed",
             "title": "고정식 가상계좌 발급 방식",
-            "description": "<p>발급 유형을 FIXED 로 선택했을 시에만 입력합니다.</p>\n"
+            "description": "발급 유형을 FIXED 로 선택했을 시에만 입력합니다.\n"
           }
         },
-        "description": "<p>가상계좌 발급 방식</p>\n",
+        "description": "가상계좌 발급 방식\n",
         "x-portone-title": "가상계좌 발급 방식"
       },
       "InstantPaymentMethodInputVirtualAccountOptionFixed": {
@@ -24497,22 +24497,22 @@
           "pgAccountId": {
             "type": "string",
             "title": "Account ID 고정식 가상계좌",
-            "description": "<p>가맹점이 가상계좌번호를 직접 관리하지 않고 PG사가 pgAccountId에 매핑되는 가상계좌번호를 내려주는 방식입니다.\n동일한 pgAccountId로 가상계좌 발급 요청시에는 항상 같은 가상계좌번호가 내려옵니다.</p>\n"
+            "description": "가맹점이 가상계좌번호를 직접 관리하지 않고 PG사가 pgAccountId에 매핑되는 가상계좌번호를 내려주는 방식입니다.\n동일한 pgAccountId로 가상계좌 발급 요청시에는 항상 같은 가상계좌번호가 내려옵니다.\n"
           },
           "accountNumber": {
             "type": "string",
             "title": "Account Number 고정식 가상계좌",
-            "description": "<p>PG사가 일정 개수만큼의 가상계좌번호를 발급하여 가맹점에게 미리 전달하고 가맹점이 그 중 하나를 선택하여 사용하는 방식입니다.</p>\n"
+            "description": "PG사가 일정 개수만큼의 가상계좌번호를 발급하여 가맹점에게 미리 전달하고 가맹점이 그 중 하나를 선택하여 사용하는 방식입니다.\n"
           }
         },
-        "description": "<p>고정식 가상계좌 발급 유형</p>\n<p>pgAccountId, accountNumber 유형 중 한 개의 필드만 입력합니다.</p>\n",
+        "description": "고정식 가상계좌 발급 유형\npgAccountId, accountNumber 유형 중 한 개의 필드만 입력합니다.\n",
         "x-portone-title": "고정식 가상계좌 발급 유형",
-        "x-portone-description": "<p>pgAccountId, accountNumber 유형 중 한 개의 필드만 입력합니다.</p>\n"
+        "x-portone-description": "pgAccountId, accountNumber 유형 중 한 개의 필드만 입력합니다.\n"
       },
       "InstantPaymentMethodInputVirtualAccountOptionType": {
         "title": "가상계좌 발급 유형",
         "type": "string",
-        "description": "<p>가상계좌 발급 유형</p>\n",
+        "description": "가상계좌 발급 유형\n",
         "enum": [
           "FIXED",
           "NORMAL"
@@ -24521,7 +24521,7 @@
         "x-portone-enum": {
           "NORMAL": {
             "title": "회전식 가상계좌",
-            "description": "<p>일반적으로 사용되는 방식이며 PG사에서 직접 채번한 가상계좌번호를 사용합니다.</p>\n"
+            "description": "일반적으로 사용되는 방식이며 PG사에서 직접 채번한 가상계좌번호를 사용합니다.\n"
           },
           "FIXED": {
             "title": "고정식 가상계좌"
@@ -24546,7 +24546,7 @@
             "title": "결제 완료 시점"
           }
         },
-        "description": "<p>수기 결제가 완료된 결제 건 요약 정보</p>\n",
+        "description": "수기 결제가 완료된 결제 건 요약 정보\n",
         "x-portone-title": "수기 결제가 완료된 결제 건 요약 정보"
       },
       "InvalidRequestError": {
@@ -24563,9 +24563,9 @@
             "type": "string"
           }
         },
-        "description": "<p>요청된 입력 정보가 유효하지 않은 경우</p>\n<p>허가되지 않은 값, 올바르지 않은 형식의 요청 등이 모두 해당됩니다.</p>\n",
+        "description": "요청된 입력 정보가 유효하지 않은 경우\n허가되지 않은 값, 올바르지 않은 형식의 요청 등이 모두 해당됩니다.\n",
         "x-portone-title": "요청된 입력 정보가 유효하지 않은 경우",
-        "x-portone-description": "<p>허가되지 않은 값, 올바르지 않은 형식의 요청 등이 모두 해당됩니다.</p>\n",
+        "x-portone-description": "허가되지 않은 값, 올바르지 않은 형식의 요청 등이 모두 해당됩니다.\n",
         "x-portone-status-code": 400
       },
       "IssueB2bTaxInvoiceError": {
@@ -24620,7 +24620,7 @@
           "documentKeyType": {
             "$ref": "#/components/schemas/B2bTaxInvoiceDocumentKeyType",
             "title": "문서 번호 유형",
-            "description": "<p>기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.</p>\n"
+            "description": "기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.\n"
           },
           "memo": {
             "type": "string",
@@ -24631,7 +24631,7 @@
             "title": "이메일 제목"
           }
         },
-        "description": "<p>세금계산서 발행 정보</p>\n",
+        "description": "세금계산서 발행 정보\n",
         "x-portone-title": "세금계산서 발행 정보"
       },
       "IssueBillingKeyBody": {
@@ -24645,7 +24645,7 @@
           "storeId": {
             "type": "string",
             "title": "상점 아이디",
-            "description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.\n"
           },
           "method": {
             "$ref": "#/components/schemas/InstantBillingKeyPaymentMethodInput",
@@ -24673,10 +24673,10 @@
               "type": "string"
             },
             "title": "웹훅 주소",
-            "description": "<p>빌링키 발급 시 요청을 받을 웹훅 주소입니다.\n상점에 설정되어 있는 값보다 우선적으로 적용됩니다.\n입력된 값이 없을 경우에는 빈 배열로 해석됩니다.</p>\n"
+            "description": "빌링키 발급 시 요청을 받을 웹훅 주소입니다.\n상점에 설정되어 있는 값보다 우선적으로 적용됩니다.\n입력된 값이 없을 경우에는 빈 배열로 해석됩니다.\n"
           }
         },
-        "description": "<p>빌링키 발급 요청 양식</p>\n",
+        "description": "빌링키 발급 요청 양식\n",
         "x-portone-title": "빌링키 발급 요청 양식"
       },
       "IssueBillingKeyError": {
@@ -24720,7 +24720,7 @@
             "title": "빌링키 정보"
           }
         },
-        "description": "<p>빌링키 발급 성공 응답</p>\n",
+        "description": "빌링키 발급 성공 응답\n",
         "x-portone-title": "빌링키 발급 성공 응답"
       },
       "IssueCashReceiptBody": {
@@ -24739,12 +24739,12 @@
           "storeId": {
             "type": "string",
             "title": "상점 아이디",
-            "description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.\n"
           },
           "paymentId": {
             "type": "string",
             "title": "결제 건 아이디",
-            "description": "<p>외부 결제 건에 대한 수동 발급의 경우, 아이디를 직접 채번하여 입력합니다.</p>\n"
+            "description": "외부 결제 건에 대한 수동 발급의 경우, 아이디를 직접 채번하여 입력합니다.\n"
           },
           "channelKey": {
             "type": "string",
@@ -24775,7 +24775,7 @@
             "title": "고객 정보"
           }
         },
-        "description": "<p>현금영수증 발급 요청 양식</p>\n",
+        "description": "현금영수증 발급 요청 양식\n",
         "x-portone-title": "현금영수증 발급 요청 양식"
       },
       "IssueCashReceiptCustomerInput": {
@@ -24802,7 +24802,7 @@
             "title": "전화번호"
           }
         },
-        "description": "<p>현금영수증 발급 시 고객 관련 입력 정보</p>\n",
+        "description": "현금영수증 발급 시 고객 관련 입력 정보\n",
         "x-portone-title": "현금영수증 발급 시 고객 관련 입력 정보"
       },
       "IssueCashReceiptError": {
@@ -24849,7 +24849,7 @@
             "$ref": "#/components/schemas/CashReceiptSummary"
           }
         },
-        "description": "<p>현금 영수증 발급 성공 응답</p>\n",
+        "description": "현금 영수증 발급 성공 응답\n",
         "x-portone-title": "현금 영수증 발급 성공 응답"
       },
       "IssueFailedCashReceipt": {
@@ -24893,7 +24893,7 @@
             "title": "수동 발급 여부"
           }
         },
-        "description": "<p>발급 실패</p>\n",
+        "description": "발급 실패\n",
         "x-portone-title": "발급 실패"
       },
       "IssuedCashReceipt": {
@@ -24982,7 +24982,7 @@
             "title": "발급 시점"
           }
         },
-        "description": "<p>발급 완료</p>\n",
+        "description": "발급 완료\n",
         "x-portone-title": "발급 완료"
       },
       "IssuedPaymentCashReceipt": {
@@ -25036,7 +25036,7 @@
             "title": "발급 시점"
           }
         },
-        "description": "<p>발급 완료된 현금영수증</p>\n",
+        "description": "발급 완료된 현금영수증\n",
         "x-portone-title": "발급 완료된 현금영수증"
       },
       "LoginViaApiKeyBody": {
@@ -25051,7 +25051,7 @@
             "title": "발급받은 API key"
           }
         },
-        "description": "<p>API key 로그인을 위한 입력 정보</p>\n",
+        "description": "API key 로그인을 위한 입력 정보\n",
         "x-portone-title": "API key 로그인을 위한 입력 정보"
       },
       "LoginViaApiKeyError": {
@@ -25082,15 +25082,15 @@
           "accessToken": {
             "type": "string",
             "title": "인증에 사용하는 엑세스 토큰",
-            "description": "<p>하루의 유효기간을 가지고 있습니다.</p>\n"
+            "description": "하루의 유효기간을 가지고 있습니다.\n"
           },
           "refreshToken": {
             "type": "string",
             "title": "토큰 재발급 및 유효기간 연장을 위해 사용하는 리프레시 토큰",
-            "description": "<p>일주일의 유효기간을 가지고 있으며, 리프레시 토큰을 통해 유효기간이 연장된 새로운 엑세스 토큰을 발급받을 수 있습니다.</p>\n"
+            "description": "일주일의 유효기간을 가지고 있으며, 리프레시 토큰을 통해 유효기간이 연장된 새로운 엑세스 토큰을 발급받을 수 있습니다.\n"
           }
         },
-        "description": "<p>API key 로그인 성공 응답</p>\n",
+        "description": "API key 로그인 성공 응답\n",
         "x-portone-title": "API key 로그인 성공 응답"
       },
       "LoginViaApiSecretBody": {
@@ -25105,7 +25105,7 @@
             "title": "발급받은 API secret"
           }
         },
-        "description": "<p>API Secret 로그인을 위한 입력 정보</p>\n",
+        "description": "API Secret 로그인을 위한 입력 정보\n",
         "x-portone-title": "API Secret 로그인을 위한 입력 정보"
       },
       "LoginViaApiSecretError": {
@@ -25136,15 +25136,15 @@
           "accessToken": {
             "type": "string",
             "title": "인증에 사용하는 엑세스 토큰",
-            "description": "<p>하루의 유효기간을 가지고 있습니다.</p>\n"
+            "description": "하루의 유효기간을 가지고 있습니다.\n"
           },
           "refreshToken": {
             "type": "string",
             "title": "토큰 재발급 및 유효기간 연장을 위해 사용하는 리프레시 토큰",
-            "description": "<p>일주일의 유효기간을 가지고 있으며, 리프레시 토큰을 통해 유효기간이 연장된 새로운 엑세스 토큰을 발급받을 수 있습니다.</p>\n"
+            "description": "일주일의 유효기간을 가지고 있으며, 리프레시 토큰을 통해 유효기간이 연장된 새로운 엑세스 토큰을 발급받을 수 있습니다.\n"
           }
         },
-        "description": "<p>API key 로그인 성공 응답</p>\n",
+        "description": "API key 로그인 성공 응답\n",
         "x-portone-title": "API key 로그인 성공 응답"
       },
       "Merchant": {
@@ -25168,7 +25168,7 @@
             "title": "리포트 정보"
           }
         },
-        "description": "<p>가맹점 정보</p>\n",
+        "description": "가맹점 정보\n",
         "x-portone-title": "가맹점 정보"
       },
       "ModifyEscrowLogisticsBody": {
@@ -25181,7 +25181,7 @@
           "storeId": {
             "type": "string",
             "title": "상점 아이디",
-            "description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.\n"
           },
           "sender": {
             "$ref": "#/components/schemas/PaymentEscrowSenderInput",
@@ -25198,7 +25198,7 @@
           "sendEmail": {
             "type": "boolean",
             "title": "이메일 알림 전송 여부",
-            "description": "<p>에스크로 구매 확정 시 이메일로 알림을 보낼지 여부입니다.</p>\n"
+            "description": "에스크로 구매 확정 시 이메일로 알림을 보낼지 여부입니다.\n"
           },
           "products": {
             "title": "상품 정보",
@@ -25208,7 +25208,7 @@
             }
           }
         },
-        "description": "<p>에스크로 배송 정보 수정 입력 정보</p>\n",
+        "description": "에스크로 배송 정보 수정 입력 정보\n",
         "x-portone-title": "에스크로 배송 정보 수정 입력 정보"
       },
       "ModifyEscrowLogisticsError": {
@@ -25268,7 +25268,7 @@
             "title": "에스크로 정보 수정 시점"
           }
         },
-        "description": "<p>에스크로 배송 정보 수정 성공 응답</p>\n",
+        "description": "에스크로 배송 정보 수정 성공 응답\n",
         "x-portone-title": "에스크로 배송 정보 수정 성공 응답"
       },
       "MonthDay": {
@@ -25288,7 +25288,7 @@
             "format": "int32"
           }
         },
-        "description": "<p>월 및 일자 정보</p>\n",
+        "description": "월 및 일자 정보\n",
         "x-portone-title": "월 및 일자 정보"
       },
       "OneLineAddress": {
@@ -25307,9 +25307,9 @@
             "title": "주소 (한 줄)"
           }
         },
-        "description": "<p>한 줄 형식 주소</p>\n<p>한 줄 형식 주소만 존재합니다.</p>\n",
+        "description": "한 줄 형식 주소\n한 줄 형식 주소만 존재합니다.\n",
         "x-portone-title": "한 줄 형식 주소",
-        "x-portone-description": "<p>한 줄 형식 주소만 존재합니다.</p>\n"
+        "x-portone-description": "한 줄 형식 주소만 존재합니다.\n"
       },
       "PageInfo": {
         "title": "반환된 페이지 결과 정보",
@@ -25336,7 +25336,7 @@
             "title": "실제 반환된 객체 수"
           }
         },
-        "description": "<p>반환된 페이지 결과 정보</p>\n",
+        "description": "반환된 페이지 결과 정보\n",
         "x-portone-title": "반환된 페이지 결과 정보"
       },
       "PageInput": {
@@ -25354,7 +25354,7 @@
             "title": "각 페이지 당 포함할 객체 수"
           }
         },
-        "description": "<p>다건 조회 API 에 사용되는 페이지 입력 정보</p>\n",
+        "description": "다건 조회 API 에 사용되는 페이지 입력 정보\n",
         "x-portone-title": "다건 조회 API 에 사용되는 페이지 입력 정보"
       },
       "PaidPayment": {
@@ -25389,7 +25389,7 @@
           "transactionId": {
             "type": "string",
             "title": "결제 건 포트원 채번 아이디",
-            "description": "<p>V1 결제 건의 경우 imp_uid에 해당합니다.</p>\n"
+            "description": "V1 결제 건의 경우 imp_uid에 해당합니다.\n"
           },
           "merchantId": {
             "type": "string",
@@ -25414,12 +25414,12 @@
           "scheduleId": {
             "type": "string",
             "title": "결제 예약 건 아이디",
-            "description": "<p>결제 예약을 이용한 경우에만 존재</p>\n"
+            "description": "결제 예약을 이용한 경우에만 존재\n"
           },
           "billingKey": {
             "type": "string",
             "title": "결제 시 사용된 빌링키",
-            "description": "<p>빌링키 결제인 경우에만 존재</p>\n"
+            "description": "빌링키 결제인 경우에만 존재\n"
           },
           "webhooks": {
             "title": "웹훅 발송 내역",
@@ -25470,7 +25470,7 @@
           "escrow": {
             "$ref": "#/components/schemas/PaymentEscrow",
             "title": "에스크로 결제 정보",
-            "description": "<p>에스크로 결제인 경우 존재합니다.</p>\n"
+            "description": "에스크로 결제인 경우 존재합니다.\n"
           },
           "products": {
             "title": "상품 정보",
@@ -25514,7 +25514,7 @@
             "title": "거래 영수증 URL"
           }
         },
-        "description": "<p>결제 완료 상태 건</p>\n",
+        "description": "결제 완료 상태 건\n",
         "x-portone-title": "결제 완료 상태 건"
       },
       "PartialCancelledPayment": {
@@ -25550,7 +25550,7 @@
           "transactionId": {
             "type": "string",
             "title": "결제 건 포트원 채번 아이디",
-            "description": "<p>V1 결제 건의 경우 imp_uid에 해당합니다.</p>\n"
+            "description": "V1 결제 건의 경우 imp_uid에 해당합니다.\n"
           },
           "merchantId": {
             "type": "string",
@@ -25575,12 +25575,12 @@
           "scheduleId": {
             "type": "string",
             "title": "결제 예약 건 아이디",
-            "description": "<p>결제 예약을 이용한 경우에만 존재</p>\n"
+            "description": "결제 예약을 이용한 경우에만 존재\n"
           },
           "billingKey": {
             "type": "string",
             "title": "결제 시 사용된 빌링키",
-            "description": "<p>빌링키 결제인 경우에만 존재</p>\n"
+            "description": "빌링키 결제인 경우에만 존재\n"
           },
           "webhooks": {
             "title": "웹훅 발송 내역",
@@ -25631,7 +25631,7 @@
           "escrow": {
             "$ref": "#/components/schemas/PaymentEscrow",
             "title": "에스크로 결제 정보",
-            "description": "<p>에스크로 결제인 경우 존재합니다.</p>\n"
+            "description": "에스크로 결제인 경우 존재합니다.\n"
           },
           "products": {
             "title": "상품 정보",
@@ -25679,7 +25679,7 @@
             "title": "결제 취소 시점"
           }
         },
-        "description": "<p>결제 부분 취소 상태 건</p>\n",
+        "description": "결제 부분 취소 상태 건\n",
         "x-portone-title": "결제 부분 취소 상태 건"
       },
       "PastPaymentScheduleError": {
@@ -25696,7 +25696,7 @@
             "type": "string"
           }
         },
-        "description": "<p>결제 예약 시점이 과거로 지정된 경우</p>\n",
+        "description": "결제 예약 시점이 과거로 지정된 경우\n",
         "x-portone-title": "결제 예약 시점이 과거로 지정된 경우",
         "x-portone-status-code": 409
       },
@@ -25749,7 +25749,7 @@
             "title": "결제 건 요약 정보"
           }
         },
-        "description": "<p>수기 결제 성공 응답</p>\n",
+        "description": "수기 결제 성공 응답\n",
         "x-portone-title": "수기 결제 성공 응답"
       },
       "PayPendingPayment": {
@@ -25802,12 +25802,12 @@
           "scheduleId": {
             "type": "string",
             "title": "결제 예약 건 아이디",
-            "description": "<p>결제 예약을 이용한 경우에만 존재</p>\n"
+            "description": "결제 예약을 이용한 경우에만 존재\n"
           },
           "billingKey": {
             "type": "string",
             "title": "결제 시 사용된 빌링키",
-            "description": "<p>빌링키 결제인 경우에만 존재</p>\n"
+            "description": "빌링키 결제인 경우에만 존재\n"
           },
           "webhooks": {
             "title": "웹훅 발송 내역",
@@ -25858,7 +25858,7 @@
           "escrow": {
             "$ref": "#/components/schemas/PaymentEscrow",
             "title": "에스크로 결제 정보",
-            "description": "<p>에스크로 결제인 경우 존재합니다.</p>\n"
+            "description": "에스크로 결제인 경우 존재합니다.\n"
           },
           "products": {
             "title": "상품 정보",
@@ -25885,7 +25885,7 @@
             "title": "PG사 거래 아이디"
           }
         },
-        "description": "<p>결제 완료 대기 상태 건</p>\n",
+        "description": "결제 완료 대기 상태 건\n",
         "x-portone-title": "결제 완료 대기 상태 건"
       },
       "PayWithBillingKeyError": {
@@ -25941,12 +25941,12 @@
             "title": "결제 건 요약 정보"
           }
         },
-        "description": "<p>빌링키 결제 성공 응답</p>\n",
+        "description": "빌링키 결제 성공 응답\n",
         "x-portone-title": "빌링키 결제 성공 응답"
       },
       "Payment": {
         "title": "결제 건",
-        "description": "<p>결제 건</p>\n",
+        "description": "결제 건\n",
         "oneOf": [
           {
             "$ref": "#/components/schemas/CancelledPayment"
@@ -26021,7 +26021,7 @@
             "type": "string"
           }
         },
-        "description": "<p>결제가 이미 취소된 경우</p>\n",
+        "description": "결제가 이미 취소된 경우\n",
         "x-portone-title": "결제가 이미 취소된 경우",
         "x-portone-status-code": 409
       },
@@ -26061,7 +26061,7 @@
             "type": "integer",
             "format": "int64",
             "title": "할인금액",
-            "description": "<p>카드사 프로모션, 아임포트 프로모션, 적립형 포인트 결제, 쿠폰 할인 등을 포함합니다.</p>\n"
+            "description": "카드사 프로모션, 아임포트 프로모션, 적립형 포인트 결제, 쿠폰 할인 등을 포함합니다.\n"
           },
           "paid": {
             "type": "integer",
@@ -26079,7 +26079,7 @@
             "title": "취소금액 중 면세액"
           }
         },
-        "description": "<p>결제 금액 세부 정보</p>\n",
+        "description": "결제 금액 세부 정보\n",
         "x-portone-title": "결제 금액 세부 정보"
       },
       "PaymentAmountInput": {
@@ -26103,15 +26103,15 @@
             "type": "integer",
             "format": "int64",
             "title": "부가세액",
-            "description": "<p>가맹점에서 직접 계산이 필요한 경우 입력합니다.\n입력하지 않으면 면세 금액을 제외한 금액의 1/11 로 자동 계산됩니다.</p>\n"
+            "description": "가맹점에서 직접 계산이 필요한 경우 입력합니다.\n입력하지 않으면 면세 금액을 제외한 금액의 1/11 로 자동 계산됩니다.\n"
           }
         },
-        "description": "<p>금액 세부 입력 정보</p>\n",
+        "description": "금액 세부 입력 정보\n",
         "x-portone-title": "금액 세부 입력 정보"
       },
       "PaymentCancellation": {
         "title": "결제 취소 내역",
-        "description": "<p>결제 취소 내역</p>\n",
+        "description": "결제 취소 내역\n",
         "oneOf": [
           {
             "$ref": "#/components/schemas/FailedPaymentCancellation"
@@ -26146,7 +26146,7 @@
       },
       "PaymentCashReceipt": {
         "title": "결제 건 내 현금영수증 정보",
-        "description": "<p>결제 건 내 현금영수증 정보</p>\n",
+        "description": "결제 건 내 현금영수증 정보\n",
         "oneOf": [
           {
             "$ref": "#/components/schemas/CancelledPaymentCashReceipt"
@@ -26175,7 +26175,7 @@
       "PaymentCashReceiptStatus": {
         "title": "결제건 내 현금영수증 상태",
         "type": "string",
-        "description": "<p>결제건 내 현금영수증 상태</p>\n",
+        "description": "결제건 내 현금영수증 상태\n",
         "enum": [
           "CANCELLED",
           "ISSUED"
@@ -26189,7 +26189,7 @@
       "PaymentClientType": {
         "title": "결제가 발생한 클라이언트 환경",
         "type": "string",
-        "description": "<p>결제가 발생한 클라이언트 환경</p>\n",
+        "description": "결제가 발생한 클라이언트 환경\n",
         "enum": [
           "API",
           "SDK_MOBILE",
@@ -26204,7 +26204,7 @@
       },
       "PaymentEscrow": {
         "title": "에스크로 정보",
-        "description": "<p>에스크로 정보</p>\n<p>V1 결제 건의 경우 타입이 REGISTERED 로 고정됩니다.</p>\n",
+        "description": "에스크로 정보\nV1 결제 건의 경우 타입이 REGISTERED 로 고정됩니다.\n",
         "oneOf": [
           {
             "$ref": "#/components/schemas/BeforeRegisteredPaymentEscrow"
@@ -26241,7 +26241,7 @@
           }
         },
         "x-portone-title": "에스크로 정보",
-        "x-portone-description": "<p>V1 결제 건의 경우 타입이 REGISTERED 로 고정됩니다.</p>\n",
+        "x-portone-description": "V1 결제 건의 경우 타입이 REGISTERED 로 고정됩니다.\n",
         "x-portone-discriminator": {
           "CONFIRMED": {
             "title": "구매 확정"
@@ -26287,7 +26287,7 @@
             "title": "주소"
           }
         },
-        "description": "<p>에스크로 수취인 정보</p>\n",
+        "description": "에스크로 수취인 정보\n",
         "x-portone-title": "에스크로 수취인 정보"
       },
       "PaymentEscrowSenderInput": {
@@ -26315,7 +26315,7 @@
             "title": "주소"
           }
         },
-        "description": "<p>에스크로 발송자 정보</p>\n",
+        "description": "에스크로 발송자 정보\n",
         "x-portone-title": "에스크로 발송자 정보"
       },
       "PaymentFilterInput": {
@@ -26329,7 +26329,7 @@
           "storeId": {
             "type": "string",
             "title": "상점 아이디",
-            "description": "<p>Merchant 사용자만 사용가능하며, 지정되지 않은 경우 가맹점 전체 결제 건을 조회합니다.</p>\n"
+            "description": "Merchant 사용자만 사용가능하며, 지정되지 않은 경우 가맹점 전체 결제 건을 조회합니다.\n"
           },
           "timestampType": {
             "$ref": "#/components/schemas/PaymentTimestampType",
@@ -26339,13 +26339,13 @@
             "type": "string",
             "format": "date-time",
             "title": "결제 요청/상태 승인 시점 범위의 시작",
-            "description": "<p>값을 입력하지 않으면 end의 90일 전으로 설정됩니다.</p>\n"
+            "description": "값을 입력하지 않으면 end의 90일 전으로 설정됩니다.\n"
           },
           "until": {
             "type": "string",
             "format": "date-time",
             "title": "결제 요청/상태 승인 시점 범위의 끝",
-            "description": "<p>값을 입력하지 않으면 현재 시점으로 설정됩니다.</p>\n"
+            "description": "값을 입력하지 않으면 현재 시점으로 설정됩니다.\n"
           },
           "status": {
             "title": "결제 상태 리스트",
@@ -26353,7 +26353,7 @@
             "items": {
               "$ref": "#/components/schemas/PaymentStatus"
             },
-            "description": "<p>값을 입력하지 않으면 결제상태 필터링이 적용되지 않습니다.</p>\n"
+            "description": "값을 입력하지 않으면 결제상태 필터링이 적용되지 않습니다.\n"
           },
           "methods": {
             "type": "array",
@@ -26361,7 +26361,7 @@
               "$ref": "#/components/schemas/PaymentMethodType"
             },
             "title": "결제수단 리스트",
-            "description": "<p>값을 입력하지 않으면 결제수단 필터링이 적용되지 않습니다.</p>\n"
+            "description": "값을 입력하지 않으면 결제수단 필터링이 적용되지 않습니다.\n"
           },
           "pgProvider": {
             "title": "PG사 리스트",
@@ -26369,7 +26369,7 @@
             "items": {
               "$ref": "#/components/schemas/PgProvider"
             },
-            "description": "<p>값을 입력하지 않으면 결제대행사 필터링이 적용되지 않습니다.</p>\n"
+            "description": "값을 입력하지 않으면 결제대행사 필터링이 적용되지 않습니다.\n"
           },
           "isTest": {
             "type": "boolean",
@@ -26451,13 +26451,13 @@
             }
           }
         },
-        "description": "<p>결제 건 다건 조회를 위한 입력 정보</p>\n",
+        "description": "결제 건 다건 조회를 위한 입력 정보\n",
         "x-portone-title": "결제 건 다건 조회를 위한 입력 정보"
       },
       "PaymentFilterInputEscrowStatus": {
         "title": "에스크로 상태",
         "type": "string",
-        "description": "<p>에스크로 상태</p>\n",
+        "description": "에스크로 상태\n",
         "enum": [
           "CANCELLED",
           "CONFIRMED",
@@ -26494,7 +26494,7 @@
             "title": "무이자할부 여부"
           }
         },
-        "description": "<p>할부 정보</p>\n",
+        "description": "할부 정보\n",
         "x-portone-title": "할부 정보"
       },
       "PaymentLogistics": {
@@ -26529,13 +26529,13 @@
             "title": "주소"
           }
         },
-        "description": "<p>배송정보</p>\n",
+        "description": "배송정보\n",
         "x-portone-title": "배송정보"
       },
       "PaymentLogisticsCompany": {
         "title": "물류 회사",
         "type": "string",
-        "description": "<p>물류 회사</p>\n",
+        "description": "물류 회사\n",
         "enum": [
           "ACI",
           "CHUNIL",
@@ -26664,7 +26664,7 @@
       },
       "PaymentMethod": {
         "title": "결제수단 정보",
-        "description": "<p>결제수단 정보</p>\n",
+        "description": "결제수단 정보\n",
         "oneOf": [
           {
             "$ref": "#/components/schemas/PaymentMethodCard"
@@ -26745,7 +26745,7 @@
             "title": "카드 포인트 사용여부"
           }
         },
-        "description": "<p>결제수단 카드 정보</p>\n",
+        "description": "결제수단 카드 정보\n",
         "x-portone-title": "결제수단 카드 정보"
       },
       "PaymentMethodEasyPay": {
@@ -26767,12 +26767,12 @@
             "title": "간편 결제 수단"
           }
         },
-        "description": "<p>간편 결제 상세 정보</p>\n",
+        "description": "간편 결제 상세 정보\n",
         "x-portone-title": "간편 결제 상세 정보"
       },
       "PaymentMethodEasyPayMethod": {
         "title": "간편 결제 수단",
-        "description": "<p>간편 결제 수단</p>\n",
+        "description": "간편 결제 수단\n",
         "oneOf": [
           {
             "$ref": "#/components/schemas/PaymentMethodCard"
@@ -26820,7 +26820,7 @@
             "title": "표준 은행 코드"
           }
         },
-        "description": "<p>충전식 포인트 결제 정보</p>\n",
+        "description": "충전식 포인트 결제 정보\n",
         "x-portone-title": "충전식 포인트 결제 정보"
       },
       "PaymentMethodGiftCertificate": {
@@ -26843,13 +26843,13 @@
             "title": "상품권 승인 번호"
           }
         },
-        "description": "<p>상품권 상세 정보</p>\n",
+        "description": "상품권 상세 정보\n",
         "x-portone-title": "상품권 상세 정보"
       },
       "PaymentMethodGiftCertificateType": {
         "title": "상품권 종류",
         "type": "string",
-        "description": "<p>상품권 종류</p>\n",
+        "description": "상품권 종류\n",
         "enum": [
           "BOOKNLIFE",
           "CULTUREGIFT",
@@ -26881,7 +26881,7 @@
             "title": "전화번호"
           }
         },
-        "description": "<p>모바일 상세 정보</p>\n",
+        "description": "모바일 상세 정보\n",
         "x-portone-title": "모바일 상세 정보"
       },
       "PaymentMethodTransfer": {
@@ -26899,7 +26899,7 @@
             "title": "표준 은행 코드"
           }
         },
-        "description": "<p>계좌 이체 상세 정보</p>\n",
+        "description": "계좌 이체 상세 정보\n",
         "x-portone-title": "계좌 이체 상세 정보"
       },
       "PaymentMethodType": {
@@ -26967,13 +26967,13 @@
             "title": "가상계좌 결제가 환불 단계일 때의 환불 상태"
           }
         },
-        "description": "<p>가상계좌 상세 정보</p>\n",
+        "description": "가상계좌 상세 정보\n",
         "x-portone-title": "가상계좌 상세 정보"
       },
       "PaymentMethodVirtualAccountRefundStatus": {
         "title": "가상계좌 환불 상태",
         "type": "string",
-        "description": "<p>가상계좌 환불 상태</p>\n",
+        "description": "가상계좌 환불 상태\n",
         "enum": [
           "COMPLETED",
           "FAILED",
@@ -26999,7 +26999,7 @@
       "PaymentMethodVirtualAccountType": {
         "title": "가상계좌 유형",
         "type": "string",
-        "description": "<p>가상계좌 유형</p>\n",
+        "description": "가상계좌 유형\n",
         "enum": [
           "FIXED",
           "NORMAL"
@@ -27028,7 +27028,7 @@
             "type": "string"
           }
         },
-        "description": "<p>결제 건이 존재하지 않는 경우</p>\n",
+        "description": "결제 건이 존재하지 않는 경우\n",
         "x-portone-title": "결제 건이 존재하지 않는 경우",
         "x-portone-status-code": 404
       },
@@ -27046,7 +27046,7 @@
             "type": "string"
           }
         },
-        "description": "<p>결제가 완료되지 않은 경우</p>\n",
+        "description": "결제가 완료되지 않은 경우\n",
         "x-portone-title": "결제가 완료되지 않은 경우",
         "x-portone-status-code": 409
       },
@@ -27064,7 +27064,7 @@
             "type": "string"
           }
         },
-        "description": "<p>결제 건이 입금 대기 상태가 아닌 경우</p>\n",
+        "description": "결제 건이 입금 대기 상태가 아닌 경우\n",
         "x-portone-title": "결제 건이 입금 대기 상태가 아닌 경우",
         "x-portone-status-code": 409
       },
@@ -27081,7 +27081,7 @@
           "id": {
             "type": "string",
             "title": "상품 고유 식별자",
-            "description": "<p>가맹점이 직접 부여한 식별자입니다.</p>\n"
+            "description": "가맹점이 직접 부여한 식별자입니다.\n"
           },
           "name": {
             "type": "string",
@@ -27090,7 +27090,7 @@
           "tag": {
             "type": "string",
             "title": "상품 태그",
-            "description": "<p>카테고리 등으로 활용될 수 있습니다.</p>\n"
+            "description": "카테고리 등으로 활용될 수 있습니다.\n"
           },
           "code": {
             "type": "string",
@@ -27107,13 +27107,13 @@
             "title": "주문 수량"
           }
         },
-        "description": "<p>상품 정보</p>\n",
+        "description": "상품 정보\n",
         "x-portone-title": "상품 정보"
       },
       "PaymentProductType": {
         "title": "상품 유형",
         "type": "string",
-        "description": "<p>상품 유형</p>\n",
+        "description": "상품 유형\n",
         "enum": [
           "DIGITAL",
           "PHYSICAL"
@@ -27125,13 +27125,13 @@
           },
           "DIGITAL": {
             "title": "디지털 상품",
-            "description": "<p>서비스, 온라인 상품 등 실물이 존재하지 않는 무형의 상품을 의미합니다.</p>\n"
+            "description": "서비스, 온라인 상품 등 실물이 존재하지 않는 무형의 상품을 의미합니다.\n"
           }
         }
       },
       "PaymentSchedule": {
         "title": "결제 예약 건",
-        "description": "<p>결제 예약 건</p>\n",
+        "description": "결제 예약 건\n",
         "oneOf": [
           {
             "$ref": "#/components/schemas/FailedPaymentSchedule"
@@ -27192,7 +27192,7 @@
             "type": "string"
           }
         },
-        "description": "<p>결제 예약건이 이미 존재하는 경우</p>\n",
+        "description": "결제 예약건이 이미 존재하는 경우\n",
         "x-portone-title": "결제 예약건이 이미 존재하는 경우",
         "x-portone-status-code": 409
       },
@@ -27210,7 +27210,7 @@
             "type": "string"
           }
         },
-        "description": "<p>결제 예약건이 이미 처리된 경우</p>\n",
+        "description": "결제 예약건이 이미 처리된 경우\n",
         "x-portone-title": "결제 예약건이 이미 처리된 경우",
         "x-portone-status-code": 409
       },
@@ -27228,7 +27228,7 @@
             "type": "string"
           }
         },
-        "description": "<p>결제 예약건이 이미 취소된 경우</p>\n",
+        "description": "결제 예약건이 이미 취소된 경우\n",
         "x-portone-title": "결제 예약건이 이미 취소된 경우",
         "x-portone-status-code": 409
       },
@@ -27239,7 +27239,7 @@
           "storeId": {
             "type": "string",
             "title": "상점 아이디",
-            "description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.\n"
           },
           "billingKey": {
             "type": "string",
@@ -27249,13 +27249,13 @@
             "type": "string",
             "format": "date-time",
             "title": "결제 예정 시점 조건 범위의 시작",
-            "description": "<p>값을 입력하지 않으면 파라미터 end의 90일 전으로 설정됩니다.</p>\n"
+            "description": "값을 입력하지 않으면 파라미터 end의 90일 전으로 설정됩니다.\n"
           },
           "until": {
             "type": "string",
             "format": "date-time",
             "title": "결제 예정 시점 조건 범위의 끝",
-            "description": "<p>값을 입력하지 않으면 현재 시점으로 설정됩니다.</p>\n"
+            "description": "값을 입력하지 않으면 현재 시점으로 설정됩니다.\n"
           },
           "status": {
             "title": "결제 예약 건 상태 리스트",
@@ -27265,7 +27265,7 @@
             }
           }
         },
-        "description": "<p>결제 예약 건 다건 조회를 위한 입력 정보</p>\n",
+        "description": "결제 예약 건 다건 조회를 위한 입력 정보\n",
         "x-portone-title": "결제 예약 건 다건 조회를 위한 입력 정보"
       },
       "PaymentScheduleNotFoundError": {
@@ -27282,14 +27282,14 @@
             "type": "string"
           }
         },
-        "description": "<p>결제 예약건이 존재하지 않는 경우</p>\n",
+        "description": "결제 예약건이 존재하지 않는 경우\n",
         "x-portone-title": "결제 예약건이 존재하지 않는 경우",
         "x-portone-status-code": 404
       },
       "PaymentScheduleStatus": {
         "title": "결제 예약 건 상태",
         "type": "string",
-        "description": "<p>결제 예약 건 상태</p>\n",
+        "description": "결제 예약 건 상태\n",
         "enum": [
           "FAILED",
           "REVOKED",
@@ -27328,13 +27328,13 @@
             "title": "결제 예약 건 아이디"
           }
         },
-        "description": "<p>결제 예약 건</p>\n",
+        "description": "결제 예약 건\n",
         "x-portone-title": "결제 예약 건"
       },
       "PaymentSortBy": {
         "title": "결제 건 정렬 기준",
         "type": "string",
-        "description": "<p>결제 건 정렬 기준</p>\n",
+        "description": "결제 건 정렬 기준\n",
         "enum": [
           "REQUESTED_AT",
           "STATUS_CHANGED_AT"
@@ -27352,7 +27352,7 @@
       "PaymentSortOrder": {
         "title": "결제 건 정렬 방식",
         "type": "string",
-        "description": "<p>결제 건 정렬 방식</p>\n",
+        "description": "결제 건 정렬 방식\n",
         "enum": [
           "ASC",
           "DESC"
@@ -27370,7 +27370,7 @@
       "PaymentStatus": {
         "title": "결제 건 상태",
         "type": "string",
-        "description": "<p>결제 건 상태</p>\n",
+        "description": "결제 건 상태\n",
         "enum": [
           "CANCELLED",
           "FAILED",
@@ -27406,13 +27406,13 @@
             "type": "string"
           }
         },
-        "description": "<p>통합검색 입력 정보</p>\n",
+        "description": "통합검색 입력 정보\n",
         "x-portone-title": "통합검색 입력 정보"
       },
       "PaymentTextSearchField": {
         "title": "통합검색 항목",
         "type": "string",
-        "description": "<p>통합검색 항목</p>\n",
+        "description": "통합검색 항목\n",
         "enum": [
           "ALL",
           "BILLING_KEY",
@@ -27486,13 +27486,13 @@
       "PaymentTimestampType": {
         "title": "조회 시점 기준",
         "type": "string",
-        "description": "<p>조회 시점 기준</p>\n<p>어떤 시점을 기준으로 조회를 할 것인지 선택합니다.\nCREATED_AT: 결제 건 생성 시점을 기준으로 조회합니다.\nSTATUS_CHANGED_AT: 상태 승인 시점을 기준으로 조회합니다. 결제 건의 최종 상태에 따라 검색 기준이 다르게 적용됩니다.\nready -&gt; 결제 요청 시점 기준\npaid -&gt; 결제 완료 시점 기준\ncancelled -&gt; 결제 취소 시점 기준\nfailed -&gt; 결제 실패 시점 기준\n값을 입력하지 않으면 STATUS_CHANGED_AT 으로 자동 적용됩니다.</p>\n",
+        "description": "조회 시점 기준\n어떤 시점을 기준으로 조회를 할 것인지 선택합니다.\nCREATED_AT: 결제 건 생성 시점을 기준으로 조회합니다.\nSTATUS_CHANGED_AT: 상태 승인 시점을 기준으로 조회합니다. 결제 건의 최종 상태에 따라 검색 기준이 다르게 적용됩니다.\nready -&gt; 결제 요청 시점 기준\npaid -&gt; 결제 완료 시점 기준\ncancelled -&gt; 결제 취소 시점 기준\nfailed -&gt; 결제 실패 시점 기준\n값을 입력하지 않으면 STATUS_CHANGED_AT 으로 자동 적용됩니다.\n",
         "enum": [
           "CREATED_AT",
           "STATUS_CHANGED_AT"
         ],
         "x-portone-title": "조회 시점 기준",
-        "x-portone-description": "<p>어떤 시점을 기준으로 조회를 할 것인지 선택합니다.\nCREATED_AT: 결제 건 생성 시점을 기준으로 조회합니다.\nSTATUS_CHANGED_AT: 상태 승인 시점을 기준으로 조회합니다. 결제 건의 최종 상태에 따라 검색 기준이 다르게 적용됩니다.\nready -&gt; 결제 요청 시점 기준\npaid -&gt; 결제 완료 시점 기준\ncancelled -&gt; 결제 취소 시점 기준\nfailed -&gt; 결제 실패 시점 기준\n값을 입력하지 않으면 STATUS_CHANGED_AT 으로 자동 적용됩니다.</p>\n",
+        "x-portone-description": "어떤 시점을 기준으로 조회를 할 것인지 선택합니다.\nCREATED_AT: 결제 건 생성 시점을 기준으로 조회합니다.\nSTATUS_CHANGED_AT: 상태 승인 시점을 기준으로 조회합니다. 결제 건의 최종 상태에 따라 검색 기준이 다르게 적용됩니다.\nready -&gt; 결제 요청 시점 기준\npaid -&gt; 결제 완료 시점 기준\ncancelled -&gt; 결제 취소 시점 기준\nfailed -&gt; 결제 실패 시점 기준\n값을 입력하지 않으면 STATUS_CHANGED_AT 으로 자동 적용됩니다.\n",
         "x-portone-enum": {
           "CREATED_AT": {
             "title": "결제 건 생성 시점"
@@ -27513,7 +27513,7 @@
           "paymentStatus": {
             "$ref": "#/components/schemas/PaymentWebhookPaymentStatus",
             "title": "웹훅 발송 시 결제 건 상태",
-            "description": "<p>V1 결제 건인 경우, 값이 존재하지 않습니다.</p>\n"
+            "description": "V1 결제 건인 경우, 값이 존재하지 않습니다.\n"
           },
           "id": {
             "type": "string",
@@ -27526,12 +27526,12 @@
           "url": {
             "type": "string",
             "title": "웹훅이 발송된 url",
-            "description": "<p>V1 결제 건인 경우, 값이 존재하지 않습니다.</p>\n"
+            "description": "V1 결제 건인 경우, 값이 존재하지 않습니다.\n"
           },
           "isAsync": {
             "type": "boolean",
             "title": "비동기 웹훅 여부",
-            "description": "<p>V1 결제 건인 경우, 값이 존재하지 않습니다.</p>\n"
+            "description": "V1 결제 건인 경우, 값이 존재하지 않습니다.\n"
           },
           "currentExecutionCount": {
             "type": "integer",
@@ -27561,13 +27561,13 @@
             "title": "웹훅 처리 시작 시점"
           }
         },
-        "description": "<p>성공 웹훅 내역</p>\n",
+        "description": "성공 웹훅 내역\n",
         "x-portone-title": "성공 웹훅 내역"
       },
       "PaymentWebhookPaymentStatus": {
         "title": "웹훅 발송 시 결제 건 상태",
         "type": "string",
-        "description": "<p>웹훅 발송 시 결제 건 상태</p>\n",
+        "description": "웹훅 발송 시 결제 건 상태\n",
         "enum": [
           "CANCELLED",
           "FAILED",
@@ -27609,7 +27609,7 @@
             "title": "요청 시점"
           }
         },
-        "description": "<p>웹훅 요청 정보</p>\n",
+        "description": "웹훅 요청 정보\n",
         "x-portone-title": "웹훅 요청 정보"
       },
       "PaymentWebhookResponse": {
@@ -27640,13 +27640,13 @@
             "title": "응답 시점"
           }
         },
-        "description": "<p>웹훅 응답 정보</p>\n",
+        "description": "웹훅 응답 정보\n",
         "x-portone-title": "웹훅 응답 정보"
       },
       "PaymentWebhookStatus": {
         "title": "웹훅 전송 상태",
         "type": "string",
-        "description": "<p>웹훅 전송 상태</p>\n",
+        "description": "웹훅 전송 상태\n",
         "enum": [
           "FAILED_NOT_OK_RESPONSE",
           "FAILED_UNEXPECTED_ERROR",
@@ -27662,7 +27662,7 @@
       "PaymentWebhookTrigger": {
         "title": "웹훅 실행 트리거",
         "type": "string",
-        "description": "<p>웹훅 실행 트리거</p>\n<p>수동 웹훅 재발송, 가상계좌 입금, 비동기 취소 승인 시 발생한 웹훅일 때 필드의 값이 존재합니다.</p>\n",
+        "description": "웹훅 실행 트리거\n수동 웹훅 재발송, 가상계좌 입금, 비동기 취소 승인 시 발생한 웹훅일 때 필드의 값이 존재합니다.\n",
         "enum": [
           "ASYNC_CANCEL_APPROVED",
           "ASYNC_CANCEL_FAILED",
@@ -27672,7 +27672,7 @@
           "VIRTUAL_ACCOUNT_DEPOSIT"
         ],
         "x-portone-title": "웹훅 실행 트리거",
-        "x-portone-description": "<p>수동 웹훅 재발송, 가상계좌 입금, 비동기 취소 승인 시 발생한 웹훅일 때 필드의 값이 존재합니다.</p>\n",
+        "x-portone-description": "수동 웹훅 재발송, 가상계좌 입금, 비동기 취소 승인 시 발생한 웹훅일 때 필드의 값이 존재합니다.\n",
         "x-portone-enum": {
           "ASYNC_CANCEL_APPROVED": {},
           "VIRTUAL_ACCOUNT_DEPOSIT": {},
@@ -27699,7 +27699,7 @@
             "title": "해당 결제 건의 커서 정보"
           }
         },
-        "description": "<p>결제 건 및 커서 정보</p>\n",
+        "description": "결제 건 및 커서 정보\n",
         "x-portone-title": "결제 건 및 커서 정보"
       },
       "PayoutPartnerSettlementsResponse": {
@@ -27749,7 +27749,7 @@
       "PgCompany": {
         "title": "PG사",
         "type": "string",
-        "description": "<p>PG사</p>\n",
+        "description": "PG사\n",
         "enum": [
           "ALIPAY",
           "BLUEWALNUT",
@@ -27815,7 +27815,7 @@
       "PgProvider": {
         "title": "PG사 결제 모듈",
         "type": "string",
-        "description": "<p>PG사 결제 모듈</p>\n",
+        "description": "PG사 결제 모듈\n",
         "enum": [
           "ALIPAY",
           "BLUEWALNUT",
@@ -27936,7 +27936,7 @@
             "type": "string"
           }
         },
-        "description": "<p>PG사에서 오류가 발생한 경우</p>\n",
+        "description": "PG사에서 오류가 발생한 경우\n",
         "x-portone-title": "PG사에서 오류가 발생한 경우",
         "x-portone-status-code": 502
       },
@@ -27971,7 +27971,7 @@
             "title": "정산 규칙"
           }
         },
-        "description": "<p>가맹점의 플랫폼 기능 관련 정보</p>\n",
+        "description": "가맹점의 플랫폼 기능 관련 정보\n",
         "x-portone-title": "가맹점의 플랫폼 기능 관련 정보"
       },
       "PlatformAccount": {
@@ -28006,9 +28006,9 @@
             "title": "계좌 상태"
           }
         },
-        "description": "<p>플랫폼 정산 계좌</p>\n<p><code>currency</code> 가 KRW 일 경우 예금주 조회 API 를 통해 올바른 계좌인지 검증합니다. 그 외의 화폐일 경우 따로 검증하지는 않습니다.</p>\n",
+        "description": "플랫폼 정산 계좌\n<code>currency</code> 가 KRW 일 경우 예금주 조회 API 를 통해 올바른 계좌인지 검증합니다. 그 외의 화폐일 경우 따로 검증하지는 않습니다.\n",
         "x-portone-title": "플랫폼 정산 계좌",
-        "x-portone-description": "<p><code>currency</code> 가 KRW 일 경우 예금주 조회 API 를 통해 올바른 계좌인지 검증합니다. 그 외의 화폐일 경우 따로 검증하지는 않습니다.</p>\n"
+        "x-portone-description": "<code>currency</code> 가 KRW 일 경우 예금주 조회 API 를 통해 올바른 계좌인지 검증합니다. 그 외의 화폐일 경우 따로 검증하지는 않습니다.\n"
       },
       "PlatformAccountHolder": {
         "title": "예금주 조회 성공 응답 정보",
@@ -28022,13 +28022,13 @@
             "title": "계좌 예금주 이름"
           }
         },
-        "description": "<p>예금주 조회 성공 응답 정보</p>\n",
+        "description": "예금주 조회 성공 응답 정보\n",
         "x-portone-title": "예금주 조회 성공 응답 정보"
       },
       "PlatformAccountStatus": {
         "title": "플랫폼 계좌 상태",
         "type": "string",
-        "description": "<p>플랫폼 계좌 상태</p>\n",
+        "description": "플랫폼 계좌 상태\n",
         "enum": [
           "EXPIRED",
           "UNKNOWN",
@@ -28129,9 +28129,9 @@
             "title": "변경 적용 시점"
           }
         },
-        "description": "<p>추가 수수료 정책</p>\n<p>추가 수수료 정책는 가맹점의 주문건에 대한 중개수수료에 별도로 추가로 부여되는 수수료입니다. 대표적인 사용 예시로 풀필먼트 수수료, 로켓배송 수수료, 마케팅 채널 수수료등이 있습니다.</p>\n",
+        "description": "추가 수수료 정책\n추가 수수료 정책는 가맹점의 주문건에 대한 중개수수료에 별도로 추가로 부여되는 수수료입니다. 대표적인 사용 예시로 풀필먼트 수수료, 로켓배송 수수료, 마케팅 채널 수수료등이 있습니다.\n",
         "x-portone-title": "추가 수수료 정책",
-        "x-portone-description": "<p>추가 수수료 정책는 가맹점의 주문건에 대한 중개수수료에 별도로 추가로 부여되는 수수료입니다. 대표적인 사용 예시로 풀필먼트 수수료, 로켓배송 수수료, 마케팅 채널 수수료등이 있습니다.</p>\n"
+        "x-portone-description": "추가 수수료 정책는 가맹점의 주문건에 대한 중개수수료에 별도로 추가로 부여되는 수수료입니다. 대표적인 사용 예시로 풀필먼트 수수료, 로켓배송 수수료, 마케팅 채널 수수료등이 있습니다.\n"
       },
       "PlatformAdditionalFeePolicyAlreadyExistsError": {
         "required": [
@@ -28155,7 +28155,7 @@
           "isArchived": {
             "type": "boolean",
             "title": "보관 조회 여부",
-            "description": "<p>true 이면 보관된 추가 수수료 정책의 필터 옵션을 조회하고, false 이면 보관되지 않은 추가 수수료 정책의 필터 옵션을 조회합니다. 아무 값도 넘기지 않을 경우 기본값은 false 입니다.</p>\n"
+            "description": "true 이면 보관된 추가 수수료 정책의 필터 옵션을 조회하고, false 이면 보관되지 않은 추가 수수료 정책의 필터 옵션을 조회합니다. 아무 값도 넘기지 않을 경우 기본값은 false 입니다.\n"
           },
           "vatPayers": {
             "title": "금액 부담 주체",
@@ -28163,14 +28163,14 @@
             "items": {
               "$ref": "#/components/schemas/PlatformPayer"
             },
-            "description": "<p>하나 이상의 값이 존재하는 경우 해당 리스트에 포함되는 부가세 부담 주체에 해당하는 추가 수수료 정책만 조회합니다.</p>\n"
+            "description": "하나 이상의 값이 존재하는 경우 해당 리스트에 포함되는 부가세 부담 주체에 해당하는 추가 수수료 정책만 조회합니다.\n"
           },
           "keyword": {
             "$ref": "#/components/schemas/PlatformAdditionalFeePolicyFilterInputKeyword",
             "title": "검색 키워드"
           }
         },
-        "description": "<p>추가 수수료 정책 다건 조회를 위한 필터 조건</p>\n",
+        "description": "추가 수수료 정책 다건 조회를 위한 필터 조건\n",
         "x-portone-title": "추가 수수료 정책 다건 조회를 위한 필터 조건"
       },
       "PlatformAdditionalFeePolicyFilterInputKeyword": {
@@ -28179,20 +28179,20 @@
         "properties": {
           "name": {
             "type": "string",
-            "description": "<p>해당 값이 포함된 name 을 가진 추가 수수료 정책만 조회합니다.</p>\n"
+            "description": "해당 값이 포함된 name 을 가진 추가 수수료 정책만 조회합니다.\n"
           },
           "id": {
             "type": "string",
-            "description": "<p>해당 값이 포함된 id 를 가진 추가 수수료 정책만 조회합니다.</p>\n"
+            "description": "해당 값이 포함된 id 를 가진 추가 수수료 정책만 조회합니다.\n"
           },
           "fee": {
             "type": "string",
-            "description": "<p>해당 값과 같은 수수료 를 가진 추가 수수료 정책만 조회합니다.</p>\n"
+            "description": "해당 값과 같은 수수료 를 가진 추가 수수료 정책만 조회합니다.\n"
           }
         },
-        "description": "<p>검색 키워드 입력 정보</p>\n<p>검색 키워드 적용을 위한 옵션으로, 명시된 키워드를 포함하는 추가 수수료 정책만 조회합니다. 하위 필드는 명시된 값 중 한 가지만 적용됩니다.</p>\n",
+        "description": "검색 키워드 입력 정보\n검색 키워드 적용을 위한 옵션으로, 명시된 키워드를 포함하는 추가 수수료 정책만 조회합니다. 하위 필드는 명시된 값 중 한 가지만 적용됩니다.\n",
         "x-portone-title": "검색 키워드 입력 정보",
-        "x-portone-description": "<p>검색 키워드 적용을 위한 옵션으로, 명시된 키워드를 포함하는 추가 수수료 정책만 조회합니다. 하위 필드는 명시된 값 중 한 가지만 적용됩니다.</p>\n"
+        "x-portone-description": "검색 키워드 적용을 위한 옵션으로, 명시된 키워드를 포함하는 추가 수수료 정책만 조회합니다. 하위 필드는 명시된 값 중 한 가지만 적용됩니다.\n"
       },
       "PlatformAdditionalFeePolicyNotFoundError": {
         "required": [
@@ -28269,7 +28269,7 @@
             "type": "string"
           }
         },
-        "description": "<p>보관된 추가 수수료 정책을 업데이트하려고 하는 경우</p>\n",
+        "description": "보관된 추가 수수료 정책을 업데이트하려고 하는 경우\n",
         "x-portone-title": "보관된 추가 수수료 정책을 업데이트하려고 하는 경우",
         "x-portone-status-code": 409
       },
@@ -28287,7 +28287,7 @@
             "type": "string"
           }
         },
-        "description": "<p>보관된 계약을 업데이트하려고 하는 경우</p>\n",
+        "description": "보관된 계약을 업데이트하려고 하는 경우\n",
         "x-portone-title": "보관된 계약을 업데이트하려고 하는 경우",
         "x-portone-status-code": 409
       },
@@ -28305,7 +28305,7 @@
             "type": "string"
           }
         },
-        "description": "<p>보관된 할인 분담 정책을 업데이트하려고 하는 경우</p>\n",
+        "description": "보관된 할인 분담 정책을 업데이트하려고 하는 경우\n",
         "x-portone-title": "보관된 할인 분담 정책을 업데이트하려고 하는 경우",
         "x-portone-status-code": 409
       },
@@ -28323,7 +28323,7 @@
             "type": "string"
           }
         },
-        "description": "<p>보관된 파트너를 업데이트하려고 하는 경우</p>\n",
+        "description": "보관된 파트너를 업데이트하려고 하는 경우\n",
         "x-portone-title": "보관된 파트너를 업데이트하려고 하는 경우",
         "x-portone-status-code": 409
       },
@@ -28341,7 +28341,7 @@
             "type": "string"
           }
         },
-        "description": "<p>보관된 파트너들을 예약 업데이트하려고 하는 경우</p>\n",
+        "description": "보관된 파트너들을 예약 업데이트하려고 하는 경우\n",
         "x-portone-title": "보관된 파트너들을 예약 업데이트하려고 하는 경우",
         "x-portone-status-code": 409
       },
@@ -28479,7 +28479,7 @@
             "type": "string"
           }
         },
-        "description": "<p>예약된 업데이트가 있는 추가 수수료 정책을 보관하려고 하는 경우</p>\n",
+        "description": "예약된 업데이트가 있는 추가 수수료 정책을 보관하려고 하는 경우\n",
         "x-portone-title": "예약된 업데이트가 있는 추가 수수료 정책을 보관하려고 하는 경우",
         "x-portone-status-code": 409
       },
@@ -28497,7 +28497,7 @@
             "type": "string"
           }
         },
-        "description": "<p>예약된 업데이트가 있는 계약을 보관하려고 하는 경우</p>\n",
+        "description": "예약된 업데이트가 있는 계약을 보관하려고 하는 경우\n",
         "x-portone-title": "예약된 업데이트가 있는 계약을 보관하려고 하는 경우",
         "x-portone-status-code": 409
       },
@@ -28515,7 +28515,7 @@
             "type": "string"
           }
         },
-        "description": "<p>예약된 업데이트가 있는 할인 분담 정책을 보관하려고 하는 경우</p>\n",
+        "description": "예약된 업데이트가 있는 할인 분담 정책을 보관하려고 하는 경우\n",
         "x-portone-title": "예약된 업데이트가 있는 할인 분담 정책을 보관하려고 하는 경우",
         "x-portone-status-code": 409
       },
@@ -28533,7 +28533,7 @@
             "type": "string"
           }
         },
-        "description": "<p>예약된 업데이트가 있는 파트너를 보관하려고 하는 경우</p>\n",
+        "description": "예약된 업데이트가 있는 파트너를 보관하려고 하는 경우\n",
         "x-portone-title": "예약된 업데이트가 있는 파트너를 보관하려고 하는 경우",
         "x-portone-status-code": 409
       },
@@ -28565,8 +28565,8 @@
           },
           "settlementDate": {
             "type": "string",
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n"
+            "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n"
           },
           "summary": {
             "$ref": "#/components/schemas/PlatformPayoutSummary"
@@ -28606,9 +28606,9 @@
             "title": "담당자 이메일"
           }
         },
-        "description": "<p>플랫폼 파트너 담당자 연락 정보</p>\n<p>파트너 담당자에게 연락하기 위한 정보들 입니다.</p>\n",
+        "description": "플랫폼 파트너 담당자 연락 정보\n파트너 담당자에게 연락하기 위한 정보들 입니다.\n",
         "x-portone-title": "플랫폼 파트너 담당자 연락 정보",
-        "x-portone-description": "<p>파트너 담당자에게 연락하기 위한 정보들 입니다.</p>\n"
+        "x-portone-description": "파트너 담당자에게 연락하기 위한 정보들 입니다.\n"
       },
       "PlatformContract": {
         "title": "계약",
@@ -28655,7 +28655,7 @@
           "subtractPaymentVatAmount": {
             "type": "boolean",
             "title": "정산 시 결제금액 부가세 감액 여부",
-            "description": "<p>false인 경우 정산금에서 결제 금액 부가세를 감액하지 않고, true인 경우 정산금에서 결제 금액 부가세를 감액합니다.</p>\n"
+            "description": "false인 경우 정산금에서 결제 금액 부가세를 감액하지 않고, true인 경우 정산금에서 결제 금액 부가세를 감액합니다.\n"
           },
           "isArchived": {
             "type": "boolean",
@@ -28667,9 +28667,9 @@
             "title": "변경 적용 시점"
           }
         },
-        "description": "<p>계약</p>\n<p>계약은 플랫폼 가맹점이 파트너에게 정산해줄 대금과 정산일을 계산하는 데 적용되는 정보입니다.\n가맹점의 플랫폼에서 재화 및 서비스를 판매하기 위한 중개수수료와 판매금에 대한 정산일로 구성되어 있습니다.</p>\n",
+        "description": "계약\n계약은 플랫폼 가맹점이 파트너에게 정산해줄 대금과 정산일을 계산하는 데 적용되는 정보입니다.\n가맹점의 플랫폼에서 재화 및 서비스를 판매하기 위한 중개수수료와 판매금에 대한 정산일로 구성되어 있습니다.\n",
         "x-portone-title": "계약",
-        "x-portone-description": "<p>계약은 플랫폼 가맹점이 파트너에게 정산해줄 대금과 정산일을 계산하는 데 적용되는 정보입니다.\n가맹점의 플랫폼에서 재화 및 서비스를 판매하기 위한 중개수수료와 판매금에 대한 정산일로 구성되어 있습니다.</p>\n"
+        "x-portone-description": "계약은 플랫폼 가맹점이 파트너에게 정산해줄 대금과 정산일을 계산하는 데 적용되는 정보입니다.\n가맹점의 플랫폼에서 재화 및 서비스를 판매하기 위한 중개수수료와 판매금에 대한 정산일로 구성되어 있습니다.\n"
       },
       "PlatformContractAlreadyExistsError": {
         "required": [
@@ -28696,7 +28696,7 @@
             "items": {
               "$ref": "#/components/schemas/PlatformPayer"
             },
-            "description": "<p>하나 이상의 값이 존재하는 경우 해당 리스트에 포함되는 수수료 부담 주체를 가진 계약만 조회합니다.</p>\n"
+            "description": "하나 이상의 값이 존재하는 경우 해당 리스트에 포함되는 수수료 부담 주체를 가진 계약만 조회합니다.\n"
           },
           "cycleTypes": {
             "title": "플랫폼 정산 주기 계산 방식",
@@ -28704,7 +28704,7 @@
             "items": {
               "$ref": "#/components/schemas/PlatformSettlementCycleType"
             },
-            "description": "<p>하나 이상의 값이 존재하는 경우 해당 리스트에 포함되는 정산 주기 계산 방식을 가진 계약만 조회합니다.</p>\n"
+            "description": "하나 이상의 값이 존재하는 경우 해당 리스트에 포함되는 정산 주기 계산 방식을 가진 계약만 조회합니다.\n"
           },
           "datePolicies": {
             "title": "플랫폼 정산 기준일",
@@ -28712,19 +28712,19 @@
             "items": {
               "$ref": "#/components/schemas/PlatformSettlementCycleDatePolicy"
             },
-            "description": "<p>하나 이상의 값이 존재하는 경우 해당 리스트에 포함되는 정산 기준일을 가진 계약만 조회합니다.</p>\n"
+            "description": "하나 이상의 값이 존재하는 경우 해당 리스트에 포함되는 정산 기준일을 가진 계약만 조회합니다.\n"
           },
           "isArchived": {
             "type": "boolean",
             "title": "보관 조회 여부",
-            "description": "<p>true 이면 보관된 계약을 조회하고, false 이면 보관되지 않은 계약을 조회합니다. 아무 값도 넘기지 않을 경우 기본값은 false 입니다.</p>\n"
+            "description": "true 이면 보관된 계약을 조회하고, false 이면 보관되지 않은 계약을 조회합니다. 아무 값도 넘기지 않을 경우 기본값은 false 입니다.\n"
           },
           "keyword": {
             "$ref": "#/components/schemas/PlatformContractFilterInputKeyword",
             "title": "검색 키워드"
           }
         },
-        "description": "<p>계약 다건 조회를 위한 필터 조건</p>\n",
+        "description": "계약 다건 조회를 위한 필터 조건\n",
         "x-portone-title": "계약 다건 조회를 위한 필터 조건"
       },
       "PlatformContractFilterInputKeyword": {
@@ -28733,16 +28733,16 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "<p>해당 값이 포함된 id 를 가진 계약만 조회합니다.</p>\n"
+            "description": "해당 값이 포함된 id 를 가진 계약만 조회합니다.\n"
           },
           "name": {
             "type": "string",
-            "description": "<p>해당 값이 포함된 name 을 가진 계약만 조회합니다.</p>\n"
+            "description": "해당 값이 포함된 name 을 가진 계약만 조회합니다.\n"
           }
         },
-        "description": "<p>검색 키워드 입력 정보</p>\n<p>검색 키워드 적용을 위한 옵션으로, 명시된 키워드를 포함하는 계약만 조회합니다. 하나의 하위 필드에만 값을 명시하여 요청합니다.</p>\n",
+        "description": "검색 키워드 입력 정보\n검색 키워드 적용을 위한 옵션으로, 명시된 키워드를 포함하는 계약만 조회합니다. 하나의 하위 필드에만 값을 명시하여 요청합니다.\n",
         "x-portone-title": "검색 키워드 입력 정보",
-        "x-portone-description": "<p>검색 키워드 적용을 위한 옵션으로, 명시된 키워드를 포함하는 계약만 조회합니다. 하나의 하위 필드에만 값을 명시하여 요청합니다.</p>\n"
+        "x-portone-description": "검색 키워드 적용을 위한 옵션으로, 명시된 키워드를 포함하는 계약만 조회합니다. 하나의 하위 필드에만 값을 명시하여 요청합니다.\n"
       },
       "PlatformContractNotFoundError": {
         "required": [
@@ -28919,7 +28919,7 @@
             "type": "integer",
             "format": "int32",
             "title": "할인 분담율",
-            "description": "<p>파트너가 분담할 할인금액의 비율을 의미하는 밀리 퍼센트 단위 (10^-5) 의 음이 아닌 정수이며, 파트너가 부담할 금액은 <code>할인금액 * partnerShareRate * 10^5</code> 로 책정합니다.</p>\n"
+            "description": "파트너가 분담할 할인금액의 비율을 의미하는 밀리 퍼센트 단위 (10^-5) 의 음이 아닌 정수이며, 파트너가 부담할 금액은 <code>할인금액 * partnerShareRate * 10^5</code> 로 책정합니다.\n"
           },
           "memo": {
             "type": "string",
@@ -28935,9 +28935,9 @@
             "title": "변경 적용 시점"
           }
         },
-        "description": "<p>할인 분담 정책</p>\n<p>할인 분담은 가맹점의 주문건에 쿠폰 및 포인트와 같은 할인금액이 적용될 때, 파트너 정산 시 할인금액에 대한 분담 정책을 가지는 객체입니다.\n할인 유형에 대한 아이디와 메모, 그리고 파트너 분담율을 가집니다.</p>\n",
+        "description": "할인 분담 정책\n할인 분담은 가맹점의 주문건에 쿠폰 및 포인트와 같은 할인금액이 적용될 때, 파트너 정산 시 할인금액에 대한 분담 정책을 가지는 객체입니다.\n할인 유형에 대한 아이디와 메모, 그리고 파트너 분담율을 가집니다.\n",
         "x-portone-title": "할인 분담 정책",
-        "x-portone-description": "<p>할인 분담은 가맹점의 주문건에 쿠폰 및 포인트와 같은 할인금액이 적용될 때, 파트너 정산 시 할인금액에 대한 분담 정책을 가지는 객체입니다.\n할인 유형에 대한 아이디와 메모, 그리고 파트너 분담율을 가집니다.</p>\n"
+        "x-portone-description": "할인 분담은 가맹점의 주문건에 쿠폰 및 포인트와 같은 할인금액이 적용될 때, 파트너 정산 시 할인금액에 대한 분담 정책을 가지는 객체입니다.\n할인 유형에 대한 아이디와 메모, 그리고 파트너 분담율을 가집니다.\n"
       },
       "PlatformDiscountSharePolicyAlreadyExistsError": {
         "required": [
@@ -28961,7 +28961,7 @@
           "isArchived": {
             "type": "boolean",
             "title": "보관 조회 여부",
-            "description": "<p>true 이면 보관된 할인 분담 정책을 조회하고, false 이면 보관되지 않은 할인 분담 정책을 조회합니다. 아무 값도 넘기지 않을 경우 기본값은 false 입니다.</p>\n"
+            "description": "true 이면 보관된 할인 분담 정책을 조회하고, false 이면 보관되지 않은 할인 분담 정책을 조회합니다. 아무 값도 넘기지 않을 경우 기본값은 false 입니다.\n"
           },
           "partnerShareRates": {
             "type": "array",
@@ -28969,14 +28969,14 @@
               "type": "integer",
               "format": "int32"
             },
-            "description": "<p>하나 이상의 값이 존재하는 경우 해당 리스트에 포함되는 파트너 분담율을 가진 할인 분담 정책만 조회합니다.</p>\n"
+            "description": "하나 이상의 값이 존재하는 경우 해당 리스트에 포함되는 파트너 분담율을 가진 할인 분담 정책만 조회합니다.\n"
           },
           "keyword": {
             "$ref": "#/components/schemas/PlatformDiscountSharePolicyFilterInputKeyword",
             "title": "검색 키워드"
           }
         },
-        "description": "<p>할인 분담 정책 다건 조회를 위한 필터 조건</p>\n",
+        "description": "할인 분담 정책 다건 조회를 위한 필터 조건\n",
         "x-portone-title": "할인 분담 정책 다건 조회를 위한 필터 조건"
       },
       "PlatformDiscountSharePolicyFilterInputKeyword": {
@@ -28985,16 +28985,16 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "<p>해당 값이 포함된 id 를 가진 할인 분담 정책만 조회합니다.</p>\n"
+            "description": "해당 값이 포함된 id 를 가진 할인 분담 정책만 조회합니다.\n"
           },
           "name": {
             "type": "string",
-            "description": "<p>해당 값이 포함된 name 을 가진 할인 분담만 조회합니다.</p>\n"
+            "description": "해당 값이 포함된 name 을 가진 할인 분담만 조회합니다.\n"
           }
         },
-        "description": "<p>검색 키워드 입력 정보</p>\n<p>검색 키워드 적용을 위한 옵션으로, 명시된 키워드를 포함하는 할인 분담 정책만 조회합니다. 하위 필드는 명시된 값 중 한 가지만 적용됩니다.</p>\n",
+        "description": "검색 키워드 입력 정보\n검색 키워드 적용을 위한 옵션으로, 명시된 키워드를 포함하는 할인 분담 정책만 조회합니다. 하위 필드는 명시된 값 중 한 가지만 적용됩니다.\n",
         "x-portone-title": "검색 키워드 입력 정보",
-        "x-portone-description": "<p>검색 키워드 적용을 위한 옵션으로, 명시된 키워드를 포함하는 할인 분담 정책만 조회합니다. 하위 필드는 명시된 값 중 한 가지만 적용됩니다.</p>\n"
+        "x-portone-description": "검색 키워드 적용을 위한 옵션으로, 명시된 키워드를 포함하는 할인 분담 정책만 조회합니다. 하위 필드는 명시된 값 중 한 가지만 적용됩니다.\n"
       },
       "PlatformDiscountSharePolicyFilterOptions": {
         "title": "할인 분담 정책 필터 옵션 조회 성공 응답 정보",
@@ -29012,7 +29012,7 @@
             "title": "조회된 파트너 분담율 리스트"
           }
         },
-        "description": "<p>할인 분담 정책 필터 옵션 조회 성공 응답 정보</p>\n",
+        "description": "할인 분담 정책 필터 옵션 조회 성공 응답 정보\n",
         "x-portone-title": "할인 분담 정책 필터 옵션 조회 성공 응답 정보"
       },
       "PlatformDiscountSharePolicyIdDuplicatedError": {
@@ -29082,7 +29082,7 @@
             "type": "string"
           }
         },
-        "description": "<p>외부 api 오류</p>\n",
+        "description": "외부 api 오류\n",
         "x-portone-title": "외부 api 오류",
         "x-portone-status-code": 503
       },
@@ -29100,7 +29100,7 @@
             "type": "string"
           }
         },
-        "description": "<p>외부 api의 일시적인 오류</p>\n",
+        "description": "외부 api의 일시적인 오류\n",
         "x-portone-title": "외부 api의 일시적인 오류",
         "x-portone-status-code": 503
       },
@@ -29135,7 +29135,7 @@
       },
       "PlatformFee": {
         "title": "플랫폼 중개수수료 정보",
-        "description": "<p>플랫폼 중개수수료 정보</p>\n",
+        "description": "플랫폼 중개수수료 정보\n",
         "oneOf": [
           {
             "$ref": "#/components/schemas/PlatformFixedAmountFee"
@@ -29176,9 +29176,9 @@
             "title": "정액 수수료"
           }
         },
-        "description": "<p>수수료 계산 방식을 특정하기 위한 입력 정보</p>\n<p>정률 수수료를 설정하고 싶은 경우 <code>fixedRate</code> 필드에, 정액 수수료를 설정하고 싶은 경우 <code>fixedAmount</code> 필드에 값을 명시해 요청합니다.\n두 필드 모두 값이 들어있지 않은 경우 요청이 거절됩니다.</p>\n",
+        "description": "수수료 계산 방식을 특정하기 위한 입력 정보\n정률 수수료를 설정하고 싶은 경우 <code>fixedRate</code> 필드에, 정액 수수료를 설정하고 싶은 경우 <code>fixedAmount</code> 필드에 값을 명시해 요청합니다.\n두 필드 모두 값이 들어있지 않은 경우 요청이 거절됩니다.\n",
         "x-portone-title": "수수료 계산 방식을 특정하기 위한 입력 정보",
-        "x-portone-description": "<p>정률 수수료를 설정하고 싶은 경우 <code>fixedRate</code> 필드에, 정액 수수료를 설정하고 싶은 경우 <code>fixedAmount</code> 필드에 값을 명시해 요청합니다.\n두 필드 모두 값이 들어있지 않은 경우 요청이 거절됩니다.</p>\n"
+        "x-portone-description": "정률 수수료를 설정하고 싶은 경우 <code>fixedRate</code> 필드에, 정액 수수료를 설정하고 싶은 경우 <code>fixedAmount</code> 필드에 값을 명시해 요청합니다.\n두 필드 모두 값이 들어있지 않은 경우 요청이 거절됩니다.\n"
       },
       "PlatformFixedAmountFee": {
         "title": "정액 수수료",
@@ -29197,9 +29197,9 @@
             "title": "고정된 수수료 금액"
           }
         },
-        "description": "<p>정액 수수료</p>\n<p>총 금액에 무관하게 정해진 수수료 금액을 책정합니다.</p>\n",
+        "description": "정액 수수료\n총 금액에 무관하게 정해진 수수료 금액을 책정합니다.\n",
         "x-portone-title": "정액 수수료",
-        "x-portone-description": "<p>총 금액에 무관하게 정해진 수수료 금액을 책정합니다.</p>\n"
+        "x-portone-description": "총 금액에 무관하게 정해진 수수료 금액을 책정합니다.\n"
       },
       "PlatformFixedRateFee": {
         "title": "정률 수수료",
@@ -29216,12 +29216,12 @@
             "type": "integer",
             "format": "int32",
             "title": "수수료율",
-            "description": "<p>총 금액 대비 수수료 비율을 의미하며, 밀리 퍼센트 단위 (10^-5) 의 음이 아닌 정수입니다. <code>총 금액 * rate * 10^5</code> (<code>rate * 10^3 %</code>) 만큼 수수료를 책정합니다.</p>\n"
+            "description": "총 금액 대비 수수료 비율을 의미하며, 밀리 퍼센트 단위 (10^-5) 의 음이 아닌 정수입니다. <code>총 금액 * rate * 10^5</code> (<code>rate * 10^3 %</code>) 만큼 수수료를 책정합니다.\n"
           }
         },
-        "description": "<p>정률 수수료</p>\n<p>총 금액에 정해진 비율을 곱한 만큼의 수수료를 책정합니다.</p>\n",
+        "description": "정률 수수료\n총 금액에 정해진 비율을 곱한 만큼의 수수료를 책정합니다.\n",
         "x-portone-title": "정률 수수료",
-        "x-portone-description": "<p>총 금액에 정해진 비율을 곱한 만큼의 수수료를 책정합니다.</p>\n"
+        "x-portone-description": "총 금액에 정해진 비율을 곱한 만큼의 수수료를 책정합니다.\n"
       },
       "PlatformInvalidSettlementFormulaError": {
         "required": [
@@ -29281,8 +29281,8 @@
           },
           "settlementDate": {
             "type": "string",
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n"
+            "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n"
           },
           "settlementCurrency": {
             "$ref": "#/components/schemas/Currency"
@@ -29336,8 +29336,8 @@
           },
           "settlementDate": {
             "type": "string",
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n"
+            "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n"
           },
           "settlementCurrency": {
             "$ref": "#/components/schemas/Currency"
@@ -29380,7 +29380,7 @@
             "type": "string"
           }
         },
-        "description": "<p>플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</p>\n",
+        "description": "플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n",
         "x-portone-title": "플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우",
         "x-portone-status-code": 403
       },
@@ -29411,8 +29411,8 @@
           },
           "settlementDate": {
             "type": "string",
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n"
+            "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n"
           },
           "summary": {
             "$ref": "#/components/schemas/PlatformPayoutSummary"
@@ -29482,8 +29482,8 @@
           },
           "settlementDate": {
             "type": "string",
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n"
+            "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n"
           },
           "settlementCurrency": {
             "$ref": "#/components/schemas/Currency"
@@ -29508,8 +29508,8 @@
           },
           "settlementStartDate": {
             "type": "string",
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n"
+            "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n"
           },
           "orderLines": {
             "type": "array",
@@ -29574,8 +29574,8 @@
           },
           "settlementDate": {
             "type": "string",
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n"
+            "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n"
           },
           "settlementCurrency": {
             "$ref": "#/components/schemas/Currency"
@@ -29591,8 +29591,8 @@
           },
           "settlementStartDate": {
             "type": "string",
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n"
+            "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n"
           }
         }
       },
@@ -29646,7 +29646,7 @@
             "type": "integer",
             "format": "int64",
             "title": "결제 금액 부가세 부담금액",
-            "description": "<p>참조된 계약의 결제 금액 부가세 감액 여부에 따라 false인 경우 0원, true인 경우 결제 금액 부가세입니다.</p>\n"
+            "description": "참조된 계약의 결제 금액 부가세 감액 여부에 따라 false인 경우 0원, true인 경우 결제 금액 부가세입니다.\n"
           },
           "order": {
             "type": "integer",
@@ -29725,8 +29725,8 @@
           },
           "settlementDate": {
             "type": "string",
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n"
+            "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n"
           },
           "settlementCurrency": {
             "$ref": "#/components/schemas/Currency"
@@ -29751,8 +29751,8 @@
           },
           "settlementStartDate": {
             "type": "string",
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n"
+            "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n"
           },
           "orderLines": {
             "type": "array",
@@ -29944,8 +29944,8 @@
           },
           "settlementDate": {
             "type": "string",
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n"
+            "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n"
           },
           "settlementCurrency": {
             "$ref": "#/components/schemas/Currency"
@@ -29961,8 +29961,8 @@
           },
           "settlementStartDate": {
             "type": "string",
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n"
+            "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n"
           }
         }
       },
@@ -30033,9 +30033,9 @@
             "title": "변경 적용 시점"
           }
         },
-        "description": "<p>파트너</p>\n<p>파트너는 가맹점이 정산해주어야 할 대상입니다.\n기본 사업자 정보와 정산정보, 그리고 적용될 계약의 정보를 등록 및 관리할 수 있습니다.</p>\n",
+        "description": "파트너\n파트너는 가맹점이 정산해주어야 할 대상입니다.\n기본 사업자 정보와 정산정보, 그리고 적용될 계약의 정보를 등록 및 관리할 수 있습니다.\n",
         "x-portone-title": "파트너",
-        "x-portone-description": "<p>파트너는 가맹점이 정산해주어야 할 대상입니다.\n기본 사업자 정보와 정산정보, 그리고 적용될 계약의 정보를 등록 및 관리할 수 있습니다.</p>\n"
+        "x-portone-description": "파트너는 가맹점이 정산해주어야 할 대상입니다.\n기본 사업자 정보와 정산정보, 그리고 적용될 계약의 정보를 등록 및 관리할 수 있습니다.\n"
       },
       "PlatformPartnerContractSummary": {
         "title": "파트너 계약 요약 정보",
@@ -30054,7 +30054,7 @@
             "title": "계약 이름"
           }
         },
-        "description": "<p>파트너 계약 요약 정보</p>\n",
+        "description": "파트너 계약 요약 정보\n",
         "x-portone-title": "파트너 계약 요약 정보"
       },
       "PlatformPartnerDashboard": {
@@ -30075,12 +30075,12 @@
           },
           "upcomingSettlementDate": {
             "type": "string",
-            "description": "<p>정산이 예정되어 있지 않은 경우 값이 주어지지 않습니다.</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "정산이 예정되어 있지 않은 경우 값이 주어지지 않습니다.\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
             "title": "예정된 정산일"
           }
         },
-        "description": "<p>파트너 현황 조회 성공 응답</p>\n",
+        "description": "파트너 현황 조회 성공 응답\n",
         "x-portone-title": "파트너 현황 조회 성공 응답"
       },
       "PlatformPartnerDashboardCount": {
@@ -30102,7 +30102,7 @@
             "title": "보관된 파트너 수"
           }
         },
-        "description": "<p>파트너 현황 정보</p>\n",
+        "description": "파트너 현황 정보\n",
         "x-portone-title": "파트너 현황 정보"
       },
       "PlatformPartnerFilterInput": {
@@ -30112,14 +30112,14 @@
           "isArchived": {
             "type": "boolean",
             "title": "보관 조회 여부",
-            "description": "<p>true 이면 보관된 파트너를 조회하고, false 이면 보관되지 않은 파트너를 조회합니다. 아무 값도 넘기지 않을 경우 기본값은 false 입니다.</p>\n"
+            "description": "true 이면 보관된 파트너를 조회하고, false 이면 보관되지 않은 파트너를 조회합니다. 아무 값도 넘기지 않을 경우 기본값은 false 입니다.\n"
           },
           "tags": {
             "type": "array",
             "items": {
               "type": "string"
             },
-            "description": "<p>하나 이상의 값이 존재하는 경우 해당 리스트에 포함되는 태그를 하나 이상 가지는 파트너만 조회합니다.</p>\n"
+            "description": "하나 이상의 값이 존재하는 경우 해당 리스트에 포함되는 태그를 하나 이상 가지는 파트너만 조회합니다.\n"
           },
           "banks": {
             "title": "은행",
@@ -30127,7 +30127,7 @@
             "items": {
               "$ref": "#/components/schemas/Bank"
             },
-            "description": "<p>하나 이상의 값이 존재하는 경우,  해당 리스트에 포함되는 계좌 은행을 가진 파트너만 조회합니다.</p>\n"
+            "description": "하나 이상의 값이 존재하는 경우,  해당 리스트에 포함되는 계좌 은행을 가진 파트너만 조회합니다.\n"
           },
           "accountCurrencies": {
             "title": "통화 단위",
@@ -30135,28 +30135,28 @@
             "items": {
               "$ref": "#/components/schemas/Currency"
             },
-            "description": "<p>하나 이상의 값이 존재하는 경우,  해당 리스트에 포함되는 계좌 통화를 가진 파트너만 조회합니다.</p>\n"
+            "description": "하나 이상의 값이 존재하는 경우,  해당 리스트에 포함되는 계좌 통화를 가진 파트너만 조회합니다.\n"
           },
           "ids": {
             "type": "array",
             "items": {
               "type": "string"
             },
-            "description": "<p>하나 이상의 값이 존재하는 경우,  해당 리스트에 포함되는 아이디를 가진 파트너만 조회합니다.</p>\n"
+            "description": "하나 이상의 값이 존재하는 경우,  해당 리스트에 포함되는 아이디를 가진 파트너만 조회합니다.\n"
           },
           "contractIds": {
             "type": "array",
             "items": {
               "type": "string"
             },
-            "description": "<p>하나 이상의 값이 존재하는 경우,  해당 리스트에 포함되는 기본 계약 id를 가진 파트너만 조회합니다.</p>\n"
+            "description": "하나 이상의 값이 존재하는 경우,  해당 리스트에 포함되는 기본 계약 id를 가진 파트너만 조회합니다.\n"
           },
           "keyword": {
             "$ref": "#/components/schemas/PlatformPartnerFilterInputKeyword",
             "title": "검색 키워드"
           }
         },
-        "description": "<p>파트너 필터 입력 정보</p>\n",
+        "description": "파트너 필터 입력 정보\n",
         "x-portone-title": "파트너 필터 입력 정보"
       },
       "PlatformPartnerFilterInputKeyword": {
@@ -30165,40 +30165,40 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "<p>해당 값이 포함된 id 를 가진 파트너만 조회합니다.</p>\n"
+            "description": "해당 값이 포함된 id 를 가진 파트너만 조회합니다.\n"
           },
           "name": {
             "type": "string",
-            "description": "<p>해당 값이 포함된 이름 을 가진 파트너만 조회합니다.</p>\n"
+            "description": "해당 값이 포함된 이름 을 가진 파트너만 조회합니다.\n"
           },
           "email": {
             "type": "string",
-            "description": "<p>해당 값이 포함된 이메일 주소를 가진 파트너만 조회합니다.</p>\n"
+            "description": "해당 값이 포함된 이메일 주소를 가진 파트너만 조회합니다.\n"
           },
           "businessRegistrationNumber": {
             "type": "string",
-            "description": "<p>해당 값이 포함된 사업자등록번호를 가진 파트너만 조회합니다.</p>\n"
+            "description": "해당 값이 포함된 사업자등록번호를 가진 파트너만 조회합니다.\n"
           },
           "defaultContractId": {
             "type": "string",
-            "description": "<p>해당 값이 포함된 기본 계약 아이디를 가진 파트너만 조회합니다.</p>\n"
+            "description": "해당 값이 포함된 기본 계약 아이디를 가진 파트너만 조회합니다.\n"
           },
           "memo": {
             "type": "string",
-            "description": "<p>해당 값이 포함된 메모를 가진 파트너만 조회합니다.</p>\n"
+            "description": "해당 값이 포함된 메모를 가진 파트너만 조회합니다.\n"
           },
           "accountNumber": {
             "type": "string",
-            "description": "<p>해당 값이 포함된 계좌번호를 가진 파트너만 조회합니다.</p>\n"
+            "description": "해당 값이 포함된 계좌번호를 가진 파트너만 조회합니다.\n"
           },
           "accountHolder": {
             "type": "string",
-            "description": "<p>해당 값이 포함된 계좌 예금주명을 가진 파트너만 조회합니다.</p>\n"
+            "description": "해당 값이 포함된 계좌 예금주명을 가진 파트너만 조회합니다.\n"
           }
         },
-        "description": "<p>파트너 검색 키워드 입력 정보</p>\n<p>검색 키워드 적용을 위한 옵션으로, 명시된 키워드를 포함하는 파트너만 조회합니다. 하나의 하위 필드에만 값을 명시하여 요청합니다.</p>\n",
+        "description": "파트너 검색 키워드 입력 정보\n검색 키워드 적용을 위한 옵션으로, 명시된 키워드를 포함하는 파트너만 조회합니다. 하나의 하위 필드에만 값을 명시하여 요청합니다.\n",
         "x-portone-title": "파트너 검색 키워드 입력 정보",
-        "x-portone-description": "<p>검색 키워드 적용을 위한 옵션으로, 명시된 키워드를 포함하는 파트너만 조회합니다. 하나의 하위 필드에만 값을 명시하여 요청합니다.</p>\n"
+        "x-portone-description": "검색 키워드 적용을 위한 옵션으로, 명시된 키워드를 포함하는 파트너만 조회합니다. 하나의 하위 필드에만 값을 명시하여 요청합니다.\n"
       },
       "PlatformPartnerFilterOptions": {
         "title": "파트너 필터 옵션 조회 성공 응답 정보",
@@ -30223,7 +30223,7 @@
             }
           }
         },
-        "description": "<p>파트너 필터 옵션 조회 성공 응답 정보</p>\n",
+        "description": "파트너 필터 옵션 조회 성공 응답 정보\n",
         "x-portone-title": "파트너 필터 옵션 조회 성공 응답 정보"
       },
       "PlatformPartnerIdAlreadyExistsError": {
@@ -30319,8 +30319,8 @@
           },
           "settlementDate": {
             "type": "string",
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n"
+            "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n"
           },
           "settlementAmount": {
             "type": "integer",
@@ -30374,8 +30374,8 @@
           },
           "settlementDate": {
             "type": "string",
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n"
+            "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n"
           },
           "settlementCurrency": {
             "$ref": "#/components/schemas/Currency"
@@ -30480,8 +30480,8 @@
         "properties": {
           "settlementDate": {
             "type": "string",
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n"
+            "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n"
           },
           "settlementStartDateRange": {
             "$ref": "#/components/schemas/DateRange"
@@ -30554,8 +30554,8 @@
         "properties": {
           "settlementDate": {
             "type": "string",
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n"
+            "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n"
           },
           "settlementStartDateRange": {
             "$ref": "#/components/schemas/DateRange"
@@ -30571,8 +30571,8 @@
         "properties": {
           "settlementDate": {
             "type": "string",
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n"
+            "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n"
           },
           "settlementStartDateRange": {
             "$ref": "#/components/schemas/DateRange"
@@ -30814,7 +30814,7 @@
       "PlatformPartnerStatus": {
         "title": "플랫폼 파트너 상태",
         "type": "string",
-        "description": "<p>플랫폼 파트너 상태</p>\n",
+        "description": "플랫폼 파트너 상태\n",
         "enum": [
           "APPROVED",
           "PENDING",
@@ -30835,7 +30835,7 @@
       },
       "PlatformPartnerType": {
         "title": "파트너 유형별 추가 정보",
-        "description": "<p>파트너 유형별 추가 정보</p>\n",
+        "description": "파트너 유형별 추가 정보\n",
         "oneOf": [
           {
             "$ref": "#/components/schemas/PlatformPartnerTypeBusiness"
@@ -30899,9 +30899,9 @@
             "title": "업종"
           }
         },
-        "description": "<p>사업자 파트너 정보</p>\n<p>사업자 유형의 파트너 추가 정보 입니다.</p>\n",
+        "description": "사업자 파트너 정보\n사업자 유형의 파트너 추가 정보 입니다.\n",
         "x-portone-title": "사업자 파트너 정보",
-        "x-portone-description": "<p>사업자 유형의 파트너 추가 정보 입니다.</p>\n"
+        "x-portone-description": "사업자 유형의 파트너 추가 정보 입니다.\n"
       },
       "PlatformPartnerTypeWhtPayer": {
         "title": "원천징수대상자 파트너 정보",
@@ -30919,20 +30919,20 @@
             "title": "생년월일"
           }
         },
-        "description": "<p>원천징수대상자 파트너 정보</p>\n<p>비사업자 유형의 파트너 추가 정보 입니다.</p>\n",
+        "description": "원천징수대상자 파트너 정보\n비사업자 유형의 파트너 추가 정보 입니다.\n",
         "x-portone-title": "원천징수대상자 파트너 정보",
-        "x-portone-description": "<p>비사업자 유형의 파트너 추가 정보 입니다.</p>\n"
+        "x-portone-description": "비사업자 유형의 파트너 추가 정보 입니다.\n"
       },
       "PlatformPayer": {
         "title": "금액 부담 주체",
         "type": "string",
-        "description": "<p>금액 부담 주체</p>\n<p>플랫폼에서 발생한 결제 수수료, 부가세 등 금액을 부담하는 주체를 나타냅니다.</p>\n",
+        "description": "금액 부담 주체\n플랫폼에서 발생한 결제 수수료, 부가세 등 금액을 부담하는 주체를 나타냅니다.\n",
         "enum": [
           "MERCHANT",
           "PARTNER"
         ],
         "x-portone-title": "금액 부담 주체",
-        "x-portone-description": "<p>플랫폼에서 발생한 결제 수수료, 부가세 등 금액을 부담하는 주체를 나타냅니다.</p>\n",
+        "x-portone-description": "플랫폼에서 발생한 결제 수수료, 부가세 등 금액을 부담하는 주체를 나타냅니다.\n",
         "x-portone-enum": {
           "PARTNER": {
             "title": "파트너가 부담하는 경우"
@@ -31455,7 +31455,7 @@
       "PlatformRoundType": {
         "title": "금액에 대한 소수점 처리 방식",
         "type": "string",
-        "description": "<p>금액에 대한 소수점 처리 방식</p>\n",
+        "description": "금액에 대한 소수점 처리 방식\n",
         "enum": [
           "DOWN",
           "OFF",
@@ -31517,7 +31517,7 @@
             "type": "integer",
             "format": "int32",
             "title": "지체일 (d+n 의 n)",
-            "description": "<p>정산시작일(통상 주문완료일)로부터 더해진 다음 날짜로부터 가장 가까운 날에 정산이 됩니다. 최소 1 에서 최대 10 까지 지정할 수 있습니다.</p>\n"
+            "description": "정산시작일(통상 주문완료일)로부터 더해진 다음 날짜로부터 가장 가까운 날에 정산이 됩니다. 최소 1 에서 최대 10 까지 지정할 수 있습니다.\n"
           },
           "datePolicy": {
             "$ref": "#/components/schemas/PlatformSettlementCycleDatePolicy",
@@ -31528,14 +31528,14 @@
             "title": "정산 주기 계산 방식"
           }
         },
-        "description": "<p>정산 주기</p>\n<p>지체일, 정산일, 기준일로 구성되며, 해당 요소들의 조합으로 실제 정산일을 계산합니다.</p>\n",
+        "description": "정산 주기\n지체일, 정산일, 기준일로 구성되며, 해당 요소들의 조합으로 실제 정산일을 계산합니다.\n",
         "x-portone-title": "정산 주기",
-        "x-portone-description": "<p>지체일, 정산일, 기준일로 구성되며, 해당 요소들의 조합으로 실제 정산일을 계산합니다.</p>\n"
+        "x-portone-description": "지체일, 정산일, 기준일로 구성되며, 해당 요소들의 조합으로 실제 정산일을 계산합니다.\n"
       },
       "PlatformSettlementCycleDatePolicy": {
         "title": "플랫폼 정산 기준일",
         "type": "string",
-        "description": "<p>플랫폼 정산 기준일</p>\n",
+        "description": "플랫폼 정산 기준일\n",
         "enum": [
           "CALENDAR_DAY",
           "HOLIDAY_AFTER",
@@ -31567,7 +31567,7 @@
             "type": "integer",
             "format": "int32",
             "title": "지체일 (d+n 의 n)",
-            "description": "<p>정산시작일(통상 주문완료일)로부터 더해진 다음 날짜로부터 가장 가까운 날에 정산이 됩니다. 최소 1 에서 최대 10 까지 지정할 수 있습니다.</p>\n"
+            "description": "정산시작일(통상 주문완료일)로부터 더해진 다음 날짜로부터 가장 가까운 날에 정산이 됩니다. 최소 1 에서 최대 10 까지 지정할 수 있습니다.\n"
           },
           "datePolicy": {
             "$ref": "#/components/schemas/PlatformSettlementCycleDatePolicy",
@@ -31578,12 +31578,12 @@
             "title": "정산 주기 계산 방식"
           }
         },
-        "description": "<p>플랫폼 정산 주기 입력 정보</p>\n",
+        "description": "플랫폼 정산 주기 입력 정보\n",
         "x-portone-title": "플랫폼 정산 주기 입력 정보"
       },
       "PlatformSettlementCycleMethod": {
         "title": "플랫폼 정산 주기 계산 방식",
-        "description": "<p>플랫폼 정산 주기 계산 방식</p>\n",
+        "description": "플랫폼 정산 주기 계산 방식\n",
         "oneOf": [
           {
             "$ref": "#/components/schemas/PlatformSettlementCycleMethodDaily"
@@ -31634,7 +31634,7 @@
             "type": "string"
           }
         },
-        "description": "<p>매일 정산</p>\n",
+        "description": "매일 정산\n",
         "x-portone-title": "매일 정산"
       },
       "PlatformSettlementCycleMethodDailyInput": {
@@ -31661,9 +31661,9 @@
             "title": "정해진 날짜(월, 일)에 정산"
           }
         },
-        "description": "<p>플랫폼 정산 주기 계산 방식 입력 정보</p>\n<p>하나의 하위 필드에만 값을 명시하여 요청합니다.</p>\n",
+        "description": "플랫폼 정산 주기 계산 방식 입력 정보\n하나의 하위 필드에만 값을 명시하여 요청합니다.\n",
         "x-portone-title": "플랫폼 정산 주기 계산 방식 입력 정보",
-        "x-portone-description": "<p>하나의 하위 필드에만 값을 명시하여 요청합니다.</p>\n"
+        "x-portone-description": "하나의 하위 필드에만 값을 명시하여 요청합니다.\n"
       },
       "PlatformSettlementCycleMethodManualDates": {
         "title": "정해진 날짜(월, 일)에 정산",
@@ -31684,7 +31684,7 @@
             }
           }
         },
-        "description": "<p>정해진 날짜(월, 일)에 정산</p>\n",
+        "description": "정해진 날짜(월, 일)에 정산\n",
         "x-portone-title": "정해진 날짜(월, 일)에 정산"
       },
       "PlatformSettlementCycleMethodManualDatesInput": {
@@ -31721,7 +31721,7 @@
             }
           }
         },
-        "description": "<p>매월 정해진 날(일)에 정산</p>\n",
+        "description": "매월 정해진 날(일)에 정산\n",
         "x-portone-title": "매월 정해진 날(일)에 정산"
       },
       "PlatformSettlementCycleMethodMonthlyInput": {
@@ -31758,7 +31758,7 @@
             }
           }
         },
-        "description": "<p>매주 정해진 요일에 정산</p>\n",
+        "description": "매주 정해진 요일에 정산\n",
         "x-portone-title": "매주 정해진 요일에 정산"
       },
       "PlatformSettlementCycleMethodWeeklyInput": {
@@ -31779,7 +31779,7 @@
       "PlatformSettlementCycleType": {
         "title": "플랫폼 정산 주기 계산 방식",
         "type": "string",
-        "description": "<p>플랫폼 정산 주기 계산 방식</p>\n",
+        "description": "플랫폼 정산 주기 계산 방식\n",
         "enum": [
           "DAILY",
           "MANUAL_DATES",
@@ -31824,7 +31824,7 @@
             "title": "추가 수수료 계산식"
           }
         },
-        "description": "<p>플랫폼 내 발생하는 여러 수수료 및 할인 분담에 관한 계산식 정보</p>\n",
+        "description": "플랫폼 내 발생하는 여러 수수료 및 할인 분담에 관한 계산식 정보\n",
         "x-portone-title": "플랫폼 내 발생하는 여러 수수료 및 할인 분담에 관한 계산식 정보"
       },
       "PlatformSettlementFormulaError": {
@@ -32082,7 +32082,7 @@
             "title": "정산일이 정산시작일보다 작거나 같을 경우 공휴일 후 영업일로 정산일 다시 계산 여부"
           }
         },
-        "description": "<p>플랫폼 정산건 처리 방식에 관한 규칙</p>\n",
+        "description": "플랫폼 정산건 처리 방식에 관한 규칙\n",
         "x-portone-title": "플랫폼 정산건 처리 방식에 관한 규칙"
       },
       "PlatformTransfer": {
@@ -32514,22 +32514,22 @@
           },
           "settlementDate": {
             "type": "string",
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n"
+            "description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.\n"
           },
           "message": {
             "type": "string"
           }
         },
-        "description": "<p>사용할 수 없는 정산일이 요청된 경우</p>\n<p>요청한 정산일에 이체되지 않은 주문 정산 건이 없을 때 발생합니다.</p>\n",
+        "description": "사용할 수 없는 정산일이 요청된 경우\n요청한 정산일에 이체되지 않은 주문 정산 건이 없을 때 발생합니다.\n",
         "x-portone-title": "사용할 수 없는 정산일이 요청된 경우",
-        "x-portone-description": "<p>요청한 정산일에 이체되지 않은 주문 정산 건이 없을 때 발생합니다.</p>\n",
+        "x-portone-description": "요청한 정산일에 이체되지 않은 주문 정산 건이 없을 때 발생합니다.\n",
         "x-portone-status-code": 400
       },
       "PortOneVersion": {
         "title": "포트원 버전",
         "type": "string",
-        "description": "<p>포트원 버전</p>\n",
+        "description": "포트원 버전\n",
         "enum": [
           "V1",
           "V2"
@@ -32547,7 +32547,7 @@
           "storeId": {
             "type": "string",
             "title": "상점 아이디",
-            "description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.\n"
           },
           "totalAmount": {
             "type": "integer",
@@ -32564,7 +32564,7 @@
             "title": "통화 단위"
           }
         },
-        "description": "<p>결제 정보 사전 등록 입력 정보</p>\n",
+        "description": "결제 정보 사전 등록 입력 정보\n",
         "x-portone-title": "결제 정보 사전 등록 입력 정보"
       },
       "PreRegisterPaymentError": {
@@ -32595,7 +32595,7 @@
       "PreRegisterPaymentResponse": {
         "title": "결제 사전 등록 성공 응답",
         "type": "object",
-        "description": "<p>결제 사전 등록 성공 응답</p>\n",
+        "description": "결제 사전 등록 성공 응답\n",
         "x-portone-title": "결제 사전 등록 성공 응답"
       },
       "ReadyIdentityVerification": {
@@ -32646,7 +32646,7 @@
             "title": "상태 업데이트 시점"
           }
         },
-        "description": "<p>준비 상태의 본인인증 내역</p>\n",
+        "description": "준비 상태의 본인인증 내역\n",
         "x-portone-title": "준비 상태의 본인인증 내역"
       },
       "ReadyPayment": {
@@ -32679,7 +32679,7 @@
           "transactionId": {
             "type": "string",
             "title": "결제 건 포트원 채번 아이디",
-            "description": "<p>V1 결제 건의 경우 imp_uid에 해당합니다.</p>\n"
+            "description": "V1 결제 건의 경우 imp_uid에 해당합니다.\n"
           },
           "merchantId": {
             "type": "string",
@@ -32704,12 +32704,12 @@
           "scheduleId": {
             "type": "string",
             "title": "결제 예약 건 아이디",
-            "description": "<p>결제 예약을 이용한 경우에만 존재</p>\n"
+            "description": "결제 예약을 이용한 경우에만 존재\n"
           },
           "billingKey": {
             "type": "string",
             "title": "결제 시 사용된 빌링키",
-            "description": "<p>빌링키 결제인 경우에만 존재</p>\n"
+            "description": "빌링키 결제인 경우에만 존재\n"
           },
           "webhooks": {
             "title": "웹훅 발송 내역",
@@ -32760,7 +32760,7 @@
           "escrow": {
             "$ref": "#/components/schemas/PaymentEscrow",
             "title": "에스크로 결제의 배송 정보",
-            "description": "<p>에스크로 결제인 경우 존재합니다.</p>\n"
+            "description": "에스크로 결제인 경우 존재합니다.\n"
           },
           "products": {
             "title": "상품 정보",
@@ -32783,7 +32783,7 @@
             "title": "국가 코드"
           }
         },
-        "description": "<p>준비 상태의 결제 건</p>\n",
+        "description": "준비 상태의 결제 건\n",
         "x-portone-title": "준비 상태의 결제 건"
       },
       "RecoverPlatformAdditionalFeePolicyError": {
@@ -32823,7 +32823,7 @@
             "title": "복원된 추가 수수료 정책"
           }
         },
-        "description": "<p>추가 수수료 정책 복원 성공 응답</p>\n",
+        "description": "추가 수수료 정책 복원 성공 응답\n",
         "x-portone-title": "추가 수수료 정책 복원 성공 응답"
       },
       "RecoverPlatformContractError": {
@@ -32863,7 +32863,7 @@
             "title": "복원된 계약"
           }
         },
-        "description": "<p>계약 복원 성공 응답</p>\n",
+        "description": "계약 복원 성공 응답\n",
         "x-portone-title": "계약 복원 성공 응답"
       },
       "RecoverPlatformDiscountSharePolicyError": {
@@ -32903,7 +32903,7 @@
             "title": "복원된 할인 분담"
           }
         },
-        "description": "<p>할인 분담 복원 성공 응답</p>\n",
+        "description": "할인 분담 복원 성공 응답\n",
         "x-portone-title": "할인 분담 복원 성공 응답"
       },
       "RecoverPlatformPartnerError": {
@@ -32943,7 +32943,7 @@
             "title": "복원된 파트너"
           }
         },
-        "description": "<p>파트너 복원 성공 응답</p>\n",
+        "description": "파트너 복원 성공 응답\n",
         "x-portone-title": "파트너 복원 성공 응답"
       },
       "RefreshTokenBody": {
@@ -32958,7 +32958,7 @@
             "title": "리프레시 토큰"
           }
         },
-        "description": "<p>토큰 재발급을 위한 입력 정보</p>\n",
+        "description": "토큰 재발급을 위한 입력 정보\n",
         "x-portone-title": "토큰 재발급을 위한 입력 정보"
       },
       "RefreshTokenError": {
@@ -32989,15 +32989,15 @@
           "accessToken": {
             "type": "string",
             "title": "인증에 사용하는 엑세스 토큰",
-            "description": "<p>하루의 유효기간을 가지고 있습니다.</p>\n"
+            "description": "하루의 유효기간을 가지고 있습니다.\n"
           },
           "refreshToken": {
             "type": "string",
             "title": "토큰 재발급 및 유효기간 연장을 위해 사용하는 리프레시 토큰",
-            "description": "<p>일주일의 유효기간을 가지고 있으며, 리프레시 토큰을 통해 유효기간이 연장된 새로운 엑세스 토큰을 발급받을 수 있습니다.</p>\n"
+            "description": "일주일의 유효기간을 가지고 있으며, 리프레시 토큰을 통해 유효기간이 연장된 새로운 엑세스 토큰을 발급받을 수 있습니다.\n"
           }
         },
-        "description": "<p>토큰 재발급 성공 응답</p>\n",
+        "description": "토큰 재발급 성공 응답\n",
         "x-portone-title": "토큰 재발급 성공 응답"
       },
       "RefuseB2bTaxInvoiceRequestBody": {
@@ -33019,14 +33019,14 @@
           "documentKeyType": {
             "$ref": "#/components/schemas/B2bTaxInvoiceDocumentKeyType",
             "title": "문서 번호 유형",
-            "description": "<p>기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.</p>\n"
+            "description": "기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.\n"
           },
           "memo": {
             "type": "string",
             "title": "메모"
           }
         },
-        "description": "<p>세금계산서 역발행 요청 거부 정보</p>\n",
+        "description": "세금계산서 역발행 요청 거부 정보\n",
         "x-portone-title": "세금계산서 역발행 요청 거부 정보"
       },
       "RefuseB2bTaxInvoiceRequestError": {
@@ -33083,7 +33083,7 @@
             "title": "담당자 정보"
           }
         },
-        "description": "<p>사업자 연동 요청 정보</p>\n",
+        "description": "사업자 연동 요청 정보\n",
         "x-portone-title": "사업자 연동 요청 정보"
       },
       "RegisterB2bMemberCompanyError": {
@@ -33128,7 +33128,7 @@
             "title": "담당자 정보"
           }
         },
-        "description": "<p>사업자 연동 응답 정보</p>\n",
+        "description": "사업자 연동 응답 정보\n",
         "x-portone-title": "사업자 연동 응답 정보"
       },
       "RegisterEscrowLogisticsBody": {
@@ -33141,7 +33141,7 @@
           "storeId": {
             "type": "string",
             "title": "상점 아이디",
-            "description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.\n"
           },
           "sender": {
             "$ref": "#/components/schemas/PaymentEscrowSenderInput",
@@ -33158,7 +33158,7 @@
           "sendEmail": {
             "type": "boolean",
             "title": "이메일 알림 전송 여부",
-            "description": "<p>에스크로 구매 확정 시 이메일로 알림을 보낼지 여부입니다.</p>\n"
+            "description": "에스크로 구매 확정 시 이메일로 알림을 보낼지 여부입니다.\n"
           },
           "products": {
             "title": "상품 정보",
@@ -33168,7 +33168,7 @@
             }
           }
         },
-        "description": "<p>에스크로 배송 정보 등록 입력 정보</p>\n",
+        "description": "에스크로 배송 정보 등록 입력 정보\n",
         "x-portone-title": "에스크로 배송 정보 등록 입력 정보"
       },
       "RegisterStoreReceiptBody": {
@@ -33190,7 +33190,7 @@
             "title": "상점 아이디"
           }
         },
-        "description": "<p>영수증 내 하위 상점 거래 등록 정보</p>\n",
+        "description": "영수증 내 하위 상점 거래 등록 정보\n",
         "x-portone-title": "영수증 내 하위 상점 거래 등록 정보"
       },
       "RegisterStoreReceiptBodyItem": {
@@ -33236,7 +33236,7 @@
             "title": "통화"
           }
         },
-        "description": "<p>하위 상점 거래 정보</p>\n",
+        "description": "하위 상점 거래 정보\n",
         "x-portone-title": "하위 상점 거래 정보"
       },
       "RegisterStoreReceiptError": {
@@ -33281,7 +33281,7 @@
             "title": "결제 영수증 URL"
           }
         },
-        "description": "<p>영수증 내 하위 상점 거래 등록 응답</p>\n",
+        "description": "영수증 내 하위 상점 거래 등록 응답\n",
         "x-portone-title": "영수증 내 하위 상점 거래 등록 응답"
       },
       "RegisteredPaymentEscrow": {
@@ -33316,7 +33316,7 @@
             "title": "배송등록 처리 일자"
           }
         },
-        "description": "<p>배송 정보 등록 완료</p>\n",
+        "description": "배송 정보 등록 완료\n",
         "x-portone-title": "배송 정보 등록 완료"
       },
       "RejectConfirmedPaymentEscrow": {
@@ -33351,7 +33351,7 @@
             "title": "배송등록 처리 일자"
           }
         },
-        "description": "<p>구매 거절 확정</p>\n",
+        "description": "구매 거절 확정\n",
         "x-portone-title": "구매 거절 확정"
       },
       "RejectPlatformPartnerBody": {
@@ -33363,7 +33363,7 @@
             "title": "파트너 메모. 값이 명시되지 않은 경우 업데이트하지 않습니다."
           }
         },
-        "description": "<p>파트너 상태를 승인 거절로 변경하기 위한 입력 정보</p>\n",
+        "description": "파트너 상태를 승인 거절로 변경하기 위한 입력 정보\n",
         "x-portone-title": "파트너 상태를 승인 거절로 변경하기 위한 입력 정보"
       },
       "RejectPlatformPartnerError": {
@@ -33407,7 +33407,7 @@
             "title": "거절된 파트너"
           }
         },
-        "description": "<p>파트너 거절 성공 응답</p>\n",
+        "description": "파트너 거절 성공 응답\n",
         "x-portone-title": "파트너 거절 성공 응답"
       },
       "RejectedPaymentEscrow": {
@@ -33442,7 +33442,7 @@
             "title": "배송등록 처리 일자"
           }
         },
-        "description": "<p>구매 거절</p>\n",
+        "description": "구매 거절\n",
         "x-portone-title": "구매 거절"
       },
       "RequestB2bTaxInvoiceRegisterBody": {
@@ -33457,7 +33457,7 @@
             "title": "세금계산서 생성 요청 정보"
           }
         },
-        "description": "<p>세금계산서 임시 저장 정보</p>\n",
+        "description": "세금계산서 임시 저장 정보\n",
         "x-portone-title": "세금계산서 임시 저장 정보"
       },
       "RequestB2bTaxInvoiceRegisterError": {
@@ -33512,14 +33512,14 @@
           "documentKeyType": {
             "$ref": "#/components/schemas/B2bTaxInvoiceDocumentKeyType",
             "title": "문서 번호 유형",
-            "description": "<p>기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.</p>\n"
+            "description": "기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.\n"
           },
           "memo": {
             "type": "string",
             "title": "메모"
           }
         },
-        "description": "<p>세금계산서 역발행 요청 정보</p>\n",
+        "description": "세금계산서 역발행 요청 정보\n",
         "x-portone-title": "세금계산서 역발행 요청 정보"
       },
       "RequestB2bTaxInvoiceReverseIssuanceError": {
@@ -33571,7 +33571,7 @@
             "title": "메모"
           }
         },
-        "description": "<p>세금계산서 역발행 요청 정보</p>\n",
+        "description": "세금계산서 역발행 요청 정보\n",
         "x-portone-title": "세금계산서 역발행 요청 정보"
       },
       "RequestedPaymentCancellation": {
@@ -33634,7 +33634,7 @@
             "title": "취소 요청 시점"
           }
         },
-        "description": "<p>취소 요청 상태</p>\n",
+        "description": "취소 요청 상태\n",
         "x-portone-title": "취소 요청 상태"
       },
       "RescheduleAdditionalFeePolicyError": {
@@ -33759,7 +33759,7 @@
             "title": "업데이트 적용 시점"
           }
         },
-        "description": "<p>추가 수수료 정책 예약 업데이트 재설정을 위한 입력 정보</p>\n",
+        "description": "추가 수수료 정책 예약 업데이트 재설정을 위한 입력 정보\n",
         "x-portone-title": "추가 수수료 정책 예약 업데이트 재설정을 위한 입력 정보"
       },
       "ReschedulePlatformAdditionalFeePolicyResponse": {
@@ -33774,7 +33774,7 @@
             "title": "예약된 추가 수수료 정책"
           }
         },
-        "description": "<p>추가 수수료 정책 예약 업데이트 재설정 성공 응답</p>\n",
+        "description": "추가 수수료 정책 예약 업데이트 재설정 성공 응답\n",
         "x-portone-title": "추가 수수료 정책 예약 업데이트 재설정 성공 응답"
       },
       "ReschedulePlatformContractBody": {
@@ -33795,7 +33795,7 @@
             "title": "업데이트 적용 시점"
           }
         },
-        "description": "<p>계약 예약 업데이트 재설정을 위한 입력 정보</p>\n",
+        "description": "계약 예약 업데이트 재설정을 위한 입력 정보\n",
         "x-portone-title": "계약 예약 업데이트 재설정을 위한 입력 정보"
       },
       "ReschedulePlatformContractResponse": {
@@ -33810,7 +33810,7 @@
             "title": "예약된 계약 정보"
           }
         },
-        "description": "<p>계약 예약 업데이트 재설정 성공 응답</p>\n",
+        "description": "계약 예약 업데이트 재설정 성공 응답\n",
         "x-portone-title": "계약 예약 업데이트 재설정 성공 응답"
       },
       "ReschedulePlatformDiscountSharePolicyBody": {
@@ -33831,7 +33831,7 @@
             "title": "업데이트 적용 시점"
           }
         },
-        "description": "<p>할인 분담 정책 예약 업데이트 재설정을 위한 입력 정보</p>\n",
+        "description": "할인 분담 정책 예약 업데이트 재설정을 위한 입력 정보\n",
         "x-portone-title": "할인 분담 정책 예약 업데이트 재설정을 위한 입력 정보"
       },
       "ReschedulePlatformDiscountSharePolicyResponse": {
@@ -33846,7 +33846,7 @@
             "title": "예약된 할인 분담 정보"
           }
         },
-        "description": "<p>할인 분담 정책 예약 업데이트 재설정 성공 응답</p>\n",
+        "description": "할인 분담 정책 예약 업데이트 재설정 성공 응답\n",
         "x-portone-title": "할인 분담 정책 예약 업데이트 재설정 성공 응답"
       },
       "ReschedulePlatformPartnerBody": {
@@ -33867,7 +33867,7 @@
             "title": "업데이트 적용 시점"
           }
         },
-        "description": "<p>파트너 예약 업데이트 재설정을 위한 입력 정보</p>\n",
+        "description": "파트너 예약 업데이트 재설정을 위한 입력 정보\n",
         "x-portone-title": "파트너 예약 업데이트 재설정을 위한 입력 정보"
       },
       "ReschedulePlatformPartnerResponse": {
@@ -33882,7 +33882,7 @@
             "title": "예약된 파트너 정보"
           }
         },
-        "description": "<p>파트너 예약 업데이트 재설정 성공 응답</p>\n",
+        "description": "파트너 예약 업데이트 재설정 성공 응답\n",
         "x-portone-title": "파트너 예약 업데이트 재설정 성공 응답"
       },
       "ResendIdentityVerificationError": {
@@ -33925,7 +33925,7 @@
       "ResendIdentityVerificationResponse": {
         "title": "본인인증 요청 재전송 성공 응답",
         "type": "object",
-        "description": "<p>본인인증 요청 재전송 성공 응답</p>\n",
+        "description": "본인인증 요청 재전송 성공 응답\n",
         "x-portone-title": "본인인증 요청 재전송 성공 응답"
       },
       "ResendWebhookBody": {
@@ -33934,16 +33934,16 @@
           "storeId": {
             "type": "string",
             "title": "상점 아이디",
-            "description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.\n"
           },
           "webhookId": {
             "type": "string",
             "title": "웹훅 아이디",
-            "description": "<p>입력하지 않으면 결제 건의 가장 최근 웹훅 아이디가 기본 적용됩니다</p>\n"
+            "description": "입력하지 않으면 결제 건의 가장 최근 웹훅 아이디가 기본 적용됩니다\n"
           }
         },
-        "description": "<p>웹훅 재발송을 위한 입력 정보</p>\n",
-        "x-portone-description": "<p>웹훅 재발송을 위한 입력 정보</p>\n"
+        "description": "웹훅 재발송을 위한 입력 정보\n",
+        "x-portone-description": "웹훅 재발송을 위한 입력 정보\n"
       },
       "ResendWebhookError": {
         "oneOf": [
@@ -33986,7 +33986,7 @@
             "title": "재발송 웹훅 정보"
           }
         },
-        "description": "<p>웹훅 재발송 응답 정보</p>\n",
+        "description": "웹훅 재발송 응답 정보\n",
         "x-portone-title": "웹훅 재발송 응답 정보"
       },
       "RevokePaymentScheduleBody": {
@@ -33996,7 +33996,7 @@
           "storeId": {
             "type": "string",
             "title": "상점 아이디",
-            "description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.\n"
           },
           "billingKey": {
             "type": "string",
@@ -34010,9 +34010,9 @@
             "title": "결제 예약 건 아이디 목록"
           }
         },
-        "description": "<p>결제 예약 건 취소 요청 입력 정보</p>\n<p>billingKey, scheduleIds 중 하나 이상은 필수로 입력합니다.\nbillingKey 만 입력된 경우 -&gt; 해당 빌링키로 예약된 모든 결제 예약 건들이 취소됩니다.\nscheduleIds 만 입력된 경우 -&gt; 입력된 결제 예약 건 아이디에 해당하는 예약 건들이 취소됩니다.\nbillingKey, scheduleIds 모두 입력된 경우 -&gt; 입력된 결제 예약 건 아이디에 해당하는 예약 건들이 취소됩니다. 그리고 예약한 빌링키가 입력된 빌링키와 일치하는지 검증합니다.\n위 정책에 따라 선택된 결제 예약 건들 중 하나라도 취소에 실패할 경우, 모든 취소 요청이 실패합니다.</p>\n",
+        "description": "결제 예약 건 취소 요청 입력 정보\nbillingKey, scheduleIds 중 하나 이상은 필수로 입력합니다.\nbillingKey 만 입력된 경우 -&gt; 해당 빌링키로 예약된 모든 결제 예약 건들이 취소됩니다.\nscheduleIds 만 입력된 경우 -&gt; 입력된 결제 예약 건 아이디에 해당하는 예약 건들이 취소됩니다.\nbillingKey, scheduleIds 모두 입력된 경우 -&gt; 입력된 결제 예약 건 아이디에 해당하는 예약 건들이 취소됩니다. 그리고 예약한 빌링키가 입력된 빌링키와 일치하는지 검증합니다.\n위 정책에 따라 선택된 결제 예약 건들 중 하나라도 취소에 실패할 경우, 모든 취소 요청이 실패합니다.\n",
         "x-portone-title": "결제 예약 건 취소 요청 입력 정보",
-        "x-portone-description": "<p>billingKey, scheduleIds 중 하나 이상은 필수로 입력합니다.\nbillingKey 만 입력된 경우 -&gt; 해당 빌링키로 예약된 모든 결제 예약 건들이 취소됩니다.\nscheduleIds 만 입력된 경우 -&gt; 입력된 결제 예약 건 아이디에 해당하는 예약 건들이 취소됩니다.\nbillingKey, scheduleIds 모두 입력된 경우 -&gt; 입력된 결제 예약 건 아이디에 해당하는 예약 건들이 취소됩니다. 그리고 예약한 빌링키가 입력된 빌링키와 일치하는지 검증합니다.\n위 정책에 따라 선택된 결제 예약 건들 중 하나라도 취소에 실패할 경우, 모든 취소 요청이 실패합니다.</p>\n"
+        "x-portone-description": "billingKey, scheduleIds 중 하나 이상은 필수로 입력합니다.\nbillingKey 만 입력된 경우 -&gt; 해당 빌링키로 예약된 모든 결제 예약 건들이 취소됩니다.\nscheduleIds 만 입력된 경우 -&gt; 입력된 결제 예약 건 아이디에 해당하는 예약 건들이 취소됩니다.\nbillingKey, scheduleIds 모두 입력된 경우 -&gt; 입력된 결제 예약 건 아이디에 해당하는 예약 건들이 취소됩니다. 그리고 예약한 빌링키가 입력된 빌링키와 일치하는지 검증합니다.\n위 정책에 따라 선택된 결제 예약 건들 중 하나라도 취소에 실패할 경우, 모든 취소 요청이 실패합니다.\n"
       },
       "RevokePaymentScheduleError": {
         "oneOf": [
@@ -34075,7 +34075,7 @@
             "title": "결제 예약 건 취소 완료 시점"
           }
         },
-        "description": "<p>결제 예약 건 취소 성공 응답</p>\n",
+        "description": "결제 예약 건 취소 성공 응답\n",
         "x-portone-title": "결제 예약 건 취소 성공 응답"
       },
       "RevokedPaymentSchedule": {
@@ -34187,7 +34187,7 @@
             "title": "결제 취소 시점"
           }
         },
-        "description": "<p>결제 예약 취소 상태</p>\n",
+        "description": "결제 예약 취소 상태\n",
         "x-portone-title": "결제 예약 취소 상태"
       },
       "ScheduleAdditionalFeePolicyError": {
@@ -34340,7 +34340,7 @@
             "title": "업데이트 적용 시점"
           }
         },
-        "description": "<p>추가 수수료 정책 업데이트 예약을 위한 입력 정보</p>\n",
+        "description": "추가 수수료 정책 업데이트 예약을 위한 입력 정보\n",
         "x-portone-title": "추가 수수료 정책 업데이트 예약을 위한 입력 정보"
       },
       "SchedulePlatformAdditionalFeePolicyResponse": {
@@ -34355,7 +34355,7 @@
             "title": "예약된 추가 수수료 정책"
           }
         },
-        "description": "<p>추가 수수료 정책 업데이트 예약 성공 응답</p>\n",
+        "description": "추가 수수료 정책 업데이트 예약 성공 응답\n",
         "x-portone-title": "추가 수수료 정책 업데이트 예약 성공 응답"
       },
       "SchedulePlatformContractBody": {
@@ -34376,7 +34376,7 @@
             "title": "업데이트 적용 시점"
           }
         },
-        "description": "<p>계약 업데이트 예약을 위한 입력 정보</p>\n",
+        "description": "계약 업데이트 예약을 위한 입력 정보\n",
         "x-portone-title": "계약 업데이트 예약을 위한 입력 정보"
       },
       "SchedulePlatformContractResponse": {
@@ -34391,7 +34391,7 @@
             "title": "예약된 계약 정보"
           }
         },
-        "description": "<p>계약 업데이트 예약 성공 응답</p>\n",
+        "description": "계약 업데이트 예약 성공 응답\n",
         "x-portone-title": "계약 업데이트 예약 성공 응답"
       },
       "SchedulePlatformDiscountSharePolicyBody": {
@@ -34412,7 +34412,7 @@
             "title": "업데이트 적용 시점"
           }
         },
-        "description": "<p>할인 분담 정책 업데이트 예약을 위한 입력 정보</p>\n",
+        "description": "할인 분담 정책 업데이트 예약을 위한 입력 정보\n",
         "x-portone-title": "할인 분담 정책 업데이트 예약을 위한 입력 정보"
       },
       "SchedulePlatformDiscountSharePolicyResponse": {
@@ -34427,7 +34427,7 @@
             "title": "예약된 할인 분담 정보"
           }
         },
-        "description": "<p>할인 분담 정책 업데이트 예약 성공 응답</p>\n",
+        "description": "할인 분담 정책 업데이트 예약 성공 응답\n",
         "x-portone-title": "할인 분담 정책 업데이트 예약 성공 응답"
       },
       "SchedulePlatformPartnerBody": {
@@ -34448,7 +34448,7 @@
             "title": "업데이트 적용 시점"
           }
         },
-        "description": "<p>파트너 업데이트 예약을 위한 입력 정보</p>\n",
+        "description": "파트너 업데이트 예약을 위한 입력 정보\n",
         "x-portone-title": "파트너 업데이트 예약을 위한 입력 정보"
       },
       "SchedulePlatformPartnerResponse": {
@@ -34463,7 +34463,7 @@
             "title": "예약된 파트너 정보"
           }
         },
-        "description": "<p>파트너 업데이트 예약 성공 응답</p>\n",
+        "description": "파트너 업데이트 예약 성공 응답\n",
         "x-portone-title": "파트너 업데이트 예약 성공 응답"
       },
       "SchedulePlatformPartnersBody": {
@@ -34541,7 +34541,7 @@
             "title": "예금주명"
           }
         },
-        "description": "<p>파트너 계좌 업데이트를 위한 입력 정보</p>\n",
+        "description": "파트너 계좌 업데이트를 위한 입력 정보\n",
         "x-portone-title": "파트너 계좌 업데이트를 위한 입력 정보"
       },
       "SchedulePlatformPartnersBodyUpdateContact": {
@@ -34561,7 +34561,7 @@
             "title": "담당자 이메일"
           }
         },
-        "description": "<p>파트너 업데이트를 위한 유형별 추가 정보</p>\n",
+        "description": "파트너 업데이트를 위한 유형별 추가 정보\n",
         "x-portone-title": "파트너 업데이트를 위한 유형별 추가 정보"
       },
       "SchedulePlatformPartnersBodyUpdateType": {
@@ -34577,9 +34577,9 @@
             "title": "원천징수대상자 추가 정보"
           }
         },
-        "description": "<p>파트너 유형별 정보 업데이트를 위한 입력 정보</p>\n<p>파트너 유형별 추가 정보를 수정합니다.\n최초 생성된 유형 내에서 세부 정보만 수정할 수 있고 파트너의 유형 자체를 수정할 수는 없습니다.</p>\n",
+        "description": "파트너 유형별 정보 업데이트를 위한 입력 정보\n파트너 유형별 추가 정보를 수정합니다.\n최초 생성된 유형 내에서 세부 정보만 수정할 수 있고 파트너의 유형 자체를 수정할 수는 없습니다.\n",
         "x-portone-title": "파트너 유형별 정보 업데이트를 위한 입력 정보",
-        "x-portone-description": "<p>파트너 유형별 추가 정보를 수정합니다.\n최초 생성된 유형 내에서 세부 정보만 수정할 수 있고 파트너의 유형 자체를 수정할 수는 없습니다.</p>\n"
+        "x-portone-description": "파트너 유형별 추가 정보를 수정합니다.\n최초 생성된 유형 내에서 세부 정보만 수정할 수 있고 파트너의 유형 자체를 수정할 수는 없습니다.\n"
       },
       "SchedulePlatformPartnersBodyUpdateTypeBusiness": {
         "type": "object",
@@ -34758,7 +34758,7 @@
             "title": "결제 예정 시점"
           }
         },
-        "description": "<p>결제 예약 완료 상태</p>\n",
+        "description": "결제 예약 완료 상태\n",
         "x-portone-title": "결제 예약 완료 상태"
       },
       "SelectedChannel": {
@@ -34795,13 +34795,13 @@
             "title": "PG사 가맹점 식별 아이디"
           }
         },
-        "description": "<p>(결제, 본인인증 등에) 선택된 채널 정보</p>\n",
+        "description": "(결제, 본인인증 등에) 선택된 채널 정보\n",
         "x-portone-title": "(결제, 본인인증 등에) 선택된 채널 정보"
       },
       "SelectedChannelType": {
         "title": "채널 타입",
         "type": "string",
-        "description": "<p>채널 타입</p>\n",
+        "description": "채널 타입\n",
         "enum": [
           "LIVE",
           "TEST"
@@ -34829,7 +34829,7 @@
           "storeId": {
             "type": "string",
             "title": "상점 아이디",
-            "description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.\n"
           },
           "channelKey": {
             "type": "string",
@@ -34856,7 +34856,7 @@
             "title": "본인인증 방식"
           }
         },
-        "description": "<p>본인인증 요청을 위한 입력 정보</p>\n",
+        "description": "본인인증 요청을 위한 입력 정보\n",
         "x-portone-title": "본인인증 요청을 위한 입력 정보"
       },
       "SendIdentityVerificationBodyCustomer": {
@@ -34878,15 +34878,15 @@
           "phoneNumber": {
             "type": "string",
             "title": "전화번호",
-            "description": "<p>특수 문자(-) 없이 숫자만 입력합니다.</p>\n"
+            "description": "특수 문자(-) 없이 숫자만 입력합니다.\n"
           },
           "identityNumber": {
             "type": "string",
             "title": "주민등록번호 앞 7자리",
-            "description": "<p>SMS 방식의 경우 필수로 입력합니다.</p>\n"
+            "description": "SMS 방식의 경우 필수로 입력합니다.\n"
           }
         },
-        "description": "<p>본인인증 요청을 위한 고객 정보</p>\n",
+        "description": "본인인증 요청을 위한 고객 정보\n",
         "x-portone-title": "본인인증 요청을 위한 고객 정보"
       },
       "SendIdentityVerificationError": {
@@ -34933,7 +34933,7 @@
       "SendIdentityVerificationResponse": {
         "title": "본인인증 요청 전송 성공 응답",
         "type": "object",
-        "description": "<p>본인인증 요청 전송 성공 응답</p>\n",
+        "description": "본인인증 요청 전송 성공 응답\n",
         "x-portone-title": "본인인증 요청 전송 성공 응답"
       },
       "SeparatedAddress": {
@@ -34974,9 +34974,9 @@
             "title": "국가"
           }
         },
-        "description": "<p>분리 형식 주소</p>\n<p>한 줄 형식 주소와 분리 형식 주소 모두 존재합니다.\n한 줄 형식 주소는 분리 형식 주소를 이어 붙인 형태로 생성됩니다.</p>\n",
+        "description": "분리 형식 주소\n한 줄 형식 주소와 분리 형식 주소 모두 존재합니다.\n한 줄 형식 주소는 분리 형식 주소를 이어 붙인 형태로 생성됩니다.\n",
         "x-portone-title": "분리 형식 주소",
-        "x-portone-description": "<p>한 줄 형식 주소와 분리 형식 주소 모두 존재합니다.\n한 줄 형식 주소는 분리 형식 주소를 이어 붙인 형태로 생성됩니다.</p>\n"
+        "x-portone-description": "한 줄 형식 주소와 분리 형식 주소 모두 존재합니다.\n한 줄 형식 주소는 분리 형식 주소를 이어 붙인 형태로 생성됩니다.\n"
       },
       "SeparatedAddressInput": {
         "title": "분리 형식 주소 입력 정보",
@@ -35007,7 +35007,7 @@
             "title": "국가"
           }
         },
-        "description": "<p>분리 형식 주소 입력 정보</p>\n",
+        "description": "분리 형식 주소 입력 정보\n",
         "x-portone-title": "분리 형식 주소 입력 정보"
       },
       "StartedPaymentSchedule": {
@@ -35119,7 +35119,7 @@
             "title": "결제 시작 시점"
           }
         },
-        "description": "<p>결제 시작 상태</p>\n",
+        "description": "결제 시작 상태\n",
         "x-portone-title": "결제 시작 상태"
       },
       "SucceededPaymentCancellation": {
@@ -35186,7 +35186,7 @@
             "title": "취소 영수증 URL"
           }
         },
-        "description": "<p>취소 완료 상태</p>\n",
+        "description": "취소 완료 상태\n",
         "x-portone-title": "취소 완료 상태"
       },
       "SucceededPaymentSchedule": {
@@ -35304,7 +35304,7 @@
             "title": "결제 완료 시점"
           }
         },
-        "description": "<p>결제 성공 상태</p>\n",
+        "description": "결제 성공 상태\n",
         "x-portone-title": "결제 성공 상태"
       },
       "SumOfPartsExceedsCancelAmountError": {
@@ -35321,7 +35321,7 @@
             "type": "string"
           }
         },
-        "description": "<p>면세 금액 등 하위 항목들의 합이 전체 취소 금액을 초과한 경우</p>\n",
+        "description": "면세 금액 등 하위 항목들의 합이 전체 취소 금액을 초과한 경우\n",
         "x-portone-title": "면세 금액 등 하위 항목들의 합이 전체 취소 금액을 초과한 경우",
         "x-portone-status-code": 409
       },
@@ -35339,7 +35339,7 @@
             "type": "string"
           }
         },
-        "description": "<p>면세 금액 등 하위 항목들의 합이 전체 결제 금액을 초과한 경우</p>\n",
+        "description": "면세 금액 등 하위 항목들의 합이 전체 결제 금액을 초과한 경우\n",
         "x-portone-title": "면세 금액 등 하위 항목들의 합이 전체 결제 금액을 초과한 경우",
         "x-portone-status-code": 409
       },
@@ -35357,7 +35357,7 @@
             "type": "string"
           }
         },
-        "description": "<p>인증 정보가 올바르지 않은 경우</p>\n",
+        "description": "인증 정보가 올바르지 않은 경우\n",
         "x-portone-title": "인증 정보가 올바르지 않은 경우",
         "x-portone-status-code": 401
       },
@@ -35441,9 +35441,9 @@
             "title": "부가세를 부담할 주체"
           }
         },
-        "description": "<p>추가 수수료 정책 업데이트를 위한 입력 정보</p>\n<p>값이 명시하지 않은 필드는 업데이트되지 않습니다.</p>\n",
+        "description": "추가 수수료 정책 업데이트를 위한 입력 정보\n값이 명시하지 않은 필드는 업데이트되지 않습니다.\n",
         "x-portone-title": "추가 수수료 정책 업데이트를 위한 입력 정보",
-        "x-portone-description": "<p>값이 명시하지 않은 필드는 업데이트되지 않습니다.</p>\n"
+        "x-portone-description": "값이 명시하지 않은 필드는 업데이트되지 않습니다.\n"
       },
       "UpdatePlatformAdditionalFeePolicyError": {
         "oneOf": [
@@ -35486,7 +35486,7 @@
             "title": "업데이트된 추가 수수료 정책"
           }
         },
-        "description": "<p>추가 수수료 정책 업데이트 성공 응답</p>\n",
+        "description": "추가 수수료 정책 업데이트 성공 응답\n",
         "x-portone-title": "추가 수수료 정책 업데이트 성공 응답"
       },
       "UpdatePlatformBody": {
@@ -35506,9 +35506,9 @@
             "title": "정산 규칙"
           }
         },
-        "description": "<p>플랫폼 업데이트를 위한 입력 정보</p>\n<p>값이 명시되지 않은 필드는 업데이트하지 않습니다.</p>\n",
+        "description": "플랫폼 업데이트를 위한 입력 정보\n값이 명시되지 않은 필드는 업데이트하지 않습니다.\n",
         "x-portone-title": "플랫폼 업데이트를 위한 입력 정보",
-        "x-portone-description": "<p>값이 명시되지 않은 필드는 업데이트하지 않습니다.</p>\n"
+        "x-portone-description": "값이 명시되지 않은 필드는 업데이트하지 않습니다.\n"
       },
       "UpdatePlatformBodySettlementFormula": {
         "title": "플랫폼 업데이트 시 변경할 계산식 정보",
@@ -35527,9 +35527,9 @@
             "title": "추가 수수료 계산식"
           }
         },
-        "description": "<p>플랫폼 업데이트 시 변경할 계산식 정보</p>\n<p>값이 명시되지 않은 필드는 업데이트하지 않습니다.</p>\n",
+        "description": "플랫폼 업데이트 시 변경할 계산식 정보\n값이 명시되지 않은 필드는 업데이트하지 않습니다.\n",
         "x-portone-title": "플랫폼 업데이트 시 변경할 계산식 정보",
-        "x-portone-description": "<p>값이 명시되지 않은 필드는 업데이트하지 않습니다.</p>\n"
+        "x-portone-description": "값이 명시되지 않은 필드는 업데이트하지 않습니다.\n"
       },
       "UpdatePlatformBodySettlementRule": {
         "title": "플랫폼 업데이트 시 변경할 정산 규칙 정보",
@@ -35544,9 +35544,9 @@
             "title": "정산일이 정산시작일보다 작거나 같을 경우 공휴일 후 영업일로 정산일 다시 계산 여부"
           }
         },
-        "description": "<p>플랫폼 업데이트 시 변경할 정산 규칙 정보</p>\n<p>값이 명시되지 않은 필드는 업데이트하지 않습니다.</p>\n",
+        "description": "플랫폼 업데이트 시 변경할 정산 규칙 정보\n값이 명시되지 않은 필드는 업데이트하지 않습니다.\n",
         "x-portone-title": "플랫폼 업데이트 시 변경할 정산 규칙 정보",
-        "x-portone-description": "<p>값이 명시되지 않은 필드는 업데이트하지 않습니다.</p>\n"
+        "x-portone-description": "값이 명시되지 않은 필드는 업데이트하지 않습니다.\n"
       },
       "UpdatePlatformContractBody": {
         "title": "계약 업데이트를 위한 입력 정보. 값이 명시되지 않은 필드는 업데이트되지 않습니다.",
@@ -35577,9 +35577,9 @@
             "title": "정산 시 결제금액 부가세 감액 여부"
           }
         },
-        "description": "<p>계약 업데이트를 위한 입력 정보. 값이 명시되지 않은 필드는 업데이트되지 않습니다.</p>\n<p>값이 명시되지 않은 필드는 업데이트되지 않습니다.</p>\n",
+        "description": "계약 업데이트를 위한 입력 정보. 값이 명시되지 않은 필드는 업데이트되지 않습니다.\n값이 명시되지 않은 필드는 업데이트되지 않습니다.\n",
         "x-portone-title": "계약 업데이트를 위한 입력 정보. 값이 명시되지 않은 필드는 업데이트되지 않습니다.",
-        "x-portone-description": "<p>값이 명시되지 않은 필드는 업데이트되지 않습니다.</p>\n"
+        "x-portone-description": "값이 명시되지 않은 필드는 업데이트되지 않습니다.\n"
       },
       "UpdatePlatformContractError": {
         "oneOf": [
@@ -35622,7 +35622,7 @@
             "title": "업데이트된 계약 객체"
           }
         },
-        "description": "<p>계약 객체 업데이트 성공 응답</p>\n",
+        "description": "계약 객체 업데이트 성공 응답\n",
         "x-portone-title": "계약 객체 업데이트 성공 응답"
       },
       "UpdatePlatformDiscountSharePolicyBody": {
@@ -35637,16 +35637,16 @@
             "type": "integer",
             "format": "int32",
             "title": "할인 분담율",
-            "description": "<p>파트너가 분담할 할인금액의 비율을 의미하는 밀리 퍼센트 단위 (10^-5) 의 음이 아닌 정수이며, 파트너가 부담할 금액은 <code>할인금액 * partnerShareRate * 10^5</code> 로 책정합니다.</p>\n"
+            "description": "파트너가 분담할 할인금액의 비율을 의미하는 밀리 퍼센트 단위 (10^-5) 의 음이 아닌 정수이며, 파트너가 부담할 금액은 <code>할인금액 * partnerShareRate * 10^5</code> 로 책정합니다.\n"
           },
           "memo": {
             "type": "string",
             "title": "해당 할인 분담에 대한 메모"
           }
         },
-        "description": "<p>할인 분담 정책 업데이트를 위한 입력 정보</p>\n<p>값이 명시되지 않은 필드는 업데이트하지 않습니다.</p>\n",
+        "description": "할인 분담 정책 업데이트를 위한 입력 정보\n값이 명시되지 않은 필드는 업데이트하지 않습니다.\n",
         "x-portone-title": "할인 분담 정책 업데이트를 위한 입력 정보",
-        "x-portone-description": "<p>값이 명시되지 않은 필드는 업데이트하지 않습니다.</p>\n"
+        "x-portone-description": "값이 명시되지 않은 필드는 업데이트하지 않습니다.\n"
       },
       "UpdatePlatformDiscountSharePolicyError": {
         "oneOf": [
@@ -35689,7 +35689,7 @@
             "title": "업데이트된 할인 분담 정책"
           }
         },
-        "description": "<p>할인 분담 정책 업데이트 성공 응답</p>\n",
+        "description": "할인 분담 정책 업데이트 성공 응답\n",
         "x-portone-title": "할인 분담 정책 업데이트 성공 응답"
       },
       "UpdatePlatformError": {
@@ -35753,9 +35753,9 @@
             "title": "파트너 유형별 정보"
           }
         },
-        "description": "<p>파트너 업데이트를 위한 입력 정보</p>\n<p>값이 명시되지 않은 필드는 업데이트되지 않습니다.</p>\n",
+        "description": "파트너 업데이트를 위한 입력 정보\n값이 명시되지 않은 필드는 업데이트되지 않습니다.\n",
         "x-portone-title": "파트너 업데이트를 위한 입력 정보",
-        "x-portone-description": "<p>값이 명시되지 않은 필드는 업데이트되지 않습니다.</p>\n"
+        "x-portone-description": "값이 명시되지 않은 필드는 업데이트되지 않습니다.\n"
       },
       "UpdatePlatformPartnerBodyAccount": {
         "title": "파트너 계좌 업데이트를 위한 입력 정보",
@@ -35784,7 +35784,7 @@
             "title": "예금주명"
           }
         },
-        "description": "<p>파트너 계좌 업데이트를 위한 입력 정보</p>\n",
+        "description": "파트너 계좌 업데이트를 위한 입력 정보\n",
         "x-portone-title": "파트너 계좌 업데이트를 위한 입력 정보"
       },
       "UpdatePlatformPartnerBodyContact": {
@@ -35804,7 +35804,7 @@
             "title": "담당자 이메일"
           }
         },
-        "description": "<p>파트너 담당자 업데이트를 위한 정보</p>\n",
+        "description": "파트너 담당자 업데이트를 위한 정보\n",
         "x-portone-title": "파트너 담당자 업데이트를 위한 정보"
       },
       "UpdatePlatformPartnerBodyType": {
@@ -35820,9 +35820,9 @@
             "title": "원천징수대상자 추가 정보"
           }
         },
-        "description": "<p>파트너 업데이트를 위한 유형별 추가 정보</p>\n<p>파트너 유형별 추가 정보를 수정합니다.\n기존과 다른 파트너 유형 정보가 입력된 경우, 파트너의 유형 자체가 변경됩니다.</p>\n",
+        "description": "파트너 업데이트를 위한 유형별 추가 정보\n파트너 유형별 추가 정보를 수정합니다.\n기존과 다른 파트너 유형 정보가 입력된 경우, 파트너의 유형 자체가 변경됩니다.\n",
         "x-portone-title": "파트너 업데이트를 위한 유형별 추가 정보",
-        "x-portone-description": "<p>파트너 유형별 추가 정보를 수정합니다.\n기존과 다른 파트너 유형 정보가 입력된 경우, 파트너의 유형 자체가 변경됩니다.</p>\n"
+        "x-portone-description": "파트너 유형별 추가 정보를 수정합니다.\n기존과 다른 파트너 유형 정보가 입력된 경우, 파트너의 유형 자체가 변경됩니다.\n"
       },
       "UpdatePlatformPartnerBodyTypeBusiness": {
         "type": "object",
@@ -35907,7 +35907,7 @@
             "title": "업데이트된 파트너"
           }
         },
-        "description": "<p>파트너 업데이트 성공 응답</p>\n",
+        "description": "파트너 업데이트 성공 응답\n",
         "x-portone-title": "파트너 업데이트 성공 응답"
       },
       "UpdatePlatformPayoutPartnerSettlementBody": {
@@ -35989,7 +35989,7 @@
             "title": "업데이트된 플랫폼 정보"
           }
         },
-        "description": "<p>플랫폼 업데이트 결과 정보</p>\n",
+        "description": "플랫폼 업데이트 결과 정보\n",
         "x-portone-title": "플랫폼 업데이트 결과 정보"
       },
       "VerifiedIdentityVerification": {
@@ -36056,7 +36056,7 @@
             "title": "PG사 응답 데이터"
           }
         },
-        "description": "<p>완료된 본인인증 내역</p>\n",
+        "description": "완료된 본인인증 내역\n",
         "x-portone-title": "완료된 본인인증 내역"
       },
       "VirtualAccountIssuedPayment": {
@@ -36090,7 +36090,7 @@
           "transactionId": {
             "type": "string",
             "title": "결제 건 포트원 채번 아이디",
-            "description": "<p>V1 결제 건의 경우 imp_uid에 해당합니다.</p>\n"
+            "description": "V1 결제 건의 경우 imp_uid에 해당합니다.\n"
           },
           "merchantId": {
             "type": "string",
@@ -36115,12 +36115,12 @@
           "scheduleId": {
             "type": "string",
             "title": "결제 예약 건 아이디",
-            "description": "<p>결제 예약을 이용한 경우에만 존재</p>\n"
+            "description": "결제 예약을 이용한 경우에만 존재\n"
           },
           "billingKey": {
             "type": "string",
             "title": "결제 시 사용된 빌링키",
-            "description": "<p>빌링키 결제인 경우에만 존재</p>\n"
+            "description": "빌링키 결제인 경우에만 존재\n"
           },
           "webhooks": {
             "title": "웹훅 발송 내역",
@@ -36171,7 +36171,7 @@
           "escrow": {
             "$ref": "#/components/schemas/PaymentEscrow",
             "title": "에스크로 결제 정보",
-            "description": "<p>에스크로 결제인 경우 존재합니다.</p>\n"
+            "description": "에스크로 결제인 경우 존재합니다.\n"
           },
           "products": {
             "title": "상품 정보",
@@ -36194,7 +36194,7 @@
             "title": "국가 코드"
           }
         },
-        "description": "<p>가상계좌 발급 완료 상태 건</p>\n",
+        "description": "가상계좌 발급 완료 상태 건\n",
         "x-portone-title": "가상계좌 발급 완료 상태 건"
       },
       "WebhookNotFoundError": {
@@ -36211,7 +36211,7 @@
             "type": "string"
           }
         },
-        "description": "<p>웹훅 내역이 존재하지 않는 경우</p>\n",
+        "description": "웹훅 내역이 존재하지 않는 경우\n",
         "x-portone-title": "웹훅 내역이 존재하지 않는 경우",
         "x-portone-status-code": 404
       },
@@ -36281,12 +36281,12 @@
     "securitySchemes": {
       "bearerJwt": {
         "type": "http",
-        "description": "<p>Authorization: Bearer <code>엑세스 토큰</code></p>\n",
+        "description": "Authorization: Bearer <code>엑세스 토큰</code>\n",
         "scheme": "bearer"
       },
       "portOne": {
         "type": "http",
-        "description": "<p>Authorization: PortOne <code>발급된 API 시크릿</code></p>\n",
+        "description": "Authorization: PortOne <code>발급된 API 시크릿</code>\n",
         "scheme": "portone"
       }
     }
@@ -36295,42 +36295,42 @@
     {
       "id": "auth",
       "title": "인증 관련 API",
-      "description": "<p>인증과 관련된 API 기능을 제공합니다.</p>\n"
+      "description": "인증과 관련된 API 기능을 제공합니다.\n"
     },
     {
       "id": "payment",
       "title": "결제 관련 API",
-      "description": "<p>결제와 관련된 API 기능을 제공합니다.</p>\n"
+      "description": "결제와 관련된 API 기능을 제공합니다.\n"
     },
     {
       "id": "paymentSchedule",
       "title": "결제 예약 관련 API",
-      "description": "<p>결제 예약과 관련된 API 기능을 제공합니다.</p>\n"
+      "description": "결제 예약과 관련된 API 기능을 제공합니다.\n"
     },
     {
       "id": "billingKey",
       "title": "빌링키 관련 API",
-      "description": "<p>빌링키와 관련된 API 기능을 제공합니다.</p>\n"
+      "description": "빌링키와 관련된 API 기능을 제공합니다.\n"
     },
     {
       "id": "cashReceipt",
       "title": "현금 영수증 관련 API",
-      "description": "<p>현금 영수증과 관련된 API 기능을 제공합니다.</p>\n"
+      "description": "현금 영수증과 관련된 API 기능을 제공합니다.\n"
     },
     {
       "id": "identityVerification",
       "title": "본인인증 관련 API",
-      "description": "<p>본인인증과 관련된 API 기능을 제공합니다.</p>\n"
+      "description": "본인인증과 관련된 API 기능을 제공합니다.\n"
     },
     {
       "id": "b2b",
       "title": "B2B 서비스 API",
-      "description": "<p>B2B 관련 API 기능을 제공합니다. alpha 버전의 API 로서, 사용을 원하실 경우 관리자콘솔 및 홈페이지를 통해 문의해주세요.</p>\n"
+      "description": "B2B 관련 API 기능을 제공합니다. alpha 버전의 API 로서, 사용을 원하실 경우 관리자콘솔 및 홈페이지를 통해 문의해주세요.\n"
     },
     {
       "id": "pgSpecific",
       "title": "특정 PG사 관련 API",
-      "description": "<p>특정 PG사에 국한된 API 기능을 제공합니다.</p>\n"
+      "description": "특정 PG사에 국한된 API 기능을 제공합니다.\n"
     }
   ]
 }


### PR DESCRIPTION
![image](https://github.com/portone-io/developers.portone.io/assets/67222970/1f1322e0-b3b0-4751-bfaf-537c9b38a5f6)

Swagger / Redoc에 위와 같이 HTML태그가 그대로 표출되는 문제가 있었습니다.
해당 문제를 @XiNiHa 님과 확인해 보니 문서 스펙이 올바르지 않았다고 하셔서 (일단) 눈에 보이는 태그만 제거한 PR을 올려드립니다.

더 나은 수정방법이 있다면 그렇게 수정하셔도 무방합니다. 항상 좋은 서비스 운영해 주셔서 감사드립니다.
