### PR TITLE
remark-lint-table-cell-padding이 전각 문자를 대응하도록 패치

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,8 @@
 			"@shikijs/rehype@1.2.1": "patches/@shikijs__rehype@1.2.1.patch",
 			"eslint-plugin-prettier@5.1.3": "patches/eslint-plugin-prettier@5.1.3.patch",
 			"eslint-plugin-markdown@3.0.1": "patches/eslint-plugin-markdown@3.0.1.patch",
-			"eslint-plugin-mdx@3.1.5": "patches/eslint-plugin-mdx@3.1.5.patch"
+			"eslint-plugin-mdx@3.1.5": "patches/eslint-plugin-mdx@3.1.5.patch",
+			"remark-lint-table-cell-padding@4.1.3": "patches/remark-lint-table-cell-padding@4.1.3.patch"
 		},
 		"overrides": {
 			"@vercel/nft": "0.26.4"

--- a/patches/remark-lint-table-cell-padding@4.1.3.patch
+++ b/patches/remark-lint-table-cell-padding@4.1.3.patch
@@ -1,0 +1,78 @@
+diff --git a/index.js b/index.js
+index e6456c91f9ebe098deb4c73dbb544c156c2d17e7..1284ed3cc4551251079b71093dedb513d9db50dd 100644
+--- a/index.js
++++ b/index.js
+@@ -206,6 +206,7 @@
+ import {lintRule} from 'unified-lint-rule'
+ import {visit, SKIP} from 'unist-util-visit'
+ import {pointStart, pointEnd} from 'unist-util-position'
++import stringWidth from 'string-width'
+ 
+ const remarkLintTableCellPadding = lintRule(
+   {
+@@ -226,6 +227,8 @@ const remarkLintTableCellPadding = lintRule(
+       )
+     }
+ 
++    const value = String(file)
++
+     visit(tree, 'table', (node) => {
+       const rows = node.children
+       // To do: fix types to always have `align` defined.
+@@ -285,7 +288,7 @@ const remarkLintTableCellPadding = lintRule(
+           sizes[column] = Math.max(
+             /* c8 ignore next */
+             sizes[column] || 0,
+-            contentEnd - contentStart
++            stringWidth(value.substring(contentStart, contentEnd))
+           )
+         }
+       }
+@@ -328,7 +331,7 @@ const remarkLintTableCellPadding = lintRule(
+ 
+       if (style === 0) {
+         // Ignore every cell except the biggest in the column.
+-        if (size(cell) < sizes[column]) {
++        if (size(cell, value) < sizes[column]) {
+           return
+         }
+ 
+@@ -338,7 +341,7 @@ const remarkLintTableCellPadding = lintRule(
+ 
+         if (spacing > style) {
+           // May be right or center aligned.
+-          if (size(cell) < sizes[column]) {
++          if (size(cell, value) < sizes[column]) {
+             return
+           }
+ 
+@@ -360,12 +363,14 @@ export default remarkLintTableCellPadding
+ 
+ /**
+  * @param {TableCell} node
++ * @param {string} value
+  * @returns {number}
+  */
+-function size(node) {
++function size(node, value) {
+   const head = pointStart(node.children[0]).offset
+   const tail = pointEnd(node.children[node.children.length - 1]).offset
+   // Only called when we’re sure offsets exist.
+-  /* c8 ignore next */
+-  return typeof head === 'number' && typeof tail === 'number' ? tail - head : 0
++  if (typeof head !== 'number' || typeof tail !== 'number') return 0
++  const content = value.substring(head, tail)
++  return stringWidth(content)
+ }
+diff --git a/package.json b/package.json
+index aa1c8caac219f9c7ba22a4c983cb9f8331bd6bbd..a722d5599f55d4817c9dc19a1d84672c47902d72 100644
+--- a/package.json
++++ b/package.json
+@@ -37,6 +37,7 @@
+   "dependencies": {
+     "@types/mdast": "^3.0.0",
+     "@types/unist": "^2.0.0",
++    "string-width": "^5",
+     "unified": "^10.0.0",
+     "unified-lint-rule": "^2.0.0",
+     "unist-util-position": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ patchedDependencies:
   eslint-plugin-prettier@5.1.3:
     hash: cblms4s5tiq5wzliuxv3xh6qju
     path: patches/eslint-plugin-prettier@5.1.3.patch
+  remark-lint-table-cell-padding@4.1.3:
+    hash: hujqseqmd2vj3eg2bft4iy7sme
+    path: patches/remark-lint-table-cell-padding@4.1.3.patch
 
 dependencies:
   '@astrojs/check':
@@ -342,7 +345,7 @@ dependencies:
     version: 3.1.2
   remark-lint-table-cell-padding:
     specifier: ^4.1.3
-    version: 4.1.3
+    version: 4.1.3(patch_hash=hujqseqmd2vj3eg2bft4iy7sme)
   remark-lint-table-pipe-alignment:
     specifier: github:simnalamburt/remark-lint#workaround-310-312
     version: github.com/simnalamburt/remark-lint/8d77dd2e42f6bee076cfd2122c19da8285a02edb
@@ -7793,7 +7796,7 @@ packages:
       unist-util-visit: 4.1.2
     dev: false
 
-  /remark-lint-table-cell-padding@4.1.3:
+  /remark-lint-table-cell-padding@4.1.3(patch_hash=hujqseqmd2vj3eg2bft4iy7sme):
     resolution: {integrity: sha512-N9xtnS6MG/H3srAMjqqaF26A7socr87pIgt64dr5rxoSbDRWRPChGQ8y7wKyV8VeyRNF37e3E5KB3bQVqjSYaQ==}
     dependencies:
       '@types/mdast': 3.0.15
@@ -7803,6 +7806,7 @@ packages:
       unist-util-position: 4.0.4
       unist-util-visit: 4.1.2
     dev: false
+    patched: true
 
   /remark-lint-table-pipes@4.1.2:
     resolution: {integrity: sha512-Ex2cJDXA0hdD9CC5Nu0p3K5LP+AhzPvk4sIOSbevCTSRyCS/SkNk4CQ6pwWBxuPVuHQUkqXkT8lgu8wwr/9A3A==}


### PR DESCRIPTION
before:
![image](https://github.com/portone-io/developers.portone.io/assets/8155259/1629ea8e-6846-4ef6-987a-ad7775bcc907)

after:
![image](https://github.com/portone-io/developers.portone.io/assets/8155259/be15220e-3872-4cb5-888b-e59d94170849)
