### PR TITLE
<ContentRef> 링크 검사하는 lint 규칙 추가

### DIFF
--- a/src/content/docs/en/api/api/readme.mdx
+++ b/src/content/docs/en/api/api/readme.mdx
@@ -5,6 +5,6 @@ description: Learn about i'mport non-authenticated payment API.
 
 import ContentRef from "~/components/gitbook/ContentRef.astro";
 
-<ContentRef slug="/en/api" />
+<ContentRef slug="/en/api/api/api" />
 
-<ContentRef slug="/en/request-non-authenticated-payment-one-time-api" />
+<ContentRef slug="/en/api/api/request-non-authenticated-payment-one-time-api" />

--- a/src/content/docs/en/api/billing-key-api/readme.mdx
+++ b/src/content/docs/en/api/billing-key-api/readme.mdx
@@ -5,12 +5,12 @@ description: Learn about i'mport billing key API.
 
 import ContentRef from "~/components/gitbook/ContentRef.astro";
 
-<ContentRef slug="/en/api-1" />
+<ContentRef slug="/en/api/billing-key-api/api-1" />
 
-<ContentRef slug="/en/delete-billing-key-api" />
+<ContentRef slug="/en/api/billing-key-api/delete-billing-key-api" />
 
-<ContentRef slug="/en/get-billing-key-api" />
+<ContentRef slug="/en/api/billing-key-api/get-billing-key-api" />
 
-<ContentRef slug="/en/get-billing-keys-api" />
+<ContentRef slug="/en/api/billing-key-api/get-billing-keys-api" />
 
-<ContentRef slug="/en/get-scheduled-payments-api" />
+<ContentRef slug="/en/api/billing-key-api/get-scheduled-payments-api" />

--- a/src/content/docs/en/api/escrow-api/readme.mdx
+++ b/src/content/docs/en/api/escrow-api/readme.mdx
@@ -11,8 +11,8 @@ import ContentRef from "~/components/gitbook/ContentRef.astro";
 - NHN KCP
 - PAYJOA (DaouData)
 
-<ContentRef slug="/en/get-delivery-info-api" />
+<ContentRef slug="/en/api/escrow-api/get-delivery-info-api" />
 
-<ContentRef slug="/en/add-delivery-info-api" />
+<ContentRef slug="/en/api/escrow-api/add-delivery-info-api" />
 
-<ContentRef slug="/en/update-delivery-info-api" />
+<ContentRef slug="/en/api/escrow-api/update-delivery-info-api" />

--- a/src/content/docs/en/api/subscription-payment-api/readme.mdx
+++ b/src/content/docs/en/api/subscription-payment-api/readme.mdx
@@ -5,12 +5,12 @@ description: Learn about i'mport API for implementing subscription payment.
 
 import ContentRef from "~/components/gitbook/ContentRef.astro";
 
-<ContentRef slug="/en/schedule-payment-api" />
+<ContentRef slug="/en/api/subscription-payment-api/schedule-payment-api" />
 
-<ContentRef slug="/en/cancel-scheduled-payment-api" />
+<ContentRef slug="/en/api/subscription-payment-api/cancel-scheduled-payment-api" />
 
-<ContentRef slug="/en/get-scheduled-payments-api" />
+<ContentRef slug="/en/api/subscription-payment-api/get-scheduled-payments-api" />
 
-<ContentRef slug="/en/get-scheduled-payment-api" />
+<ContentRef slug="/en/api/subscription-payment-api/get-scheduled-payment-api" />
 
-<ContentRef slug="/en/get-scheduled-payments-by-billing-key-api" />
+<ContentRef slug="/en/api/subscription-payment-api/get-scheduled-payments-by-billing-key-api" />

--- a/src/content/docs/en/auth/guide-1/bill/readme.mdx
+++ b/src/content/docs/en/auth/guide-1/bill/readme.mdx
@@ -46,9 +46,9 @@ Depending on the PG, the billing key can be issued using the following two metho
   </Tab>
 </Tabs>
 
-<ContentRef slug="/en/rest-api" />
+<ContentRef slug="/en/auth/guide-1/bill/rest-api" />
 
-<ContentRef slug="/en/pg-window" />
+<ContentRef slug="/en/auth/guide-1/bill/pg-window" />
 
 ## 2. Payment using card info (key-in payment) <a href="#a-rest-api" id="a-rest-api" />
 

--- a/src/content/docs/en/auth/guide/4/readme.mdx
+++ b/src/content/docs/en/auth/guide/4/readme.mdx
@@ -18,6 +18,6 @@ payment window type as follows:
 
 Refer to the following detailed instructions:
 
-<ContentRef slug="/en/iframe" />
+<ContentRef slug="/en/auth/guide/4/iframe" />
 
