### PR TITLE
fix: V2 KSNET 가이드 productType 내용 업데이트

### DIFF
--- a/src/content/docs/ko/v2-payment/pg/ksnet.mdx
+++ b/src/content/docs/ko/v2-payment/pg/ksnet.mdx
@@ -221,21 +221,20 @@ KSNET 기준으로 작성한 예시 코드는 아래와 같습니다.
 
 ### API 결제
 
-- `product_type`
+- `productType`
   - 판매 상품에 대한 상품 유형 파라미터로 API 결제 시 필수로 입력해야 합니다.
-  - `PRODUCT_TYPE_REAL`: 실물 상품
-  - `PRODUCT_TYPE_DIGITAL` : 디지털 상품
+  - `PHYSICAL`: 실물 상품
+  - `DIGITAL` : 디지털 상품
 
 ### SDK 결제 (`requestPayment`)
 
-- `product_type`
+- `productType`
+  - 휴대폰 결제인 경우 필수로 입력해야 하며, KSNET의 상점아이디에 설정된 상품 유형과 일치해야합니다.
+    디지털 상품유형으로 설정된 경우 항상 `PRODUCT_TYPE_DIGITAL`로 입력해야 합니다.
 
-  - 판매 상품에 대한 상품 유형 파라미터로 API 결제 시 필수로 입력해야 합니다.
-    - `PRODUCT_TYPE_REAL`: 실물 상품
-    - `PRODUCT_TYPE_DIGITAL` : 디지털 상품
+  - `PRODUCT_TYPE_REAL`: 실물 상품
 
-  - 휴대폰 결제인 경우 필수로 입력해야 하며, KSNET의 상점아이디에 설정된 상품 유형과 일치해야
-    합니다. 디지털 상품유형으로 설정된 경우 항상 `PRODUCT_TYPE_DIGITAL`로 입력해야 합니다.
+  - `PRODUCT_TYPE_DIGITAL` : 디지털 상품
 
 - `bypass.ksnet.sndQpayType` <mark style="color:green;">**string**</mark>
   - 카드 결제 시 결제창에 간편 결제 수단 표시 여부를 설정할 수 있습니다.


### PR DESCRIPTION
V2 KSNET 연동가이드 중 productType 필드에 대한 설명이 잘못 기입된 부분이 있어서 수정합니다.