### PR TITLE
`x-portone-query-or-body` 대응

### DIFF
--- a/src/layouts/rest-api/editor/RequestJsonEditor.tsx
+++ b/src/layouts/rest-api/editor/RequestJsonEditor.tsx
@@ -96,11 +96,12 @@ export function getReqParams(
   schema: unknown,
   operation: Operation,
   part: RequestPart,
+  isQueryOrBody: boolean,
 ): Parameter[] {
   return part === "path"
     ? getPathParameters(operation)
     : part === "query"
-      ? getQueryParameters(operation)
+      ? getQueryParameters(operation, isQueryOrBody)
       : getBodyParameters(schema, operation);
 }
 

--- a/src/layouts/rest-api/endpoint/EndpointDoc.tsx
+++ b/src/layouts/rest-api/endpoint/EndpointDoc.tsx
@@ -11,6 +11,7 @@ import {
   getPathParameters,
   getQueryParameters,
   getResponseSchemata,
+  isQueryOrBodyOperation,
   type Operation,
   type Parameter,
 } from "../schema-utils/operation";
@@ -143,8 +144,9 @@ interface RequestDocProps {
   operation: Operation;
 }
 function RequestDoc({ basepath, schema, operation }: RequestDocProps) {
+  const isQueryOrBody = isQueryOrBodyOperation(operation);
   const pathParameters = getPathParameters(operation);
-  const queryParameters = getQueryParameters(operation);
+  const queryParameters = getQueryParameters(operation, isQueryOrBody);
   const bodyParameters = getBodyParameters(schema, operation);
   const showPath = pathParameters.length > 0;
   const showQuery = queryParameters.length > 0;

--- a/src/layouts/rest-api/endpoint/EndpointDoc.tsx
+++ b/src/layouts/rest-api/endpoint/EndpointDoc.tsx
@@ -157,6 +157,12 @@ function RequestDoc({ basepath, schema, operation }: RequestDocProps) {
         <prose.h4 class="border-b pb-1" style={{ marginTop: 0 }}>
           Request
         </prose.h4>
+        {isQueryOrBody && (
+          <prose.h5 class="text-slate-5">
+            body를 쿼리 문자열에 포함시켜 보낼 수 있습니다.{" "}
+            <prose.a href="#get-with-body">자세히 보기</prose.a>
+          </prose.h5>
+        )}
         {showPath && (
           <ReqParameters
             basepath={basepath}

--- a/src/layouts/rest-api/endpoint/playground/try/Req.tsx
+++ b/src/layouts/rest-api/endpoint/playground/try/Req.tsx
@@ -49,7 +49,12 @@ export default function Req({
   ]);
   const isQueryOrBody = isQueryOrBodyOperation(operation);
   const reqPathParams = useReqParams(schema, operation, "path");
-  const reqQueryParams = useReqParams(schema, operation, "query");
+  const reqQueryParams = useReqParams(
+    schema,
+    operation,
+    "query",
+    isQueryOrBody,
+  );
   const reqBodyParams = useReqParams(schema, operation, "body");
   useSignalEffect(() => {
     harRequestSignal.value = createHarRequest(
@@ -177,9 +182,10 @@ function useReqParams(
   schema: unknown,
   operation: Operation,
   part: RequestPart,
+  isQueryOrBody: boolean = false,
 ): ReqParams {
   return useMemo(() => {
-    const params = getReqParams(schema, operation, part);
+    const params = getReqParams(schema, operation, part, isQueryOrBody);
     const reqSchema: ReqSchema = {
       type: "object",
       properties: Object.fromEntries(

--- a/src/layouts/rest-api/endpoint/playground/try/ReqSample.tsx
+++ b/src/layouts/rest-api/endpoint/playground/try/ReqSample.tsx
@@ -24,8 +24,6 @@ export interface ReqSampleProps {
 
 const httpSnippetLanguageMap = new Map(
   Object.entries({
-    c: "c",
-    clojure: "clojure",
     csharp: "csharp",
     go: "go",
     java: "java",
@@ -34,9 +32,7 @@ const httpSnippetLanguageMap = new Map(
     node: "javascript",
     objc: "objective-c",
     php: "php",
-    powershell: "powershell",
     python: "python",
-    r: "r",
     ruby: "ruby",
     shell: "shell",
     swift: "swift",

--- a/src/layouts/rest-api/endpoint/playground/try/ReqSample.tsx
+++ b/src/layouts/rest-api/endpoint/playground/try/ReqSample.tsx
@@ -20,34 +20,52 @@ import Card from "../Card";
 
 export interface ReqSampleProps {
   harRequestSignal: Signal<HarRequest | undefined>;
+  isQueryOrBody: boolean;
 }
 
-const httpSnippetLanguageMap = new Map(
-  Object.entries({
-    csharp: "csharp",
-    go: "go",
-    java: "java",
-    javascript: "javascript",
-    kotlin: "kotlin",
-    node: "javascript",
-    objc: "objective-c",
-    php: "php",
-    python: "python",
-    ruby: "ruby",
-    shell: "shell",
-    swift: "swift",
-  }),
-);
+const httpSnippetLanguageMap = new Map([
+  ["csharp", "csharp"],
+  ["go", "go"],
+  ["java", "java"],
+  ["javascript", "javascript"],
+  ["kotlin", "kotlin"],
+  ["node", "javascript"],
+  ["objc", "objective-c"],
+  ["php", "php"],
+  ["python", "python"],
+  ["ruby", "ruby"],
+  ["shell", "shell"],
+  ["swift", "swift"],
+]);
+const supportGetWithBodyTargetMap: Map<string, Set<string>> = new Map([
+  ["go", new Set(["native"])],
+  ["java", new Set(["asynchttp", "nethttp"])],
+  ["node", new Set(["native", "request", "unirest"])],
+  ["php", new Set(["curl", "guzzle", "http2"])],
+  ["python", new Set(["python3", "requests"])],
+  ["ruby", new Set(["native"])],
+  ["shell", new Set(["curl", "httpie", "wget"])],
+]);
 const availableTargets = _availableTargets()
   .map((target) => ({
     ...target,
     language: httpSnippetLanguageMap.get(target.key),
+    clients: target.clients.map((client) => ({
+      ...client,
+      supportGetWithBody:
+        supportGetWithBodyTargetMap
+          .get(httpSnippetLanguageMap.get(target.key)!)
+          ?.has(client.key) ?? false,
+    })),
   }))
   .filter((target) => target.language);
 type AvailableTarget = (typeof availableTargets)[number];
 type ClientInfo = AvailableTarget["clients"][number];
 
-export default function ReqSample({ harRequestSignal }: ReqSampleProps) {
+export default function ReqSample({
+  harRequestSignal,
+  isQueryOrBody,
+}: ReqSampleProps) {
   const targetKeySignal = useSignal("shell");
   const clientKeySignal = useSignal("curl");
   const targetInfoSignal = useTargetInfo(targetKeySignal);
@@ -56,6 +74,7 @@ export default function ReqSample({ harRequestSignal }: ReqSampleProps) {
     harRequestSignal,
     targetInfoSignal,
     clientInfoSignal,
+    isQueryOrBody,
   );
 
   return (
@@ -149,18 +168,19 @@ function useClientInfo(
 
 function useHTTPSnippet(
   harRequestSignal: Signal<HarRequest | undefined>,
-  targetIdSignal: ReadonlySignal<AvailableTarget | null>,
-  clientIdSignal: ReadonlySignal<ClientInfo | null>,
+  targetSignal: ReadonlySignal<AvailableTarget | null>,
+  clientSignal: ReadonlySignal<ClientInfo | null>,
+  isQueryOrBody: boolean,
 ): Signal<string | null> {
   const snippetSignal = useSignal<string | null>(null);
   useSignalEffect(() => {
-    if (
-      harRequestSignal.value &&
-      targetIdSignal.value &&
-      clientIdSignal.value
-    ) {
-      new HTTPSnippet(harRequestSignal.value)
-        .convert(targetIdSignal.value.key, clientIdSignal.value.key)
+    if (harRequestSignal.value && targetSignal.value && clientSignal.value) {
+      const harRequest =
+        isQueryOrBody && !clientSignal.value.supportGetWithBody
+          ? transformHarRequestBodyToQs(harRequestSignal.value)
+          : harRequestSignal.value;
+      new HTTPSnippet(harRequest)
+        .convert(targetSignal.value.key, clientSignal.value.key)
         .then((snippet) => {
           if (Array.isArray(snippet)) {
             snippet = snippet.join("\n");
@@ -175,4 +195,19 @@ function useHTTPSnippet(
     }
   });
   return snippetSignal;
+}
+
+function transformHarRequestBodyToQs(harRequest: HarRequest): HarRequest {
+  if (!harRequest.postData) return harRequest;
+  if (!harRequest.postData.text) return harRequest;
+  if (harRequest.postData.mimeType !== "application/json") return harRequest;
+  const transformed = {
+    ...harRequest,
+    queryString: [
+      { name: "requestBody", value: harRequest.postData.text },
+      ...harRequest.queryString,
+    ],
+  } satisfies HarRequest;
+  delete transformed.postData;
+  return transformed;
 }

--- a/src/layouts/rest-api/endpoint/playground/try/Try.tsx
+++ b/src/layouts/rest-api/endpoint/playground/try/Try.tsx
@@ -2,7 +2,10 @@ import { useSignal } from "@preact/signals";
 import { type HarRequest } from "httpsnippet-lite";
 
 import type { Endpoint } from "../../../schema-utils/endpoint";
-import type { Operation } from "../../../schema-utils/operation";
+import {
+  isQueryOrBodyOperation,
+  type Operation,
+} from "../../../schema-utils/operation";
 import Err from "./Err";
 import Req from "./Req";
 import ReqSample from "./ReqSample";
@@ -26,6 +29,7 @@ export default function Try(props: TryProps) {
   const example =
     props.operation.responses?.["200"]?.content?.["application/json"]?.example;
   const tabIdSignal = useSignal<"request" | "response">("request");
+  const isQueryOrBody = isQueryOrBodyOperation(props.operation);
   return (
     <div
       class={`grid grid-rows-[auto_1fr] flex-1 gap-3 ${waiting ? "pointer-events-none opacity-50" : ""}`}
@@ -56,7 +60,10 @@ export default function Try(props: TryProps) {
                     })()
                   }
                 />
-                <ReqSample harRequestSignal={harRequestSignal} />
+                <ReqSample
+                  harRequestSignal={harRequestSignal}
+                  isQueryOrBody={isQueryOrBody}
+                />
               </div>
             ),
           },

--- a/src/layouts/rest-api/misc/SchemaDownloadButton.tsx
+++ b/src/layouts/rest-api/misc/SchemaDownloadButton.tsx
@@ -2,7 +2,10 @@ import type React from "preact/compat";
 import { createRef } from "preact/compat";
 
 import { getEveryEndpoints } from "../schema-utils/endpoint";
-import { getOperation } from "../schema-utils/operation";
+import {
+  getOperation,
+  isQueryOrBodyOperation,
+} from "../schema-utils/operation";
 
 export interface SchemaDownloadButtonProps {
   href: string;
@@ -49,9 +52,7 @@ async function downloadSchema(href: string) {
   getEveryEndpoints(schema)
     .map((endpoint) => getOperation(schema, endpoint))
     .filter(({ parameters }) => parameters !== undefined)
-    .filter(({ parameters }) =>
-      parameters!.some((parameter) => "x-portone-query-or-body" in parameter),
-    )
+    .filter(isQueryOrBodyOperation)
     .forEach((operation) => {
       delete operation.requestBody;
       operation.parameters!.forEach((parameter) => {

--- a/src/layouts/rest-api/misc/SchemaDownloadButton.tsx
+++ b/src/layouts/rest-api/misc/SchemaDownloadButton.tsx
@@ -1,73 +1,31 @@
 import type React from "preact/compat";
-import { createRef } from "preact/compat";
-
-import { getEveryEndpoints } from "../schema-utils/endpoint";
-import {
-  getOperation,
-  isQueryOrBodyOperation,
-} from "../schema-utils/operation";
 
 export interface SchemaDownloadButtonProps {
   href: string;
   label: React.ReactNode;
   children: React.ReactNode;
+  download: string;
 }
 export default function SchemaDownloadButton({
   href,
   label,
   children,
+  download,
 }: SchemaDownloadButtonProps) {
-  const downloadRef = createRef<HTMLAnchorElement>();
   return (
     <div class="flex flex-col items-start gap-1 text-14px">
       <a
-        ref={downloadRef}
-        class="hidden"
-        download="portone-api-schema.json"
+        download={download}
         target="_blank"
-      ></a>
-      <button
-        type="button"
+        href={href}
         class="inline-flex items-center gap-2 rounded bg-slate-1 p-2 pr-3 font-bold hover:bg-slate-2"
-        onClick={() =>
-          void (async () => {
-            const schema = await downloadSchema(href);
-            const blob = new Blob([JSON.stringify(schema)], {
-              type: "application/json",
-            });
-            const url = URL.createObjectURL(blob);
-            const a = downloadRef.current!;
-            a.href = url;
-            a.click();
-          })()
-        }
       >
         <i class="i-ic-baseline-download text-xl" />
         {label}
-      </button>
+      </a>
       {children}
     </div>
   );
-}
-
-async function downloadSchema(href: string) {
-  const response = await fetch(href);
-  const schema = (await response.json()) as unknown;
-  getEveryEndpoints(schema)
-    .map((endpoint) => getOperation(schema, endpoint))
-    .filter(({ parameters }) => parameters !== undefined)
-    .filter(isQueryOrBodyOperation)
-    .forEach((operation) => {
-      delete operation.requestBody;
-      operation.parameters!.forEach((parameter) => {
-        if ("x-portone-query-or-body" in parameter) {
-          const { required } = parameter["x-portone-query-or-body"]!;
-          if (required) parameter.required = true;
-          delete parameter["x-portone-query-or-body"];
-        }
-      });
-    });
-  return schema;
 }
 
 export interface PostmanGuideProps {

--- a/src/layouts/rest-api/misc/SchemaDownloadButton.tsx
+++ b/src/layouts/rest-api/misc/SchemaDownloadButton.tsx
@@ -20,7 +20,12 @@ export default function SchemaDownloadButton({
   const downloadRef = createRef<HTMLAnchorElement>();
   return (
     <div class="flex flex-col items-start gap-1 text-14px">
-      <a ref={downloadRef} class="hidden"></a>
+      <a
+        ref={downloadRef}
+        class="hidden"
+        download="portone-api-schema.json"
+        target="_blank"
+      ></a>
       <button
         type="button"
         class="inline-flex items-center gap-2 rounded bg-slate-1 p-2 pr-3 font-bold hover:bg-slate-2"
@@ -33,7 +38,6 @@ export default function SchemaDownloadButton({
             const url = URL.createObjectURL(blob);
             const a = downloadRef.current!;
             a.href = url;
-            a.download = "schema.json";
             a.click();
           })()
         }

--- a/src/layouts/rest-api/schema-utils/operation.ts
+++ b/src/layouts/rest-api/schema-utils/operation.ts
@@ -66,7 +66,11 @@ export function getPathParameters(operation: Operation): Parameter[] {
 }
 
 export function getQueryParameters(operation: Operation): Parameter[] {
-  return operation.parameters?.filter((p) => p.in === "query") || [];
+  return (
+    operation.parameters
+      ?.filter((p) => p.in === "query")
+      .filter((p) => p.name !== "requestBody") || []
+  );
 }
 
 export function getBodyParameters(

--- a/src/layouts/rest-api/schema-utils/operation.ts
+++ b/src/layouts/rest-api/schema-utils/operation.ts
@@ -82,6 +82,12 @@ export function getBodyParameters(
   );
 }
 
+export function isQueryOrBodyOperation(operation: Operation): boolean {
+  return (
+    operation.parameters?.some((p) => "x-portone-query-or-body" in p) || false
+  );
+}
+
 export type ResponseSchemata = ResponseSchema[];
 export type ResponseSchema = [
   string /* statusCode */,

--- a/src/layouts/rest-api/schema-utils/operation.ts
+++ b/src/layouts/rest-api/schema-utils/operation.ts
@@ -65,12 +65,15 @@ export function getPathParameters(operation: Operation): Parameter[] {
   return operation.parameters?.filter((p) => p.in === "path") || [];
 }
 
-export function getQueryParameters(operation: Operation): Parameter[] {
-  return (
-    operation.parameters
-      ?.filter((p) => p.in === "query")
-      .filter((p) => p.name !== "requestBody") || []
-  );
+export function getQueryParameters(
+  operation: Operation,
+  isQueryOrBody: boolean,
+): Parameter[] {
+  const parameters =
+    operation.parameters?.filter((p) => p.in === "query") || [];
+  return isQueryOrBody
+    ? parameters.filter((p) => p.name !== "requestBody")
+    : parameters;
 }
 
 export function getBodyParameters(

--- a/src/layouts/rest-api/schema-utils/type-def.ts
+++ b/src/layouts/rest-api/schema-utils/type-def.ts
@@ -48,6 +48,12 @@ export interface Property {
   "x-portone-title"?: string | undefined;
   "x-portone-summary"?: string | undefined;
   "x-portone-description"?: string | undefined;
+  "x-portone-query-or-body"?:
+    | {
+        enabled: boolean;
+        required: boolean;
+      }
+    | undefined;
 }
 
 export type TypeDefKind = "object" | "union" | "enum";

--- a/src/pages/api/rest-v1/_Page.tsx
+++ b/src/pages/api/rest-v1/_Page.tsx
@@ -39,7 +39,8 @@ export default function RestV1(props: RestV1Props) {
       <prose.p>
         <SchemaDownloadButton
           label="Swagger JSON 내려받기"
-          href="https://raw.githubusercontent.com/portone-io/developers.portone.io/main/src/schema/v1.openapi.json"
+          href="/api/schema/v1.openapi.json"
+          download="portone-v1-swagger.json"
         >
           <PostmanGuide href="https://learning.postman.com/docs/getting-started/importing-and-exporting/importing-from-swagger/" />
         </SchemaDownloadButton>

--- a/src/pages/api/rest-v2/_Page.tsx
+++ b/src/pages/api/rest-v2/_Page.tsx
@@ -77,6 +77,15 @@ export default function RestV2(props: RestV2Props) {
         </li>
       </ul>
       액세스 토큰을 사용한 인증을 원하는 경우, 인증 관련 API를 이용해 주세요.
+      <prose.h3 id="get-with-body">GET 요청 시 Body 대신 Query 사용</prose.h3>
+      <prose.p>
+        GET 요청 시에 Body를 사용해야 하는 경우, Body 대신 Query를 사용할 수
+        있습니다.
+      </prose.p>
+      <prose.p>
+        이 경우, Body 객체를 <code>requestBody</code> Query 필드에 넣어주시면
+        됩니다.
+      </prose.p>
     </RestApi>
   );
 }

--- a/src/pages/api/rest-v2/_Page.tsx
+++ b/src/pages/api/rest-v2/_Page.tsx
@@ -35,7 +35,8 @@ export default function RestV2(props: RestV2Props) {
       <prose.p>
         <SchemaDownloadButton
           label="OpenAPI JSON 내려받기"
-          href="https://raw.githubusercontent.com/portone-io/developers.portone.io/main/src/schema/v2.openapi.json"
+          href="/api/schema/v2.openapi.json"
+          download="portone-v2-openapi.json"
         >
           <PostmanGuide href="https://learning.postman.com/docs/integrations/available-integrations/working-with-openAPI/" />
         </SchemaDownloadButton>

--- a/src/pages/api/schema/[version].openapi.json.ts
+++ b/src/pages/api/schema/[version].openapi.json.ts
@@ -22,10 +22,10 @@ const schemaMap = new Map(
   }),
 );
 
-export const GET: APIRoute = ({ params, redirect }) => {
+export const GET: APIRoute = ({ params }) => {
   const { version } = params;
   const schema = schemaMap.get(version ?? "");
-  if (!schema) return redirect("/404");
+  if (!schema) return new Response(null, { status: 404 });
 
   return new Response(schema, {
     headers: {

--- a/src/pages/api/schema/[version].openapi.json.ts
+++ b/src/pages/api/schema/[version].openapi.json.ts
@@ -1,0 +1,53 @@
+import type { APIRoute } from "astro";
+
+import { getEveryEndpoints } from "~/layouts/rest-api/schema-utils/endpoint";
+import {
+  getOperation,
+  isQueryOrBodyOperation,
+} from "~/layouts/rest-api/schema-utils/operation";
+
+import v1Schema from "../../../schema/v1.openapi.json";
+import v2Schema from "../../../schema/v2.openapi.json";
+
+export const prerender = true;
+
+export function getStaticPaths() {
+  return [{ params: { version: "v1" } }, { params: { version: "v2" } }];
+}
+
+const schemaMap = new Map(
+  Object.entries({
+    v1: JSON.stringify(transformSchema(v1Schema)),
+    v2: JSON.stringify(transformSchema(v2Schema)),
+  }),
+);
+
+export const GET: APIRoute = ({ params, redirect }) => {
+  const { version } = params;
+  const schema = schemaMap.get(version ?? "");
+  if (!schema) return redirect("/404");
+
+  return new Response(schema, {
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+};
+
+function transformSchema(schema: unknown): unknown {
+  getEveryEndpoints(schema)
+    .map((endpoint) => getOperation(schema, endpoint))
+    .filter(({ parameters }) => parameters !== undefined)
+    .filter(isQueryOrBodyOperation)
+    .forEach((operation) => {
+      delete operation.requestBody;
+      operation.parameters!.forEach((parameter) => {
+        if ("x-portone-query-or-body" in parameter) {
+          const { required } = parameter["x-portone-query-or-body"]!;
+          if (required) parameter.required = true;
+          delete parameter["x-portone-query-or-body"];
+        }
+      });
+    });
+  return schema;
+}


### PR DESCRIPTION
closes #427 

- Astro endpoint 기능으로 트랜스폼된 api 스키마를 다운로드 받을 수 있는 정적 링크 구현
- Operation 내에 `x-portone-query-or-body` 속성의 Parameter가 있으면 언어 / 라이브러리에 따라 Body 객체를 `requestBody` 쿼리로 보내거나 GET with Body로 보내도록 구현
- API 엔드포인트 문서에 `requestBody` 관련 설명 추가