### PR TITLE
docs: 다우데이타 유의사항 추가

### DIFF
--- a/src/content/docs/ko/pg/payment-gateway/daou/undefined.mdx
+++ b/src/content/docs/ko/pg/payment-gateway/daou/undefined.mdx
@@ -146,5 +146,6 @@ import Details from "~/components/gitbook/Details.astro";
   <p slot="summary">비인증 결제 API 호출 시 초당 호출 횟수 제한됨</p>
 
   **비인증 결제 API 호출 시 초당 50건 이하로 호출 하는 것을 권장합니다.**
+
   - 초당 50건 이상의 비인증 결제 API가 호출 될 경우 오류가 발생할 수 있습니다.
 </Details>

--- a/src/content/docs/ko/pg/payment-gateway/daou/undefined.mdx
+++ b/src/content/docs/ko/pg/payment-gateway/daou/undefined.mdx
@@ -141,3 +141,10 @@ import Details from "~/components/gitbook/Details.astro";
 
   - `IMP.request_pay` 호출시 전달한 구매자의 전화번호(`buyer_tel`)가 다른 결제창과는 달리 에스크로 결제창에서는 자동 완성되지 않습니다. 이는 페이조아가 해당 기능을 제공하지 않는 것으로 이용에 참고 부탁드립니다.
 </Details>
+
+<Details>
+  <p slot="summary">비인증 결제 API 호출 시 초당 호출 횟수 제한됨</p>
+
+  **비인증 결제 API 호출 시 초당 50건 이하로 호출 하는 것을 권장합니다.**
+  - 초당 50건 이상의 비인증 결제 API가 호출 될 경우 오류가 발생할 수 있습니다.
+</Details>


### PR DESCRIPTION
docs: 다우데이타 유의사항 추가
비인증 결제 API 호출 횟수가 초당 50건을 초과할 경우 오류가 발생할 수 있어 해당 내용을 추가했습니다.