### PR TITLE
더이상 지원하지 않는 PG사(syrup, kakao, payple) 목록 삭제

### DIFF
--- a/src/content/docs/en/tips/pg-codes.mdx
+++ b/src/content/docs/en/tips/pg-codes.mdx
@@ -17,7 +17,6 @@ description: JavaScript SDK PG codes
 |           Danal payment           | `danal_tpay` |
 |   Mobilians mobile micropayment   |   mobilians  |
 |          CHAI Simple Pay          |    `chai`    |
-|             Syrup Pay             |    `syrup`   |
 |               Payco               |    `payco`   |
 |               PayPal              |   `paypal`   |
 |              Eximbay              |   `eximbay`  |

--- a/src/content/docs/ko/api-v2/billing-key.mdx
+++ b/src/content/docs/ko/api-v2/billing-key.mdx
@@ -258,7 +258,7 @@ import Tabs from "~/components/gitbook/tabs/Tabs.astro";
 
         결제대행사(PG사)
 
-        `"HTML5_INICIS"`, `"PAYPAL"`, `"PAYPAL_V2"`, `"INICIS"`, `"DANAL"`, `"NICE"`, `"DANAL_TPAY"`, `"UPLUS"`, `"NAVERPAY"`, `"KAKAO"`, `"SETTLE"`, `"KCP"`, `"MOBILIANS"`, `"KAKAOPAY"`, `"NAVERCO"`, `"SYRUP"`, `"KICC"`, `"EXIMBAY"`, `"SMILEPAY"`, `"PAYCO"`, `"KCP_BILLING"`, `"PAYPLE"`, `"CHAI"`, `"SMARTRO"`, `"SMARTRO_V2"`, `"PAYMENTWALL"`, `"TOSSPAYMENTS"`, `"KCP_QUICK"`, `"DAOU"`, `"GALAXIA"`, `"TOSSPAY"`, `"KCP_DIRECT"`, `"SETTLE_ACC"`, `"SETTLE_FIRM"`, `"INICIS_UNIFIED"`, `"KSNET"`, `"PINPAY"`
+        `"HTML5_INICIS"`, `"PAYPAL"`, `"PAYPAL_V2"`, `"INICIS"`, `"DANAL"`, `"NICE"`, `"DANAL_TPAY"`, `"UPLUS"`, `"NAVERPAY"`, `"SETTLE"`, `"KCP"`, `"MOBILIANS"`, `"KAKAOPAY"`, `"NAVERCO"`, `"KICC"`, `"EXIMBAY"`, `"SMILEPAY"`, `"PAYCO"`, `"KCP_BILLING"`, `"CHAI"`, `"SMARTRO"`, `"SMARTRO_V2"`, `"PAYMENTWALL"`, `"TOSSPAYMENTS"`, `"KCP_QUICK"`, `"DAOU"`, `"GALAXIA"`, `"TOSSPAY"`, `"KCP_DIRECT"`, `"SETTLE_ACC"`, `"SETTLE_FIRM"`, `"INICIS_UNIFIED"`, `"KSNET"`, `"PINPAY"`
 
         ---
 
@@ -1183,7 +1183,7 @@ import Tabs from "~/components/gitbook/tabs/Tabs.astro";
 
         결제대행사(PG사)
 
