### PR TITLE
V2 API Secret 사용 방식 수정

### DIFF
--- a/src/content/docs/ko/ready/readme.mdx
+++ b/src/content/docs/ko/ready/readme.mdx
@@ -341,42 +341,41 @@ import IntegrationTosspayments from './_components/integration-guide/tosspayment
 
     <VersionGate>
       <Tabs slot="v1">
-          <Tab title="결제창 일반/정기 결제">
-              <IntegrationInicis />
-          </Tab>
+        <Tab title="결제창 일반/정기 결제">
+          <IntegrationInicis />
+        </Tab>
 
-          <Tab title="결제창 일반결제 및 API 수기/정기결제">
-              1. [KG이니시스 가맹점관리자](https://iniweb.inicis.com/security/login.do) 접속 후 로그인을 합니다.
-              2. \[상점정보]→\[계약정보]→\[부가정보]를 클릭합니다.
-              3. INIAPI key 생성 갱신의 조회 버튼을 클릭하여 \[INIAPI KEY], \[INIAPI IV] 값을 확인할 수 있습니다. 값이 표시되지 않는 경우 갱신 버튼을 클릭해 주세요.
+        <Tab title="결제창 일반결제 및 API 수기/정기결제">
+          1. [KG이니시스 가맹점관리자](https://iniweb.inicis.com/security/login.do) 접속 후 로그인을 합니다.
+          2. \[상점정보]→\[계약정보]→\[부가정보]를 클릭합니다.
+          3. INIAPI key 생성 갱신의 조회 버튼을 클릭하여 \[INIAPI KEY], \[INIAPI IV] 값을 확인할 수 있습니다. 값이 표시되지 않는 경우 갱신 버튼을 클릭해 주세요.
 
-              <Figure src={image15} caption="KG이니시스 가맹점관리자 내 크레덴셜 정보 조회 화면 1" />
+          <Figure src={image15} caption="KG이니시스 가맹점관리자 내 크레덴셜 정보 조회 화면 1" />
 
-              6. 포트원 콘솔에서 채널 추가 시 \[상점아이디]를 입력한 후 `저장`을 클릭합니다. \[INIAPI Key], \[INIAPI IV]의 값은 케이스에 따라 추가로 입력한 후 `저장`을 클릭합니다.
-          </Tab>
+          6. 포트원 콘솔에서 채널 추가 시 \[상점아이디]를 입력한 후 `저장`을 클릭합니다. \[INIAPI Key], \[INIAPI IV]의 값은 케이스에 따라 추가로 입력한 후 `저장`을 클릭합니다.
+        </Tab>
 
-          <Tab title="통합 본인인증">
-              포트원 콘솔에서 채널 추가 시 계약 완료 후 이니시스로부터 전달받은 \[MID]와\[apikey]를 입력한 후 `저장`을 클릭합니다.
-          </Tab>
+        <Tab title="통합 본인인증">
+          포트원 콘솔에서 채널 추가 시 계약 완료 후 이니시스로부터 전달받은 \[MID]와\[apikey]를 입력한 후 `저장`을 클릭합니다.
+        </Tab>
 
-          <Tab title="신용카드 본인인증">
-              <Hint style="warning">
-                  신용카드 본인인증 서비스는 2021-11-22일부로 신규 서비스를 제공하지 않습니다.
-              </Hint>
+        <Tab title="신용카드 본인인증">
+          <Hint style="warning">
+            신용카드 본인인증 서비스는 2021-11-22일부로 신규 서비스를 제공하지 않습니다.
+          </Hint>
 
-              포트원 콘솔에서 채널 추가 시 계약 완료 후 이니시스로부터 전달받은 \[SEEDKEY],\[SEEDIV], \[DI\_CODE]를 입력한 후 `저장`을 클릭합니다.
+          포트원 콘솔에서 채널 추가 시 계약 완료 후 이니시스로부터 전달받은 \[SEEDKEY],\[SEEDIV], \[DI\_CODE]를 입력한 후 `저장`을 클릭합니다.
 
-              <Hint style="info">
-                  DI\_CODE는 12자리로 고객사에서 자체적으로 사이트(서비스)를 관리하는 코드입니다. 고객사 사이트(서비스)마다 DI\_CODE를 부여하여 관리하고 있는 경우에는 KG이니시스 카드본인인증 계약 진행시 계약서상에 고객사가 직접 기입한 값을 입력하시면 됩니다.
+          <Hint style="info">
+            DI\_CODE는 12자리로 고객사에서 자체적으로 사이트(서비스)를 관리하는 코드입니다. 고객사 사이트(서비스)마다 DI\_CODE를 부여하여 관리하고 있는 경우에는 KG이니시스 카드본인인증 계약 진행시 계약서상에 고객사가 직접 기입한 값을 입력하시면 됩니다.
 
-                  계약시 **DI\_CODE를 기입하지 않은 경우** 빈칸으로 저장해야 합니다.
-              </Hint>
-          </Tab>
+            계약시 **DI\_CODE를 기입하지 않은 경우** 빈칸으로 저장해야 합니다.
+          </Hint>
+        </Tab>
       </Tabs>
 
       <IntegrationInicis slot="v2" />
     </VersionGate>
-
   </Details>
 
   <Details>
@@ -651,8 +650,10 @@ import IntegrationTosspayments from './_components/integration-guide/tosspayment
     <Hint style="info">
       **API Secret이란?**
 
-      - API 호출 시 사용되는 Access Token을 발급할 때 사용되는 값입니다.
-      - V2 API Secret을 발급받으신 후, 이를 이용해 [API Secret을 이용한 토큰 발급](/api/rest-v2/auth#post%20%2Flogin%2Fapi-secret) API를 호출하시면 <br /> **Access Token**을 발급받으실 수 있습니다.
+      - API 사용 시 Authorization 헤더 인증을 위해 사용되는 값입니다.
+      
+      - API Secret을 발급받으신 후, 선호하는 [인증 방식](/api/rest-v2?v=v2#:~:text=%EC%82%AC%EC%9A%A9%ED%95%A0%20%EC%88%98%20%EC%9E%88%EC%8A%B5%EB%8B%88%EB%8B%A4.-,%EC%9D%B8%EC%A6%9D,-%EB%B0%A9%EC%8B%9D)
+        을 선택하여 API를 사용하실 수 있습니다.
     </Hint>
 
     <Hint style="danger">


### PR DESCRIPTION
[결제 연동 준비하기] 탭에서 V2 API Secret 을 활용하는 방법이 access token 을 발급받는 것으로 한정되어 있던 설명을 변경합니다.
V2 API 페이지로 이동하며 1. 직접 사용 방식, 2. 액세스 토큰 방식인증 방식 중 선택하도록 유도합니다.