### PR TITLE
개발자센터 api 문서 예시 요청/응답 값 보여주기

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
 		"eslint-plugin-react": "^7.34.1",
 		"eslint-plugin-simple-import-sort": "^12.0.0",
 		"fuse.js": "^7.0.0",
+		"httpsnippet-lite": "^3.0.5",
 		"js-yaml": "^4.1.0",
 		"json5": "^2.2.3",
 		"lodash-es": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,6 +154,9 @@ dependencies:
   fuse.js:
     specifier: ^7.0.0
     version: 7.0.0
+  httpsnippet-lite:
+    specifier: ^3.0.5
+    version: 3.0.5
   js-yaml:
     specifier: ^4.1.0
     version: 4.1.0
@@ -2451,6 +2454,10 @@ packages:
 
   /@types/estree@1.0.5:
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
+    dev: false
+
+  /@types/har-format@1.2.15:
+    resolution: {integrity: sha512-RpQH4rXLuvTXKR0zqHq3go0RVXYv/YVqv4TnPH95VbwUxZdQlK1EtcMvQvMpDngHbt13Csh9Z4qT9AbkiQH5BA==}
     dev: false
 
   /@types/hast@3.0.4:
@@ -4751,6 +4758,14 @@ packages:
     engines: {node: '>=0.4.x'}
     dev: false
 
+  /formdata-node@4.4.1:
+    resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
+    engines: {node: '>= 12.20'}
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 4.0.0-beta.3
+    dev: false
+
   /fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
     requiresBuild: true
@@ -4838,6 +4853,10 @@ packages:
       has-proto: 1.0.3
       has-symbols: 1.0.3
       hasown: 2.0.1
+    dev: false
+
+  /get-own-enumerable-property-symbols@3.0.2:
+    resolution: {integrity: sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==}
     dev: false
 
   /get-stream@6.0.1:
@@ -5209,6 +5228,15 @@ packages:
       - supports-color
     dev: false
 
+  /httpsnippet-lite@3.0.5:
+    resolution: {integrity: sha512-So4qTXY5iFj5XtFDwyz2PicUu+8NWrI8e8h+ZeZoVtMNcFQp4FFIntBHUE+JPUG6QQU8o1VHCy+X4ETRDwt9CA==}
+    engines: {node: '>=14.13'}
+    dependencies:
+      '@types/har-format': 1.2.15
+      formdata-node: 4.4.1
+      stringify-object: 3.3.0
+    dev: false
+
   /human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
@@ -5469,6 +5497,11 @@ packages:
     engines: {node: '>=0.12.0'}
     dev: false
 
