### PR TITLE
eslint 스크립트 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 		"typecheck": "astro check",
 		"lint:fix": "NODE_OPTIONS=\"$NODE_OPTIONS --loader ts-node/esm\" eslint --fix .",
 		"lint": "NODE_OPTIONS=\"$NODE_OPTIONS --loader ts-node/esm\" eslint .",
+		"eslint": "NODE_OPTIONS=\"$NODE_OPTIONS --loader ts-node/esm\" eslint",
 		"build": "astro build",
 		"preview": "astro preview",
 		"astro": "astro"


### PR DESCRIPTION
closes #460 

ts-node 도입 이후, 기존 `pnpm eslint` 명령어를 사용하려면 수동으로 `NODE_OPTIONS` 환경변수를 설정해야 하는 문제가 있어 이를 해결하기 위해 package.json에 `eslint` 스크립트를 구현하는 PR입니다.