-        `"HTML5_INICIS"`, `"PAYPAL"`, `"PAYPAL_V2"`, `"INICIS"`, `"DANAL"`, `"NICE"`, `"DANAL_TPAY"`, `"UPLUS"`, `"NAVERPAY"`, `"KAKAO"`, `"SETTLE"`, `"KCP"`, `"MOBILIANS"`, `"KAKAOPAY"`, `"NAVERCO"`, `"SYRUP"`, `"KICC"`, `"EXIMBAY"`, `"SMILEPAY"`, `"PAYCO"`, `"KCP_BILLING"`, `"PAYPLE"`, `"CHAI"`, `"SMARTRO"`, `"SMARTRO_V2"`, `"PAYMENTWALL"`, `"TOSSPAYMENTS"`, `"KCP_QUICK"`, `"DAOU"`, `"GALAXIA"`, `"TOSSPAY"`, `"KCP_DIRECT"`, `"SETTLE_ACC"`, `"SETTLE_FIRM"`, `"INICIS_UNIFIED"`, `"KSNET"`, `"PINPAY"`
+        `"HTML5_INICIS"`, `"PAYPAL"`, `"PAYPAL_V2"`, `"INICIS"`, `"DANAL"`, `"NICE"`, `"DANAL_TPAY"`, `"UPLUS"`, `"NAVERPAY"`, `"SETTLE"`, `"KCP"`, `"MOBILIANS"`, `"KAKAOPAY"`, `"NAVERCO"`, `"KICC"`, `"EXIMBAY"`, `"SMILEPAY"`, `"PAYCO"`, `"KCP_BILLING"`, `"CHAI"`, `"SMARTRO"`, `"SMARTRO_V2"`, `"PAYMENTWALL"`, `"TOSSPAYMENTS"`, `"KCP_QUICK"`, `"DAOU"`, `"GALAXIA"`, `"TOSSPAY"`, `"KCP_DIRECT"`, `"SETTLE_ACC"`, `"SETTLE_FIRM"`, `"INICIS_UNIFIED"`, `"KSNET"`, `"PINPAY"`
 
         ---
 

--- a/src/content/docs/ko/api-v2/cash-receipt.mdx
+++ b/src/content/docs/ko/api-v2/cash-receipt.mdx
@@ -176,7 +176,7 @@ import Tabs from "~/components/gitbook/tabs/Tabs.astro";
 
         결제대행사(PG사)
 
-        `"HTML5_INICIS"`, `"PAYPAL"`, `"PAYPAL_V2"`, `"INICIS"`, `"DANAL"`, `"NICE"`, `"DANAL_TPAY"`, `"UPLUS"`, `"NAVERPAY"`, `"KAKAO"`, `"SETTLE"`, `"KCP"`, `"MOBILIANS"`, `"KAKAOPAY"`, `"NAVERCO"`, `"SYRUP"`, `"KICC"`, `"EXIMBAY"`, `"SMILEPAY"`, `"PAYCO"`, `"KCP_BILLING"`, `"PAYPLE"`, `"CHAI"`, `"SMARTRO"`, `"SMARTRO_V2"`, `"PAYMENTWALL"`, `"TOSSPAYMENTS"`, `"KCP_QUICK"`, `"DAOU"`, `"GALAXIA"`, `"TOSSPAY"`, `"KCP_DIRECT"`, `"SETTLE_ACC"`, `"SETTLE_FIRM"`, `"INICIS_UNIFIED"`, `"KSNET"`, `"PINPAY"`
+        `"HTML5_INICIS"`, `"PAYPAL"`, `"PAYPAL_V2"`, `"INICIS"`, `"DANAL"`, `"NICE"`, `"DANAL_TPAY"`, `"UPLUS"`, `"NAVERPAY"`, `"SETTLE"`, `"KCP"`, `"MOBILIANS"`, `"KAKAOPAY"`, `"NAVERCO"`, `"KICC"`, `"EXIMBAY"`, `"SMILEPAY"`, `"PAYCO"`, `"KCP_BILLING"`, `"CHAI"`, `"SMARTRO"`, `"SMARTRO_V2"`, `"PAYMENTWALL"`, `"TOSSPAYMENTS"`, `"KCP_QUICK"`, `"DAOU"`, `"GALAXIA"`, `"TOSSPAY"`, `"KCP_DIRECT"`, `"SETTLE_ACC"`, `"SETTLE_FIRM"`, `"INICIS_UNIFIED"`, `"KSNET"`, `"PINPAY"`
 
         ---
 

--- a/src/content/docs/ko/api-v2/payment.mdx
+++ b/src/content/docs/ko/api-v2/payment.mdx
@@ -453,7 +453,7 @@ import Tabs from "~/components/gitbook/tabs/Tabs.astro";
 
           결제대행사(PG사)
 