-<ContentRef slug="/en/redirect" />
+<ContentRef slug="/en/auth/guide/4/redirect" />

--- a/src/content/docs/en/ready/2-pg/payment-gateway-settings/readme.mdx
+++ b/src/content/docs/en/ready/2-pg/payment-gateway-settings/readme.mdx
@@ -7,30 +7,30 @@ import ContentRef from "~/components/gitbook/ContentRef.astro";
 
 ## Use the following instructions to set up each PG for payment integration from the i'mport Admin page.
 
-<ContentRef slug="/en/nhn-kcp" />
+<ContentRef slug="/en/ready/2-pg/payment-gateway-settings/nhn-kcp" />
 
-<ContentRef slug="/en/nhn-kcp-1" />
+<ContentRef slug="/en/ready/2-pg/payment-gateway-settings/nhn-kcp-1" />
 
-<ContentRef slug="/en/nice-payments" />
+<ContentRef slug="/en/ready/2-pg/payment-gateway-settings/nice-payments" />
 
-<ContentRef slug="/en/undefined" />
+<ContentRef slug="/en/ready/2-pg/payment-gateway-settings/undefined" />
 
-<ContentRef slug="/en/kicc" />
+<ContentRef slug="/en/ready/2-pg/payment-gateway-settings/kicc" />
 
-<ContentRef slug="/en/undefined-1" />
+<ContentRef slug="/en/ready/2-pg/payment-gateway-settings/undefined-1" />
 
-<ContentRef slug="/en/daou" />
+<ContentRef slug="/en/ready/2-pg/payment-gateway-settings/daou" />
 
-<ContentRef slug="/en/undefined-2" />
+<ContentRef slug="/en/ready/2-pg/payment-gateway-settings/undefined-2" />
 
-<ContentRef slug="/en/undefined-3" />
+<ContentRef slug="/en/ready/2-pg/payment-gateway-settings/undefined-3" />
 
-<ContentRef slug="/en/kg" />
+<ContentRef slug="/en/ready/2-pg/payment-gateway-settings/kg" />
 
-<ContentRef slug="/en/undefined-4" />
+<ContentRef slug="/en/ready/2-pg/payment-gateway-settings/undefined-4" />
 
-<ContentRef slug="/en/undefined-5" />
+<ContentRef slug="/en/ready/2-pg/payment-gateway-settings/undefined-5" />
 
-<ContentRef slug="/en/undefined-6" />
+<ContentRef slug="/en/ready/2-pg/payment-gateway-settings/undefined-6" />
 
-<ContentRef slug="/en/undefined-7" />
+<ContentRef slug="/en/ready/2-pg/payment-gateway-settings/undefined-7" />

--- a/src/content/docs/ko/pg/simple/readme.mdx
+++ b/src/content/docs/ko/pg/simple/readme.mdx
@@ -13,7 +13,7 @@ import ContentRef from "~/components/gitbook/ContentRef.astro";
 
 <ContentRef slug="/ko/pg/simple/naver" />
 
-<ContentRef slug="/ko/pg/simple/kakaopay" />
+<ContentRef slug="/ko/pg/simple/kakopay" />
 
 <ContentRef slug="/ko/pg/simple/payco" />
 

--- a/src/content/docs/ko/wordpress/wordpress/readme.mdx
+++ b/src/content/docs/ko/wordpress/wordpress/readme.mdx
@@ -8,4 +8,4 @@ import ContentRef from "~/components/gitbook/ContentRef.astro";
 
 우커머스 플러그인을 통해 워드프레스에서 포트원을 사용할 수 있습니다.
 
-<ContentRef slug="/ko/woocommerce/readme" />
+<ContentRef slug="/ko/wordpress/wordpress/woocommerce/readme" />

--- a/src/content/docs/ko/wordpress/wordpress/woocommerce/readme.mdx
+++ b/src/content/docs/ko/wordpress/wordpress/woocommerce/readme.mdx
@@ -29,6 +29,6 @@ import image2 from "./_assets/woocermerce-2.png";
 
 일반결제 또는 정기결제 기능을 워드프레스 우커머스 플러그인을 사용하여 연동할 수 있습니다.
 
-<ContentRef slug="/ko/payment" />
+<ContentRef slug="/ko/wordpress/wordpress/woocommerce/payment" />
 
-<ContentRef slug="/ko/subscription" />
+<ContentRef slug="/ko/wordpress/wordpress/woocommerce/subscription" />


### PR DESCRIPTION
closes #458 

- <ContentRef> 컴포넌트의 slug 링크를 검사하는 remark lint 규칙을 추가했습니다.
- 린터에서 감지된 유실된 링크 37개를 수정했습니다.