### PR TITLE
V2 본인인증 가이드 수정사항 적용

### DIFF
--- a/src/content/docs/ko/pg/simple/tosspay-v2/readme.mdx
+++ b/src/content/docs/ko/pg/simple/tosspay-v2/readme.mdx
@@ -213,12 +213,12 @@ import Hint from "~/components/Hint.astro";
         amount: 1000, // [필수 입력] 결제 금액
         name: "주문명", // 주문명
         cash_recipt_type: "person", // 현금영수증 발급 타입
-        bypass: JSON.stringify({
+        bypass: {
           tosspay_v2: {
             cashReceiptTradeType: "GENERAL", // 현금영수증 발급 대상 타입
             sendFailPush: false, // 결제 실패 시 토스페이앱 푸시알람 발송 여부
           },
-        }),
+        },
       }),
     });
     ```

--- a/src/content/docs/ko/v2-payment/pg/danal-identity-verification.mdx
+++ b/src/content/docs/ko/v2-payment/pg/danal-identity-verification.mdx
@@ -3,8 +3,8 @@ title: 다날 본인인증
 description: 다날 본인인증 연동 방법을 안내합니다.
 ---
 
-import Tabs from "~/components/gitbook/tabs/Tabs.astro";
 import Tab from "~/components/gitbook/tabs/Tab.astro";
+import Tabs from "~/components/gitbook/tabs/Tabs.astro";
 
 ## 다날 본인인증 채널 설정하기
 
@@ -12,7 +12,7 @@ import Tab from "~/components/gitbook/tabs/Tab.astro";
 
 ## SDK 방식으로 본인인증하기
 
-- [본인인증 연동하기](../identity-verification/readme) 페이지의 내용을 참고하여 연동을 진행합니다.
+- [본인인증 연동하기](../identity-verification) 페이지의 내용을 참고하여 연동을 진행합니다.
 
 ### 전화번호 고정하기
 
@@ -48,12 +48,12 @@ SDK, API 에서 각각 아래와 같은 방식으로 특수 파라미터들을 �
 ```javascript
 // 필요한 파라미터를 선택하여 입력해주세요.
 const danalByass = {
-  danal : {
-    IsCarrier: 'KTF',
+  danal: {
+    IsCarrier: "KTF",
     AGELIMIT: 20,
-    CPTITLE: 'www.MarketA.co.kr'
-  }
-}
+    CPTITLE: "www.MarketA.co.kr",
+  },
+};
 ```
 </Tab>
 </Tabs>
@@ -65,8 +65,8 @@ SDK의 `requestIdentityVerfication` 함수의 파라미터 중 `bypass` 필드�
 ```javascript
 PortOne.requestIdentityVerfication({
   /* 기타 파라미터 생략 */
-  bypass: danalByass
-})
+  bypass: danalByass,
+});
 ```
 </Tab>
 <Tab title="API 사용 예시">
@@ -80,7 +80,7 @@ await axios({
   headers: { "Content-Type": "application/json" },
   data: {
     /* 기타 파라미터 생략 */
-    bypass: JSON.stringify(danalByass)
+    bypass: JSON.stringify(danalByass),
   },
 });
 ```

--- a/src/content/docs/ko/v2-payment/pg/danal-identity-verification.mdx
+++ b/src/content/docs/ko/v2-payment/pg/danal-identity-verification.mdx
@@ -47,7 +47,7 @@ SDK, API 에서 각각 아래와 같은 방식으로 특수 파라미터들을 �
 <Tab title="bypass 파라미터 예시">
 ```javascript
 // 필요한 파라미터를 선택하여 입력해주세요.
-const danalByass = {
+const danalBypass = {
   danal: {
     IsCarrier: "KTF",
     AGELIMIT: 20,

--- a/src/content/docs/ko/v2-payment/pg/danal-identity-verification.mdx
+++ b/src/content/docs/ko/v2-payment/pg/danal-identity-verification.mdx
@@ -65,7 +65,7 @@ SDK의 `requestIdentityVerfication` 함수의 파라미터 중 `bypass` 필드�
 ```javascript
 PortOne.requestIdentityVerfication({
   /* 기타 파라미터 생략 */
-  bypass: danalByass,
+  bypass: danalBypass,
 });
 ```
 </Tab>
@@ -80,7 +80,7 @@ await axios({
   headers: { "Content-Type": "application/json" },
   data: {
     /* 기타 파라미터 생략 */
-    bypass: JSON.stringify(danalByass),
+    bypass: danalBypass,
   },
 });
 ```

--- a/src/content/docs/ko/v2-payment/v2-sdk/identity-verification-request.mdx
+++ b/src/content/docs/ko/v2-payment/v2-sdk/identity-verification-request.mdx
@@ -49,7 +49,7 @@ description: 본인인증 요청 파라미터를 확인할 수 있습니다.
 >
 > 선택하신 채널이 테스트 채널이 아닌 경우 에러가 발생합니다.
 
-### **`customer`** <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+### **`customer`** <mark style="color:blue;">**object**</mark>
 
 > **고객 정보**
 >


### PR DESCRIPTION
V2 본인인증과 관련한 수정 사항들을 반영합니다.
- V2 SDK 파라미터 가이드 중 본인인증 요청 시 customer 필드가 optional 이지만 required로 표기되어 있던 부분 수정
- V2 다날 본인인증 연동 가이드에서 다른 페이지로 연결하는 링크 path가 변경되었으나 미반영되어있던 내용 수정
- bypass를 Json.Stringify 하지 않고 직접 사용하는 방식 가이드에도 적용 (토스페이, 다날)
- byass -> bypass 오타 수정