-          `"HTML5_INICIS"`, `"PAYPAL"`, `"PAYPAL_V2"`, `"INICIS"`, `"DANAL"`, `"NICE"`, `"DANAL_TPAY"`, `"UPLUS"`, `"NAVERPAY"`, `"KAKAO"`, `"SETTLE"`, `"KCP"`, `"MOBILIANS"`, `"KAKAOPAY"`, `"NAVERCO"`, `"SYRUP"`, `"KICC"`, `"EXIMBAY"`, `"SMILEPAY"`, `"PAYCO"`, `"KCP_BILLING"`, `"PAYPLE"`, `"CHAI"`, `"SMARTRO"`, `"SMARTRO_V2"`, `"PAYMENTWALL"`, `"TOSSPAYMENTS"`, `"KCP_QUICK"`, `"DAOU"`, `"GALAXIA"`, `"TOSSPAY"`, `"KCP_DIRECT"`, `"SETTLE_ACC"`, `"SETTLE_FIRM"`, `"INICIS_UNIFIED"`, `"KSNET"`, `"PINPAY"`
+          `"HTML5_INICIS"`, `"PAYPAL"`, `"PAYPAL_V2"`, `"INICIS"`, `"DANAL"`, `"NICE"`, `"DANAL_TPAY"`, `"UPLUS"`, `"NAVERPAY"`, `"SETTLE"`, `"KCP"`, `"MOBILIANS"`, `"KAKAOPAY"`, `"NAVERCO"`, `"KICC"`, `"EXIMBAY"`, `"SMILEPAY"`, `"PAYCO"`, `"KCP_BILLING"`, `"CHAI"`, `"SMARTRO"`, `"SMARTRO_V2"`, `"PAYMENTWALL"`, `"TOSSPAYMENTS"`, `"KCP_QUICK"`, `"DAOU"`, `"GALAXIA"`, `"TOSSPAY"`, `"KCP_DIRECT"`, `"SETTLE_ACC"`, `"SETTLE_FIRM"`, `"INICIS_UNIFIED"`, `"KSNET"`, `"PINPAY"`
 
           ---
 
@@ -1829,7 +1829,7 @@ import Tabs from "~/components/gitbook/tabs/Tabs.astro";
 
           결제대행사(PG사)
 
-          `"HTML5_INICIS"`, `"PAYPAL"`, `"PAYPAL_V2"`, `"INICIS"`, `"DANAL"`, `"NICE"`, `"DANAL_TPAY"`, `"UPLUS"`, `"NAVERPAY"`, `"KAKAO"`, `"SETTLE"`, `"KCP"`, `"MOBILIANS"`, `"KAKAOPAY"`, `"NAVERCO"`, `"SYRUP"`, `"KICC"`, `"EXIMBAY"`, `"SMILEPAY"`, `"PAYCO"`, `"KCP_BILLING"`, `"PAYPLE"`, `"CHAI"`, `"SMARTRO"`, `"SMARTRO_V2"`, `"PAYMENTWALL"`, `"TOSSPAYMENTS"`, `"KCP_QUICK"`, `"DAOU"`, `"GALAXIA"`, `"TOSSPAY"`, `"KCP_DIRECT"`, `"SETTLE_ACC"`, `"SETTLE_FIRM"`, `"INICIS_UNIFIED"`, `"KSNET"`, `"PINPAY"`
+          `"HTML5_INICIS"`, `"PAYPAL"`, `"PAYPAL_V2"`, `"INICIS"`, `"DANAL"`, `"NICE"`, `"DANAL_TPAY"`, `"UPLUS"`, `"NAVERPAY"`, `"SETTLE"`, `"KCP"`, `"MOBILIANS"`, `"KAKAOPAY"`, `"NAVERCO"`, `"KICC"`, `"EXIMBAY"`, `"SMILEPAY"`, `"PAYCO"`, `"KCP_BILLING"`, `"CHAI"`, `"SMARTRO"`, `"SMARTRO_V2"`, `"PAYMENTWALL"`, `"TOSSPAYMENTS"`, `"KCP_QUICK"`, `"DAOU"`, `"GALAXIA"`, `"TOSSPAY"`, `"KCP_DIRECT"`, `"SETTLE_ACC"`, `"SETTLE_FIRM"`, `"INICIS_UNIFIED"`, `"KSNET"`, `"PINPAY"`
 
           ---
 
