### PR TITLE
<Details> 내부 레이아웃을 flex에서 grid로 변경

### DIFF
--- a/src/components/gitbook/Details.astro
+++ b/src/components/gitbook/Details.astro
@@ -30,8 +30,10 @@ const { id } = Astro.props;
       <slot name="summary" />
     </div>
   </summary>
-  <div class="flex gap-3 border-l-4 border-l-transparent px-4 pb-2 -mt-2">
-    <div class="h-5 w-5 shrink-0"></div>
+  <div
+    class="grid grid-cols-[auto_minmax(0,1fr)] gap-3 border-l-4 border-l-transparent px-4 pb-2 -mt-2"
+  >
+    <div class="h-5 w-5"></div>
     <div class="w-full">
       <slot />
     </div>


### PR DESCRIPTION
closes #352 
![image](https://github.com/portone-io/developers.portone.io/assets/17797795/73e8df35-b76e-4507-b197-4beb1f2a743d)

Link: https://developers-8qtiz9ivg-portone.vercel.app/docs/ko/v2-payment/pg/paypal-v2?v=v2#%EC%A0%95%EA%B8%B0%EA%B2%B0%EC%A0%9C-%EC%9C%A0%EC%9D%98%EC%82%AC%ED%95%AD