+  /is-obj@1.0.1:
+    resolution: {integrity: sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /is-path-inside@3.0.3:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
     engines: {node: '>=8'}
@@ -5491,6 +5524,11 @@ packages:
     dependencies:
       call-bind: 1.0.7
       has-tostringtag: 1.0.2
+    dev: false
+
+  /is-regexp@1.0.0:
+    resolution: {integrity: sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==}
+    engines: {node: '>=0.10.0'}
     dev: false
 
   /is-set@2.0.2:
@@ -6592,6 +6630,11 @@ packages:
     requiresBuild: true
     dev: false
     optional: true
+
+  /node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    dev: false
 
   /node-fetch-native@1.6.4:
     resolution: {integrity: sha512-IhOigYzAKHd244OC0JIMIUrjzctirCmPkaIfhDeGcEETWof5zKYUW7e7MYvChGWh/4CJeXEgsRyGzuF334rOOQ==}
@@ -8414,6 +8457,15 @@ packages:
       character-entities-legacy: 3.0.0
     dev: false
 
+  /stringify-object@3.3.0:
+    resolution: {integrity: sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==}
+    engines: {node: '>=4'}
+    dependencies:
+      get-own-enumerable-property-symbols: 3.0.2
+      is-obj: 1.0.1
+      is-regexp: 1.0.0
+    dev: false
+
   /strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -9344,6 +9396,11 @@ packages:
 
   /web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+    dev: false
+
+  /web-streams-polyfill@4.0.0-beta.3:
+    resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
+    engines: {node: '>= 14'}
     dev: false
 
   /web-vitals@3.4.0:

--- a/src/layouts/rest-api/editor/RequestJsonEditor.tsx
+++ b/src/layouts/rest-api/editor/RequestJsonEditor.tsx
@@ -124,7 +124,7 @@ function getDefaultValue(_schema: unknown, param: Parameter): unknown {
   const type = param.type ? param.type : param.schema?.type || "object";
   if (type === "boolean") return false;
   if (type === "number" || type === "integer") return 0;
-  if (type === "string") return "";
+  if (type === "string") return param.name;
   if (type === "object") return {};
   if (type === "array") return [];
   return null;

--- a/src/layouts/rest-api/editor/RequestJsonEditor.tsx
+++ b/src/layouts/rest-api/editor/RequestJsonEditor.tsx
@@ -120,7 +120,8 @@ export function getInitialJsonText(
 }
 
 function getDefaultValue(_schema: unknown, param: Parameter): unknown {
-  const type = param.type || "object";
+  if (param.example) return param.example;
+  const type = param.type ? param.type : param.schema?.type || "object";
   if (type === "boolean") return false;
   if (type === "number" || type === "integer") return 0;
   if (type === "string") return "";

--- a/src/layouts/rest-api/endpoint/playground/try/Req.tsx
+++ b/src/layouts/rest-api/endpoint/playground/try/Req.tsx
@@ -245,9 +245,9 @@ function createHarRequest(
     headers: Object.entries(headers).map(([name, value]) => ({ name, value })),
     cookies: [],
     httpVersion: "HTTP/1.1",
-    queryString: Object
-      .entries(reqQuery as Record<string, string>)
-      .map(([name, value]) => ({ name, value })),
+    queryString: Object.entries(reqQuery as Record<string, string>).map(
+      ([name, value]) => ({ name, value }),
+    ),
     postData: {
       mimeType: "application/json",
       text: JSON.stringify(reqBody),

--- a/src/layouts/rest-api/endpoint/playground/try/Req.tsx
+++ b/src/layouts/rest-api/endpoint/playground/try/Req.tsx
@@ -245,10 +245,9 @@ function createHarRequest(
     headers: Object.entries(headers).map(([name, value]) => ({ name, value })),
     cookies: [],
     httpVersion: "HTTP/1.1",
-    queryString: Object.entries(reqQuery as object).map(([name, value]) => ({
-      name,
-      value: value as string,
-    })),
+    queryString: Object
+      .entries(reqQuery as Record<string, string>)
+      .map(([name, value]) => ({ name, value })),
     postData: {
       mimeType: "application/json",
       text: JSON.stringify(reqBody),

--- a/src/layouts/rest-api/endpoint/playground/try/Req.tsx
+++ b/src/layouts/rest-api/endpoint/playground/try/Req.tsx
@@ -1,4 +1,10 @@
-import { type Signal, signal, useSignal } from "@preact/signals";
+import {
+  type Signal,
+  signal,
+  useSignal,
+  useSignalEffect,
+} from "@preact/signals";
+import { type HarRequest } from "httpsnippet-lite";
 import json5 from "json5";
 import { useMemo } from "preact/hooks";
 import { encode as encodeQs } from "querystring";
@@ -23,6 +29,7 @@ export interface ReqProps {
   schema: unknown;
   endpoint: Endpoint;
   operation: Operation;
+  harRequestSignal: Signal<HarRequest | undefined>;
   execute: (fn: () => Promise<Res>) => void;
 }
 export default function Req({
@@ -30,6 +37,7 @@ export default function Req({
   schema,
   endpoint,
   operation,
+  harRequestSignal,
   execute,
 }: ReqProps) {
   const { path, method } = endpoint;
@@ -39,6 +47,17 @@ export default function Req({
   const reqPathParams = useReqParams(schema, operation, "path");
   const reqQueryParams = useReqParams(schema, operation, "query");
   const reqBodyParams = useReqParams(schema, operation, "body");
+  useSignalEffect(() => {
+    harRequestSignal.value = createHarRequest(
+      apiHost,
+      path,
+      method,
+      reqHeaderSignal,
+      reqPathParams,
+      reqQueryParams,
+      reqBodyParams,
+    );
+  });
   return (
     <Card
       title={
@@ -205,4 +224,36 @@ async function responseToRes(res: Response): Promise<Res> {
   const { status, headers } = res;
   const body = (await res.json()) as unknown;
   return { status, headers, body };
+}
+
+function createHarRequest(
+  apiHost: string,
+  path: string,
+  method: string,
+  reqHeaderSignal: Signal<KvList>,
+  reqPathParams: ReqParams,
+  reqQueryParams: ReqParams,
+  reqBodyParams: ReqParams,
+): HarRequest {
+  const headers = kvListToObject(reqHeaderSignal.value);
+  const reqPath = reqPathParams.parseJson();
+  const reqQuery = reqQueryParams.parseJson();
+  const reqBody = reqBodyParams.parseJson();
+  return {
+    url: createUrl(apiHost, path, reqPath, reqQuery).toString(),
+    method,
+    headers: Object.entries(headers).map(([name, value]) => ({ name, value })),
+    cookies: [],
+    httpVersion: "HTTP/1.1",
+    queryString: Object.entries(reqQuery as object).map(([name, value]) => ({
+      name,
+      value: value as string,
+    })),
+    postData: {
+      mimeType: "application/json",
+      text: JSON.stringify(reqBody),
+    },
+    bodySize: -1,
+    headersSize: -1,
+  } satisfies HarRequest;
 }

--- a/src/layouts/rest-api/endpoint/playground/try/ReqSample.tsx
+++ b/src/layouts/rest-api/endpoint/playground/try/ReqSample.tsx
@@ -1,0 +1,152 @@
+import {
+  type ReadonlySignal,
+  type Signal,
+  useComputed,
+  useSignal,
+  useSignalEffect,
+} from "@preact/signals";
+import {
+  availableTargets as _availableTargets,
+  type HarRequest,
+  HTTPSnippet,
+} from "httpsnippet-lite";
+
+import MonacoEditor, {
+  commonEditorConfig,
+} from "~/layouts/rest-api/editor/MonacoEditor";
+
+import Card from "../Card";
+
+export interface ReqSampleProps {
+  harRequestSignal: Signal<HarRequest | undefined>;
+}
+
+const availableTargets = _availableTargets();
+type AvailableTarget = (typeof availableTargets)[number];
+type ClientInfo = AvailableTarget["clients"][number];
+
+export default function ReqSample({ harRequestSignal }: ReqSampleProps) {
+  const targetKeySignal = useSignal("shell");
+  const clientKeySignal = useSignal("curl");
+  const targetInfoSignal = useTargetInfo(targetKeySignal);
+  const clientInfoSignal = useClientInfo(targetInfoSignal, clientKeySignal);
+  const snippetSignal = useHTTPSnippet(
+    harRequestSignal,
+    targetInfoSignal,
+    clientInfoSignal,
+  );
+
+  return (
+    <Card
+      title={
+        <>
+          <div className="flex flex-wrap">
+            <span className="flex-shrink-0">Request Sample{": "}</span>
+            <div className="flex-shrink-0">
+              <select
+                value={targetKeySignal.value}
+                onChange={(e) =>
+                  (targetKeySignal.value = String(e.currentTarget.value))
+                }
+              >
+                {availableTargets.map((target) => (
+                  <option key={target.key} value={target.key}>
+                    {target.title}
+                  </option>
+                ))}
+              </select>
+              <select
+                value={clientKeySignal.value}
+                onChange={(e) =>
+                  (clientKeySignal.value = String(e.currentTarget.value))
+                }
+              >
+                {targetInfoSignal.value?.clients.map((client) => (
+                  <option key={client.key} value={client.key}>
+                    {client.title}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+        </>
+      }
+    >
+      {snippetSignal.value ? (
+        <MonacoEditor
+          key={snippetSignal.value}
+          init={(monaco, domElement) =>
+            monaco.editor.create(domElement, {
+              ...commonEditorConfig,
+              value: snippetSignal.value || "",
+              language: targetInfoSignal.value?.key || "plaintext",
+              readOnly: true,
+            })
+          }
+        />
+      ) : (
+        <span class="p-4 text-xs text-slate-4 font-bold">N/A</span>
+      )}
+    </Card>
+  );
+}
+
+function useTargetInfo(
+  keySignal: Signal<string>,
+): ReadonlySignal<AvailableTarget | null> {
+  return useComputed(
+    () =>
+      availableTargets.find((target) => target.key === keySignal.value) || null,
+  );
+}
+
+function useClientInfo(
+  targetInfoSignal: ReadonlySignal<AvailableTarget | null>,
+  clientKeySignal: Signal<string>,
+): ReadonlySignal<ClientInfo | null> {
+  return useComputed(() => {
+    const clientInfo =
+      targetInfoSignal.value?.clients.find(
+        (client) => client.key === clientKeySignal.value,
+      ) ||
+      targetInfoSignal.value?.clients.find(
+        (client) => client.key === targetInfoSignal.value?.default,
+      ) ||
+      targetInfoSignal.value?.clients[0] ||
+      null;
+    if (clientInfo) {
+      clientKeySignal.value = clientInfo.key;
+    }
+    return clientInfo;
+  });
+}
+
+function useHTTPSnippet(
+  harRequestSignal: Signal<HarRequest | undefined>,
+  targetIdSignal: ReadonlySignal<AvailableTarget | null>,
+  clientIdSignal: ReadonlySignal<ClientInfo | null>,
+): Signal<string | null> {
+  const snippetSignal = useSignal<string | null>(null);
+  useSignalEffect(() => {
+    if (
+      harRequestSignal.value &&
+      targetIdSignal.value &&
+      clientIdSignal.value
+    ) {
+      new HTTPSnippet(harRequestSignal.value)
+        .convert(targetIdSignal.value.key, clientIdSignal.value.key)
+        .then((snippet) => {
+          if (Array.isArray(snippet)) {
+            snippet = snippet.join("\n");
+          }
+          snippetSignal.value = snippet;
+        })
+        .catch((err) => {
+          console.error(err);
+        });
+    } else {
+      snippetSignal.value = null;
+    }
+  });
+  return snippetSignal;
+}

--- a/src/layouts/rest-api/endpoint/playground/try/ReqSample.tsx
+++ b/src/layouts/rest-api/endpoint/playground/try/ReqSample.tsx
@@ -21,7 +21,32 @@ export interface ReqSampleProps {
   harRequestSignal: Signal<HarRequest | undefined>;
 }
 
-const availableTargets = _availableTargets();
+const httpSnippetLanguageMap = new Map(
+  Object.entries({
+    c: "c",
+    clojure: "clojure",
+    csharp: "csharp",
+    go: "go",
+    java: "java",
+    javascript: "javascript",
+    kotlin: "kotlin",
+    node: "javascript",
+    objc: "objective-c",
+    php: "php",
+    powershell: "powershell",
+    python: "python",
+    r: "r",
+    ruby: "ruby",
+    shell: "shell",
+    swift: "swift",
+  }),
+);
+const availableTargets = _availableTargets()
+  .map((target) => ({
+    ...target,
+    language: httpSnippetLanguageMap.get(target.key),
+  }))
+  .filter((target) => target.language);
 type AvailableTarget = (typeof availableTargets)[number];
 type ClientInfo = AvailableTarget["clients"][number];
 
@@ -79,7 +104,7 @@ export default function ReqSample({ harRequestSignal }: ReqSampleProps) {
             monaco.editor.create(domElement, {
               ...commonEditorConfig,
               value: snippetSignal.value || "",
-              language: targetInfoSignal.value?.key || "plaintext",
+              language: targetInfoSignal.value?.language ?? "plaintext",
               readOnly: true,
             })
           }

--- a/src/layouts/rest-api/endpoint/playground/try/ReqSample.tsx
+++ b/src/layouts/rest-api/endpoint/playground/try/ReqSample.tsx
@@ -92,7 +92,7 @@ export default function ReqSample({ harRequestSignal }: ReqSampleProps) {
 }
 
 function useTargetInfo(
-  keySignal: Signal<string>,
+  keySignal: ReadonlySignal<string>,
 ): ReadonlySignal<AvailableTarget | null> {
   return useComputed(
     () =>

--- a/src/layouts/rest-api/endpoint/playground/try/ReqSample.tsx
+++ b/src/layouts/rest-api/endpoint/playground/try/ReqSample.tsx
@@ -45,9 +45,9 @@ export default function ReqSample({ harRequestSignal }: ReqSampleProps) {
             <div className="flex-shrink-0">
               <select
                 value={targetKeySignal.value}
-                onChange={(e) =>
-                  (targetKeySignal.value = String(e.currentTarget.value))
-                }
+                onChange={(e) => {
+                  targetKeySignal.value = String(e.currentTarget.value);
+                }}
               >
                 {availableTargets.map((target) => (
                   <option key={target.key} value={target.key}>

--- a/src/layouts/rest-api/endpoint/playground/try/ReqSample.tsx
+++ b/src/layouts/rest-api/endpoint/playground/try/ReqSample.tsx
@@ -96,7 +96,7 @@ function useTargetInfo(
 ): ReadonlySignal<AvailableTarget | null> {
   return useComputed(
     () =>
-      availableTargets.find((target) => target.key === keySignal.value) || null,
+      availableTargets.find((target) => target.key === keySignal.value) ?? null,
   );
 }
 

--- a/src/layouts/rest-api/endpoint/playground/try/ReqSample.tsx
+++ b/src/layouts/rest-api/endpoint/playground/try/ReqSample.tsx
@@ -108,11 +108,11 @@ function useClientInfo(
     const clientInfo =
       targetInfoSignal.value?.clients.find(
         (client) => client.key === clientKeySignal.value,
-      ) ||
+      ) ??
       targetInfoSignal.value?.clients.find(
         (client) => client.key === targetInfoSignal.value?.default,
-      ) ||
-      targetInfoSignal.value?.clients[0] ||
+      ) ??
+      targetInfoSignal.value?.clients[0] ??
       null;
     if (clientInfo) {
       clientKeySignal.value = clientInfo.key;

--- a/src/layouts/rest-api/endpoint/playground/try/ReqSample.tsx
+++ b/src/layouts/rest-api/endpoint/playground/try/ReqSample.tsx
@@ -64,37 +64,37 @@ export default function ReqSample({ harRequestSignal }: ReqSampleProps) {
   return (
     <Card
       title={
-        <>
-          <div className="flex flex-wrap">
-            <span className="flex-shrink-0">Request Sample{": "}</span>
-            <div className="flex-shrink-0">
-              <select
-                value={targetKeySignal.value}
-                onChange={(e) => {
-                  targetKeySignal.value = String(e.currentTarget.value);
-                }}
-              >
-                {availableTargets.map((target) => (
-                  <option key={target.key} value={target.key}>
-                    {target.title}
-                  </option>
-                ))}
-              </select>
-              <select
-                value={clientKeySignal.value}
-                onChange={(e) =>
-                  (clientKeySignal.value = String(e.currentTarget.value))
-                }
-              >
-                {targetInfoSignal.value?.clients.map((client) => (
-                  <option key={client.key} value={client.key}>
-                    {client.title}
-                  </option>
-                ))}
-              </select>
-            </div>
+        <div className="flex flex-grow flex-wrap items-center justify-between gap-3">
+          <span className="flex-shrink-0">Request Sample</span>
+          <div className="flex-shrink-0">
+            <select
+              className="rounded-l bg-slate-1 px-2 py-1 font-medium"
+              value={targetKeySignal.value}
+              onChange={(e) => {
+                targetKeySignal.value = String(e.currentTarget.value);
+              }}
+            >
+              {availableTargets.map((target) => (
+                <option key={target.key} value={target.key}>
+                  {target.title}
+                </option>
+              ))}
+            </select>
+            <select
+              className="rounded-r bg-slate-1 px-2 py-1 font-medium"
+              value={clientKeySignal.value}
+              onChange={(e) =>
+                (clientKeySignal.value = String(e.currentTarget.value))
+              }
+            >
+              {targetInfoSignal.value?.clients.map((client) => (
+                <option key={client.key} value={client.key}>
+                  {client.title}
+                </option>
+              ))}
+            </select>
           </div>
-        </>
+        </div>
       }
     >
       {snippetSignal.value ? (

--- a/src/layouts/rest-api/endpoint/playground/try/ResExample.tsx
+++ b/src/layouts/rest-api/endpoint/playground/try/ResExample.tsx
@@ -1,15 +1,11 @@
-import type { Operation } from "~/layouts/rest-api/schema-utils/operation";
-
 import JsonViewer from "../../../editor/JsonViewer";
 import Card from "../Card";
 
 export interface ResExampleProps {
-  operation: Operation;
+  example: { [key: string]: unknown };
 }
 
-export default function ResExample({ operation }: ResExampleProps) {
-  const example =
-    operation.responses?.["200"]?.content?.["application/json"]?.example;
+export default function ResExample({ example }: ResExampleProps) {
   return (
     <Card title={`Response Example`}>
       {example ? (

--- a/src/layouts/rest-api/endpoint/playground/try/ResExample.tsx
+++ b/src/layouts/rest-api/endpoint/playground/try/ResExample.tsx
@@ -1,0 +1,22 @@
+import type { Operation } from "~/layouts/rest-api/schema-utils/operation";
+
+import JsonViewer from "../../../editor/JsonViewer";
+import Card from "../Card";
+
+export interface ResExampleProps {
+  operation: Operation;
+}
+
+export default function ResExample({ operation }: ResExampleProps) {
+  const example =
+    operation.responses?.["200"]?.content?.["application/json"]?.example;
+  return (
+    <Card title={`Response Example`}>
+      {example ? (
+        <JsonViewer jsonText={JSON.stringify(example, null, 2) + "\n"} />
+      ) : (
+        <span class="p-4 text-xs text-slate-4 font-bold">N/A</span>
+      )}
+    </Card>
+  );
+}

--- a/src/layouts/rest-api/endpoint/playground/try/ResExample.tsx
+++ b/src/layouts/rest-api/endpoint/playground/try/ResExample.tsx
@@ -2,7 +2,7 @@ import JsonViewer from "../../../editor/JsonViewer";
 import Card from "../Card";
 
 export interface ResExampleProps {
-  example: { [key: string]: unknown };
+  example: { [key: string]: unknown } | undefined;
 }
 
 export default function ResExample({ example }: ResExampleProps) {

--- a/src/layouts/rest-api/endpoint/playground/try/Tabs.tsx
+++ b/src/layouts/rest-api/endpoint/playground/try/Tabs.tsx
@@ -12,9 +12,7 @@ export interface TabsProps<Id extends string> {
 }
 export function Tabs<Id extends string>({ tabs, tabIdSignal }: TabsProps<Id>) {
   const _tabs = tabs.filter(Boolean);
-  const currTabIdSignal = tabIdSignal
-    ? tabIdSignal
-    : useSignal(_tabs[0]?.id || "");
+  const currTabIdSignal = tabIdSignal ?? useSignal(_tabs[0]?.id || "");
   const currTabId = currTabIdSignal.value;
   const currTab = _tabs.find((tab) => tab.id === currTabId);
   return (

--- a/src/layouts/rest-api/endpoint/playground/try/Tabs.tsx
+++ b/src/layouts/rest-api/endpoint/playground/try/Tabs.tsx
@@ -1,4 +1,4 @@
-import { useSignal } from "@preact/signals";
+import { Signal, useSignal } from "@preact/signals";
 import type React from "preact/compat";
 
 export interface Tab<Id extends string> {
@@ -8,10 +8,13 @@ export interface Tab<Id extends string> {
 }
 export interface TabsProps<Id extends string> {
   tabs: (Tab<Id> | false | 0)[];
+  tabIdSignal?: Signal<string | Id>;
 }
-export function Tabs<Id extends string>({ tabs }: TabsProps<Id>) {
+export function Tabs<Id extends string>({ tabs, tabIdSignal }: TabsProps<Id>) {
   const _tabs = tabs.filter(Boolean);
-  const currTabIdSignal = useSignal(_tabs[0]?.id || "");
+  const currTabIdSignal = tabIdSignal
+    ? tabIdSignal
+    : useSignal(_tabs[0]?.id || "");
   const currTabId = currTabIdSignal.value;
   const currTab = _tabs.find((tab) => tab.id === currTabId);
   return (

--- a/src/layouts/rest-api/endpoint/playground/try/Try.tsx
+++ b/src/layouts/rest-api/endpoint/playground/try/Try.tsx
@@ -1,9 +1,11 @@
 import { useSignal } from "@preact/signals";
+import { type HarRequest } from "httpsnippet-lite";
 
 import type { Endpoint } from "../../../schema-utils/endpoint";
 import type { Operation } from "../../../schema-utils/operation";
 import Err from "./Err";
 import Req from "./Req";
+import ReqSample from "./ReqSample";
 import ResComponent, { type Res } from "./Res";
 import ResExample from "./ResExample";
 
@@ -19,14 +21,18 @@ export default function Try(props: TryProps) {
   const errSignal = useSignal("");
   const err = errSignal.value;
   const resSignal = useSignal<Res | undefined>(undefined);
+  const harRequestSignal = useSignal<HarRequest | undefined>(undefined);
+  const example =
+    props.operation.responses?.["200"]?.content?.["application/json"]?.example;
   return (
     <div
-      class={`grid flex-1 grid-rows-3 gap-3 ${
+      class={`grid flex-1 grid-rows-4 gap-3 ${
         waiting ? "pointer-events-none opacity-50" : ""
       }`}
     >
       <Req
         {...props}
+        harRequestSignal={harRequestSignal}
         execute={(fn) =>
           void (async () => {
             try {
@@ -41,8 +47,13 @@ export default function Try(props: TryProps) {
           })()
         }
       />
-      {err ? <Err>{err}</Err> : <ResComponent resSignal={resSignal} />}
-      <ResExample operation={props.operation} />
+      {err ? (
+        <Err>{err}</Err>
+      ) : (
+        resSignal.value && <ResComponent resSignal={resSignal} />
+      )}
+      <ReqSample harRequestSignal={harRequestSignal} />
+      {example && <ResExample example={example} />}
     </div>
   );
 }

--- a/src/layouts/rest-api/endpoint/playground/try/Try.tsx
+++ b/src/layouts/rest-api/endpoint/playground/try/Try.tsx
@@ -5,6 +5,7 @@ import type { Operation } from "../../../schema-utils/operation";
 import Err from "./Err";
 import Req from "./Req";
 import ResComponent, { type Res } from "./Res";
+import ResExample from "./ResExample";
 
 export interface TryProps {
   apiHost: string;
@@ -20,7 +21,7 @@ export default function Try(props: TryProps) {
   const resSignal = useSignal<Res | undefined>(undefined);
   return (
     <div
-      class={`grid flex-1 grid-rows-2 gap-3 ${
+      class={`grid flex-1 grid-rows-3 gap-3 ${
         waiting ? "pointer-events-none opacity-50" : ""
       }`}
     >
@@ -41,6 +42,7 @@ export default function Try(props: TryProps) {
         }
       />
       {err ? <Err>{err}</Err> : <ResComponent resSignal={resSignal} />}
+      <ResExample operation={props.operation} />
     </div>
   );
 }

--- a/src/layouts/rest-api/endpoint/playground/try/Try.tsx
+++ b/src/layouts/rest-api/endpoint/playground/try/Try.tsx
@@ -8,6 +8,7 @@ import Req from "./Req";
 import ReqSample from "./ReqSample";
 import ResComponent, { type Res } from "./Res";
 import ResExample from "./ResExample";
+import { Tabs } from "./Tabs";
 
 export interface TryProps {
   apiHost: string;
@@ -24,36 +25,57 @@ export default function Try(props: TryProps) {
   const harRequestSignal = useSignal<HarRequest | undefined>(undefined);
   const example =
     props.operation.responses?.["200"]?.content?.["application/json"]?.example;
+  const tabIdSignal = useSignal<"request" | "response">("request");
   return (
     <div
-      class={`grid flex-1 grid-rows-4 gap-3 ${
-        waiting ? "pointer-events-none opacity-50" : ""
-      }`}
+      class={`grid grid-rows-[auto_1fr] flex-1 gap-3 ${waiting ? "pointer-events-none opacity-50" : ""}`}
     >
-      <Req
-        {...props}
-        harRequestSignal={harRequestSignal}
-        execute={(fn) =>
-          void (async () => {
-            try {
-              waitingSignal.value = true;
-              resSignal.value = await fn();
-              errSignal.value = "";
-            } catch (err) {
-              errSignal.value = (err as Error).message;
-            } finally {
-              waitingSignal.value = false;
-            }
-          })()
-        }
-      />
-      {err ? (
-        <Err>{err}</Err>
-      ) : (
-        resSignal.value && <ResComponent resSignal={resSignal} />
-      )}
-      <ReqSample harRequestSignal={harRequestSignal} />
-      {example && <ResExample example={example} />}
+      <Tabs
+        tabIdSignal={tabIdSignal}
+        tabs={[
+          {
+            id: "request",
+            label: "request",
+            render: (key) => (
+              <div key={key} class="grid grid-rows-2 h-full gap-3">
+                <Req
+                  {...props}
+                  harRequestSignal={harRequestSignal}
+                  execute={(fn) =>
+                    void (async () => {
+                      try {
+                        waitingSignal.value = true;
+                        resSignal.value = await fn();
+                        errSignal.value = "";
+                      } catch (err) {
+                        errSignal.value = (err as Error).message;
+                      } finally {
+                        waitingSignal.value = false;
+                        tabIdSignal.value = "response";
+                      }
+                    })()
+                  }
+                />
+                <ReqSample harRequestSignal={harRequestSignal} />
+              </div>
+            ),
+          },
+          {
+            id: "response",
+            label: "response",
+            render: (key) => (
+              <div key={key} class="grid grid-rows-2 h-full gap-3">
+                {err ? (
+                  <Err>{err}</Err>
+                ) : (
+                  <ResComponent resSignal={resSignal} />
+                )}
+                <ResExample example={example} />
+              </div>
+            ),
+          },
+        ]}
+      ></Tabs>
     </div>
   );
 }

--- a/src/layouts/rest-api/schema-utils/operation.ts
+++ b/src/layouts/rest-api/schema-utils/operation.ts
@@ -74,7 +74,7 @@ export function getBodyParameters(
   operation: Operation,
 ): Parameter[] {
   const { schema: requestSchema, example } =
-    operation.requestBody?.content["application/json"] || {};
+    operation.requestBody?.content["application/json"] ?? {};
   if (requestSchema) return bakeProperties(schema, requestSchema, example);
   return (
     operation.parameters?.filter((p) => p.in !== "path" && p.in !== "query") ||

--- a/src/layouts/rest-api/schema-utils/operation.ts
+++ b/src/layouts/rest-api/schema-utils/operation.ts
@@ -13,7 +13,14 @@ export interface Operation {
   summary?: string | undefined;
   description?: string | undefined;
   requestBody?:
-    | { content: { "application/json": { schema: TypeDef } } }
+    | {
+        content: {
+          "application/json": {
+            schema: TypeDef;
+            example?: { [key: string]: unknown };
+          };
+        };
+      }
     | undefined;
   parameters?: Parameter[] | undefined;
   responses: { [statusCode: number]: Response };
@@ -36,7 +43,12 @@ export interface Parameter extends Property {
 export interface Response {
   description?: string | undefined;
   schema?: TypeDef | undefined;
-  content?: { "application/json": { schema: TypeDef } };
+  content?: {
+    "application/json": {
+      schema: TypeDef;
+      example?: { [key: string]: unknown };
+    };
+  };
 }
 
 export function getOperation(
@@ -61,9 +73,9 @@ export function getBodyParameters(
   schema: unknown,
   operation: Operation,
 ): Parameter[] {
-  const requestSchema =
-    operation.requestBody?.content["application/json"]?.schema;
-  if (requestSchema) return bakeProperties(schema, requestSchema);
+  const { schema: requestSchema, example } =
+    operation.requestBody?.content["application/json"] || {};
+  if (requestSchema) return bakeProperties(schema, requestSchema, example);
   return (
     operation.parameters?.filter((p) => p.in !== "path" && p.in !== "query") ||
     []

--- a/src/layouts/rest-api/schema-utils/type-def.ts
+++ b/src/layouts/rest-api/schema-utils/type-def.ts
@@ -40,6 +40,7 @@ export interface Property {
   format?: string | undefined;
   items?: string | TypeDef | undefined;
   deprecated?: boolean | undefined;
+  example?: unknown;
   /**
    * @deprecated use `x-portone-title`
    */
@@ -64,6 +65,7 @@ export interface BakedProperty extends Property {
 export function bakeProperties(
   schema: unknown,
   typeDef: TypeDef,
+  example?: { [key: string]: unknown },
 ): BakedProperty[] {
   filter: if (!typeDef.$ref && typeDef.type) {
     switch (typeDef.type) {
@@ -81,7 +83,14 @@ export function bakeProperties(
     const resolvedProperty = resolveTypeDef(schema, property);
     const type = $ref ? getTypenameByRef($ref) : resolvedProperty.type;
     const required = resolvedDef.required?.includes(name);
-    return { ...resolvedProperty, $ref, type, name, required } as BakedProperty;
+    return {
+      ...resolvedProperty,
+      $ref,
+      type,
+      name,
+      required,
+      example: example?.[name],
+    } as BakedProperty;
   });
 }
 


### PR DESCRIPTION
### 작업 내용
- `openapi.json` 스키마에 정의되어 있는 `example` 프로퍼티로 예시 응답을 보여주는 `ResExample` 컴포넌트를 구현했습니다.
- Try 요청 초기값이 `example` 프로퍼티 값으로 설정되도록 했고, `string` 타입의 기본 값을 빈 문자열에서 파라미터 이름으로 변경했습니다.
- `Parameter["type"]`이 `falsy`일 경우에 `Parameter["schema"]["type"]` 값으로 타입이 결정되지 않고 `object`로 잘못 설정되는 버그를 수정했습니다.
- [httpsnippet-lite](https://github.com/P0lip/httpsnippet) 라이브러리를 사용해서 Try 요청을 다양한 코드 샘플로 보여주는 `ReqSample` 컴포넌트를 구현했습니다.
- Try 응답 결과를 보여주는 컴포넌트를 기본적으로 비활성화 하고, 요청을 실행했을 때 표시하도록 변경했습니다.

### 설명
- Example 섹션을 별도로 만들기 보다는, 기존에 사용하고 있던 Try 섹션에서 예시 파라미터 값을 보여주는 방향이 공간 효율적이고, 에디터로 수정할 수 있으면서 복사도 용이하기 때문에 DX면에서 더 좋다고 판단했습니다.
- 응답 결과를 보여주는 컴포넌트를 기본적으로 비활성화 한 이유는, 이렇게 하면 요청 에디터와 요청 샘플을 나란히 표시할 수 있고, 응답 결과 자체가 사용자가 실행 버튼을 누르는 Action이 있어야 생성되는 데이터이기 때문에 굳이 N/A 형태로 표시할 이유가 없다고 판단했기 때문입니다.
- `string` 타입의 기본값을 파라미터 이름으로 설정한 이유는 요청 샘플에서 `string` 타입의 Path 파라미터를 처리하기가 곤란했기 때문입니다. 가령, [/payments/{paymentId}/cash-receipt](https://developers-git-feature-openapi-examples-portone.vercel.app/api/rest-v2/cashReceipt?v=v1#get%20%2Fpayments%2F%7BpaymentId%7D%2Fcash-receipt) 엔드포인트의 경우에는 `paymentId` 파라미터가 빈 문자열이면 `/payments//cash-receipt` 형태로 샘플 코드가 생성되기 때문에 이를 방지하기 위해 기본값을 파라미터 이름으로 설정했습니다.