@@ -3115,7 +3115,7 @@ import Tabs from "~/components/gitbook/tabs/Tabs.astro";
 
           결제대행사(PG사)
 
-          `"HTML5_INICIS"`, `"PAYPAL"`, `"PAYPAL_V2"`, `"INICIS"`, `"DANAL"`, `"NICE"`, `"DANAL_TPAY"`, `"UPLUS"`, `"NAVERPAY"`, `"KAKAO"`, `"SETTLE"`, `"KCP"`, `"MOBILIANS"`, `"KAKAOPAY"`, `"NAVERCO"`, `"SYRUP"`, `"KICC"`, `"EXIMBAY"`, `"SMILEPAY"`, `"PAYCO"`, `"KCP_BILLING"`, `"PAYPLE"`, `"CHAI"`, `"SMARTRO"`, `"SMARTRO_V2"`, `"PAYMENTWALL"`, `"TOSSPAYMENTS"`, `"KCP_QUICK"`, `"DAOU"`, `"GALAXIA"`, `"TOSSPAY"`, `"KCP_DIRECT"`, `"SETTLE_ACC"`, `"SETTLE_FIRM"`, `"INICIS_UNIFIED"`, `"KSNET"`, `"PINPAY"`
+          `"HTML5_INICIS"`, `"PAYPAL"`, `"PAYPAL_V2"`, `"INICIS"`, `"DANAL"`, `"NICE"`, `"DANAL_TPAY"`, `"UPLUS"`, `"NAVERPAY"`, `"SETTLE"`, `"KCP"`, `"MOBILIANS"`, `"KAKAOPAY"`, `"NAVERCO"`, `"KICC"`, `"EXIMBAY"`, `"SMILEPAY"`, `"PAYCO"`, `"KCP_BILLING"`, `"CHAI"`, `"SMARTRO"`, `"SMARTRO_V2"`, `"PAYMENTWALL"`, `"TOSSPAYMENTS"`, `"KCP_QUICK"`, `"DAOU"`, `"GALAXIA"`, `"TOSSPAY"`, `"KCP_DIRECT"`, `"SETTLE_ACC"`, `"SETTLE_FIRM"`, `"INICIS_UNIFIED"`, `"KSNET"`, `"PINPAY"`
 
           ---
 
@@ -4417,7 +4417,7 @@ import Tabs from "~/components/gitbook/tabs/Tabs.astro";
 
           결제대행사(PG사)
 
-          `"HTML5_INICIS"`, `"PAYPAL"`, `"PAYPAL_V2"`, `"INICIS"`, `"DANAL"`, `"NICE"`, `"DANAL_TPAY"`, `"UPLUS"`, `"NAVERPAY"`, `"KAKAO"`, `"SETTLE"`, `"KCP"`, `"MOBILIANS"`, `"KAKAOPAY"`, `"NAVERCO"`, `"SYRUP"`, `"KICC"`, `"EXIMBAY"`, `"SMILEPAY"`, `"PAYCO"`, `"KCP_BILLING"`, `"PAYPLE"`, `"CHAI"`, `"SMARTRO"`, `"SMARTRO_V2"`, `"PAYMENTWALL"`, `"TOSSPAYMENTS"`, `"KCP_QUICK"`, `"DAOU"`, `"GALAXIA"`, `"TOSSPAY"`, `"KCP_DIRECT"`, `"SETTLE_ACC"`, `"SETTLE_FIRM"`, `"INICIS_UNIFIED"`, `"KSNET"`, `"PINPAY"`
+          `"HTML5_INICIS"`, `"PAYPAL"`, `"PAYPAL_V2"`, `"INICIS"`, `"DANAL"`, `"NICE"`, `"DANAL_TPAY"`, `"UPLUS"`, `"NAVERPAY"`, `"SETTLE"`, `"KCP"`, `"MOBILIANS"`, `"KAKAOPAY"`, `"NAVERCO"`, `"KICC"`, `"EXIMBAY"`, `"SMILEPAY"`, `"PAYCO"`, `"KCP_BILLING"`, `"CHAI"`, `"SMARTRO"`, `"SMARTRO_V2"`, `"PAYMENTWALL"`, `"TOSSPAYMENTS"`, `"KCP_QUICK"`, `"DAOU"`, `"GALAXIA"`, `"TOSSPAY"`, `"KCP_DIRECT"`, `"SETTLE_ACC"`, `"SETTLE_FIRM"`, `"INICIS_UNIFIED"`, `"KSNET"`, `"PINPAY"`
 
           ---
 
