### PR TITLE
SDK 체인지로그에서 커밋 해시 제거하는 로직 내 버그 수정

### DIFF
--- a/src/content/docs/ko/v2-payment/v2-sdk/_components/SDKChangelog.astro
+++ b/src/content/docs/ko/v2-payment/v2-sdk/_components/SDKChangelog.astro
@@ -38,7 +38,7 @@ const html = await unified()
         ) {
           parent.children.splice(index, 1);
           visit(parent, "text", (node) => {
-            node.value = node.value.replaceAll(/[0-9a-f]+: (.+)/g, "$1");
+            node.value = node.value.replaceAll(/^[0-9a-f]+: /g, "");
           });
         } else {
           console.warn("Unexpected CHANGELOG.md structure");


### PR DESCRIPTION
변경사항 내에 rich text가 포함되어 있으면 text node가 나뉘어져서 정규식 매칭이 안됐었음