### PR TITLE
fetch method 대소문자 이슈 수정

### DIFF
--- a/src/layouts/rest-api/endpoint/playground/try/Req.tsx
+++ b/src/layouts/rest-api/endpoint/playground/try/Req.tsx
@@ -91,7 +91,11 @@ export default function Req({
                     ? null
                     : JSON.stringify(reqBody);
                 const reqUrl = createUrl(apiHost, path, reqPath, reqQuery);
-                const res = await fetch(reqUrl, { method, headers, body });
+                const res = await fetch(reqUrl, {
+                  method: method.toUpperCase(),
+                  headers,
+                  body,
+                });
                 return await responseToRes(res);
               })
             }


### PR DESCRIPTION
Slack 링크: https://portone-io.slack.com/archives/C03N8773P1A/p1718609124285429?thread_ts=1718608700.086539&cid=C03N8773P1A

![image](https://github.com/portone-io/developers.portone.io/assets/17797795/b3b4b83b-6bd1-44e9-b6ce-0084cb164f92)

대소문자 구분 때문에 CORS 정책으로 차단되는 문제 해결 😢 