@@ -5775,7 +5775,7 @@ import Tabs from "~/components/gitbook/tabs/Tabs.astro";
 
           결제대행사(PG사)
 
-          `"HTML5_INICIS"`, `"PAYPAL"`, `"PAYPAL_V2"`, `"INICIS"`, `"DANAL"`, `"NICE"`, `"DANAL_TPAY"`, `"UPLUS"`, `"NAVERPAY"`, `"KAKAO"`, `"SETTLE"`, `"KCP"`, `"MOBILIANS"`, `"KAKAOPAY"`, `"NAVERCO"`, `"SYRUP"`, `"KICC"`, `"EXIMBAY"`, `"SMILEPAY"`, `"PAYCO"`, `"KCP_BILLING"`, `"PAYPLE"`, `"CHAI"`, `"SMARTRO"`, `"SMARTRO_V2"`, `"PAYMENTWALL"`, `"TOSSPAYMENTS"`, `"KCP_QUICK"`, `"DAOU"`, `"GALAXIA"`, `"TOSSPAY"`, `"KCP_DIRECT"`, `"SETTLE_ACC"`, `"SETTLE_FIRM"`, `"INICIS_UNIFIED"`, `"KSNET"`, `"PINPAY"`
+          `"HTML5_INICIS"`, `"PAYPAL"`, `"PAYPAL_V2"`, `"INICIS"`, `"DANAL"`, `"NICE"`, `"DANAL_TPAY"`, `"UPLUS"`, `"NAVERPAY"`, `"SETTLE"`, `"KCP"`, `"MOBILIANS"`, `"KAKAOPAY"`, `"NAVERCO"`, `"KICC"`, `"EXIMBAY"`, `"SMILEPAY"`, `"PAYCO"`, `"KCP_BILLING"`, `"CHAI"`, `"SMARTRO"`, `"SMARTRO_V2"`, `"PAYMENTWALL"`, `"TOSSPAYMENTS"`, `"KCP_QUICK"`, `"DAOU"`, `"GALAXIA"`, `"TOSSPAY"`, `"KCP_DIRECT"`, `"SETTLE_ACC"`, `"SETTLE_FIRM"`, `"INICIS_UNIFIED"`, `"KSNET"`, `"PINPAY"`
 
           ---
 
@@ -7071,7 +7071,7 @@ import Tabs from "~/components/gitbook/tabs/Tabs.astro";
 
           결제대행사(PG사)
 
-          `"HTML5_INICIS"`, `"PAYPAL"`, `"PAYPAL_V2"`, `"INICIS"`, `"DANAL"`, `"NICE"`, `"DANAL_TPAY"`, `"UPLUS"`, `"NAVERPAY"`, `"KAKAO"`, `"SETTLE"`, `"KCP"`, `"MOBILIANS"`, `"KAKAOPAY"`, `"NAVERCO"`, `"SYRUP"`, `"KICC"`, `"EXIMBAY"`, `"SMILEPAY"`, `"PAYCO"`, `"KCP_BILLING"`, `"PAYPLE"`, `"CHAI"`, `"SMARTRO"`, `"SMARTRO_V2"`, `"PAYMENTWALL"`, `"TOSSPAYMENTS"`, `"KCP_QUICK"`, `"DAOU"`, `"GALAXIA"`, `"TOSSPAY"`, `"KCP_DIRECT"`, `"SETTLE_ACC"`, `"SETTLE_FIRM"`, `"INICIS_UNIFIED"`, `"KSNET"`, `"PINPAY"`
+          `"HTML5_INICIS"`, `"PAYPAL"`, `"PAYPAL_V2"`, `"INICIS"`, `"DANAL"`, `"NICE"`, `"DANAL_TPAY"`, `"UPLUS"`, `"NAVERPAY"`, `"SETTLE"`, `"KCP"`, `"MOBILIANS"`, `"KAKAOPAY"`, `"NAVERCO"`, `"KICC"`, `"EXIMBAY"`, `"SMILEPAY"`, `"PAYCO"`, `"KCP_BILLING"`, `"CHAI"`, `"SMARTRO"`, `"SMARTRO_V2"`, `"PAYMENTWALL"`, `"TOSSPAYMENTS"`, `"KCP_QUICK"`, `"DAOU"`, `"GALAXIA"`, `"TOSSPAY"`, `"KCP_DIRECT"`, `"SETTLE_ACC"`, `"SETTLE_FIRM"`, `"INICIS_UNIFIED"`, `"KSNET"`, `"PINPAY"`
 
           ---
 
@@ -10533,7 +10533,7 @@ import Tabs from "~/components/gitbook/tabs/Tabs.astro";
 
           결제대행사(PG사)
 
-          `"HTML5_INICIS"`, `"PAYPAL"`, `"PAYPAL_V2"`, `"INICIS"`, `"DANAL"`, `"NICE"`, `"DANAL_TPAY"`, `"UPLUS"`, `"NAVERPAY"`, `"KAKAO"`, `"SETTLE"`, `"KCP"`, `"MOBILIANS"`, `"KAKAOPAY"`, `"NAVERCO"`, `"SYRUP"`, `"KICC"`, `"EXIMBAY"`, `"SMILEPAY"`, `"PAYCO"`, `"KCP_BILLING"`, `"PAYPLE"`, `"CHAI"`, `"SMARTRO"`, `"SMARTRO_V2"`, `"PAYMENTWALL"`, `"TOSSPAYMENTS"`, `"KCP_QUICK"`, `"DAOU"`, `"GALAXIA"`, `"TOSSPAY"`, `"KCP_DIRECT"`, `"SETTLE_ACC"`, `"SETTLE_FIRM"`, `"INICIS_UNIFIED"`, `"KSNET"`, `"PINPAY"`
+          `"HTML5_INICIS"`, `"PAYPAL"`, `"PAYPAL_V2"`, `"INICIS"`, `"DANAL"`, `"NICE"`, `"DANAL_TPAY"`, `"UPLUS"`, `"NAVERPAY"`, `"SETTLE"`, `"KCP"`, `"MOBILIANS"`, `"KAKAOPAY"`, `"NAVERCO"`, `"KICC"`, `"EXIMBAY"`, `"SMILEPAY"`, `"PAYCO"`, `"KCP_BILLING"`, `"CHAI"`, `"SMARTRO"`, `"SMARTRO_V2"`, `"PAYMENTWALL"`, `"TOSSPAYMENTS"`, `"KCP_QUICK"`, `"DAOU"`, `"GALAXIA"`, `"TOSSPAY"`, `"KCP_DIRECT"`, `"SETTLE_ACC"`, `"SETTLE_FIRM"`, `"INICIS_UNIFIED"`, `"KSNET"`, `"PINPAY"`
 
           ---
 


### PR DESCRIPTION
### 작업 맥락
- https://github.com/portone-io/browser-sdk/pull/299

### 참고 링크
https://portone-io.slack.com/archives/C050NUE2C30/p1715830075923449