### PR TITLE
update V1 openapi schema

### DIFF
--- a/src/schema/v1.openapi.json
+++ b/src/schema/v1.openapi.json
@@ -5,7 +5,7 @@
     "description": "* 결제완료된 정보, 결제취소, 상태별 결제목록 조회 등의 기능을 하는 REST API를 제공합니다.<br> 비인증결제, 정기 자동결제 등 부가기능을 위한 REST API를 제공합니다.",
     "contact": {
       "name": "(주)코리아포트원",
-      "url": "https://admin.iamport.kr",
+      "url": "https://admin.portone.io",
       "email": "cs@portone.io"
     },
     "version": "1.0"
@@ -35,20 +35,20 @@
           {
             "name": "imp_key",
             "in": "formData",
-            "description": "REST API 키 (포트원 관리자 페이지의 `상점 ・ 계정 관리` -> `내 식별코드 ・ API Keys`에서 확인하실 수 있습니다 : https://admin.portone.io)",
+            "description": "REST API key (포트원 관리자콘솔 내 [결제 연동] > [식별코드・API Keys] > [V1 API]에서 확인할 수 있습니다. : https://admin.portone.io)",
             "required": true,
             "type": "string",
             "x-portone-name": "REST API KEY",
-            "x-portone-description": "<p>REST API 키로 포트원 관리자 페이지의 <code>상점 ・ 계정 관리</code> -&gt; <code>내 식별코드 ・ API Keys</code>에서 확인하실 수 있습니다 : <a href=\"https://admin.portone.io\" rel=\"noopener noreferrer\">https://admin.portone.io</a></p>\n"
+            "x-portone-description": "<p>REST API key로 포트원 관리자콘솔 내 [결제 연동] &gt; [식별코드・API Keys] &gt; [V1 API]에서 확인할 수 있습니다. : <a href=\"https://admin.portone.io\" rel=\"noopener noreferrer\">https://admin.portone.io</a></p>\n"
           },
           {
             "name": "imp_secret",
             "in": "formData",
-            "description": "REST API Secret (포트원 관리자 페이지의 `상점 ・ 계정 관리` -> `내 식별코드 ・ API Keys`에서 확인하실 수 있습니다 : https://admin.portone.io)",
+            "description": "REST API Secret (포트원 관리자콘솔 내 [결제 연동] > [식별코드・API Keys] > [V1 API]에서 확인할 수 있습니다. : https://admin.portone.io)",
             "required": true,
             "type": "string",
             "x-portone-name": "REST API SECRET",
-            "x-portone-description": "<p>REST API Secret으로 포트원 관리자 페이지의 <code>상점 ・ 계정 관리</code> -&gt; <code>내 식별코드 ・ API Keys</code>에서 확인하실 수 있습니다 : <a href=\"https://admin.portone.io\" rel=\"noopener noreferrer\">https://admin.portone.io</a></p>\n"
+            "x-portone-description": "<p>REST API Secret으로 포트원 관리자콘솔 내 [결제 연동] &gt; [식별코드・API Keys] &gt; [V1 API]에서 확인할 수 있습니다. : <a href=\"https://admin.portone.io\" rel=\"noopener noreferrer\">https://admin.portone.io</a></p>\n"
           }
         ],
         "responses": {
@@ -166,12 +166,12 @@
           {
             "name": "merchant_uid",
             "in": "formData",
-            "description": "가맹점 거래 고유번호. 이미 결제가 이뤄진 적이 있는 merchant_uid로는 결제요청이 불가능합니다.",
+            "description": "고객사 거래 고유번호. 이미 결제가 이뤄진 적이 있는 merchant_uid로는 결제요청이 불가능합니다.",
             "required": true,
             "type": "string",
             "maxLength": 40,
-            "x-portone-name": "가맹점 주문번호",
-            "x-portone-summary": "<p>가맹점 거래 고유번호</p>\n",
+            "x-portone-name": "고객사 주문번호",
+            "x-portone-summary": "<p>고객사 거래 고유번호</p>\n",
             "x-portone-description": "<p>이미 결제가 이뤄진 적이 있는 merchant_uid로는 결제요청이 불가능합니다.</p>\n"
           },
           {
@@ -395,7 +395,7 @@
           "certifications"
         ],
         "summary": "본인인증 요청 API",
-        "description": "사용자 개인정보를 API로 전달하여, 통신사로부터 확인되는 경우 OTP(6자리 인증번호)를 사용자에게 SMS로 전달합니다.\n      <br><br>통신사 승인을 받은 일부 가맹점에 한해 사용하실 수 있으며, 현재 <b>다날</b>을 통해서만 서비스되고 있습니다.\n      <br><br>본인인증 대상자의 성명, 생년월일 + 주민등록 뒷부분 첫 자리, 휴대폰번호, 통신사 정보를 가맹점에서 직접 입력받아 API요청하면 됩니다. 전달된 개인정보가 올바를 경우 해당 휴대폰으로 인증번호 SMS가 전송됩니다.\n      <br><br>200응답 시 imp_uid 가 응답데이터로 전달되며, SMS전송된 인증번호를 본인인증 완료 API 로 요청주시면 최종 본인인증 프로세스가 완료됩니다.",
+        "description": "사용자 개인정보를 API로 전달하여, 통신사로부터 확인되는 경우 OTP(6자리 인증번호)를 사용자에게 SMS로 전달합니다.\n      <br><br>통신사 승인을 받은 일부 고객사에 한해 사용하실 수 있으며, 현재 <b>다날</b>을 통해서만 서비스되고 있습니다.\n      <br><br>본인인증 대상자의 성명, 생년월일 + 주민등록 뒷부분 첫 자리, 휴대폰번호, 통신사 정보를 고객사에서 직접 입력받아 API요청하면 됩니다. 전달된 개인정보가 올바를 경우 해당 휴대폰으로 인증번호 SMS가 전송됩니다.\n      <br><br>200응답 시 imp_uid 가 응답데이터로 전달되며, SMS전송된 인증번호를 본인인증 완료 API 로 요청주시면 최종 본인인증 프로세스가 완료됩니다.",
         "operationId": "requestOTP",
         "consumes": [
           "application/json",
@@ -472,21 +472,21 @@
           {
             "name": "company",
             "in": "formData",
-            "description": "가맹점 서비스명칭 또는 domain URL. <br> KISA에서 대상자에게 발송하는 SMS에 안내될 서비스 명칭",
+            "description": "고객사 서비스명칭 또는 domain URL. <br> KISA에서 대상자에게 발송하는 SMS에 안내될 서비스 명칭",
             "required": false,
             "type": "string",
-            "x-portone-name": "가맹점 서비스명칭",
-            "x-portone-summary": "<p>가맹점 서비스명칭 또는 domain URL</p>\n",
+            "x-portone-name": "고객사 서비스명칭",
+            "x-portone-summary": "<p>고객사 서비스명칭 또는 domain URL</p>\n",
             "x-portone-description": "<p>KISA에서 대상자에게 발송하는 SMS에 안내될 서비스 명칭</p>\n"
           },
           {
             "name": "merchant_uid",
             "in": "formData",
-            "description": "본인인증 요청건을 식별하기 위한 가맹점 주문번호",
+            "description": "본인인증 요청건을 식별하기 위한 고객사 주문번호",
             "required": false,
             "type": "string",
-            "x-portone-name": "가맹점 주문번호",
-            "x-portone-description": "<p>본인인증 요청건을 식별하기 위한 가맹점 주문번호</p>\n"
+            "x-portone-name": "고객사 주문번호",
+            "x-portone-description": "<p>본인인증 요청건을 식별하기 위한 고객사 주문번호</p>\n"
           },
           {
             "name": "pg",
@@ -589,7 +589,7 @@
           "subscribe.customer"
         ],
         "summary": "빌링키 정보 복수조회 API",
-        "description": "여러 개의 빌링키를 한 번에 조회하는 API입니다.<br><br>등록된 카드마다 1개의 customer_uid가 매핑되므로,\n     가맹점 시스템 내에 1명의 고객이 여러 장의 카드를 등록할 수 있는 경우 여러 개의 customer_uid를 가지게 됩니다.<br> 해당 고객이 등록해놓은 카드정보 목록을 한 번에 조회하는데 사용하면 편리합니다.\n     <br><br>예시) /subscribe/customers?customer_uid[]=hong_1234_a&customer_uid[]=hong_1234_b",
+        "description": "여러 개의 빌링키를 한 번에 조회하는 API입니다.<br><br>등록된 카드마다 1개의 customer_uid가 매핑되므로,\n     고객사 시스템 내에 1명의 고객이 여러 장의 카드를 등록할 수 있는 경우 여러 개의 customer_uid를 가지게 됩니다.<br> 해당 고객이 등록해놓은 카드정보 목록을 한 번에 조회하는데 사용하면 편리합니다.\n     <br><br>예시) /subscribe/customers?customer_uid[]=hong_1234_a&customer_uid[]=hong_1234_b",
         "operationId": "customer_view_multiple",
         "consumes": [
           "application/json",
@@ -602,7 +602,7 @@
           {
             "name": "customer_uid[]",
             "in": "query",
-            "description": "빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호",
+            "description": "빌링키와 매핑되며 고객사에서 채번하는 구매자의 결제 수단 식별 고유번호",
             "required": true,
             "type": "array",
             "items": {
@@ -611,7 +611,7 @@
             "collectionFormat": "multi",
             "default": "customer_1234",
             "x-portone-name": "구매자의 결제 수단 식별 고유번호",
-            "x-portone-description": "<p>빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n"
+            "x-portone-description": "<p>빌링키와 매핑되며 고객사에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n"
           }
         ],
         "responses": {
@@ -641,7 +641,6 @@
           "daou",
           "html5_inicis",
           "inicis",
-          "jtnet",
           "kakaopay",
           "kcp",
           "kcp_billing",
@@ -688,12 +687,12 @@
           {
             "name": "customer_uid",
             "in": "path",
-            "description": "빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호",
+            "description": "빌링키와 매핑되며 고객사에서 채번하는 구매자의 결제 수단 식별 고유번호",
             "required": true,
             "type": "string",
             "default": "customer_1234",
             "x-portone-name": "구매자의 결제 수단 식별 고유번호",
-            "x-portone-description": "<p>빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n"
+            "x-portone-description": "<p>빌링키와 매핑되며 고객사에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n"
           }
         ],
         "responses": {
@@ -717,7 +716,6 @@
           "daou",
           "html5_inicis",
           "inicis",
-          "jtnet",
           "kakaopay",
           "kcp",
           "kcp_billing",
@@ -763,18 +761,18 @@
           {
             "name": "customer_uid",
             "in": "path",
-            "description": "빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호",
+            "description": "빌링키와 매핑되며 고객사에서 채번하는 구매자의 결제 수단 식별 고유번호",
             "required": true,
             "type": "string",
             "default": "customer_1234",
             "maxLength": 80,
             "x-portone-name": "구매자의 결제 수단 식별 고유번호",
-            "x-portone-description": "<p>빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n"
+            "x-portone-description": "<p>빌링키와 매핑되며 고객사에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n"
           },
           {
             "name": "pg",
             "in": "formData",
-            "description": "API 방식 비인증 PG설정이 2개 이상인 경우, 결제가 진행되길 원하는 PG사를 지정하실 수 있습니다. pg 파라메터는 <b>{PG사}</b> 혹은 <b>{PG사}.{PG상점아이디}</b> 형태의 문자열입니다. <br>지정하지 않거나 유효하지 않은 값이 전달되면 기본PG설정된 값을 이용해 결제하게 됩니다. <br><ul><li>나이스페이먼츠, JTNet 2가지 PG설정이 되어있다면, pg 파라메터로 <b>nice</b> 또는 <b>jtnet</b>로 구분 가능</li><li>나이스페이먼츠로부터 2개 이상의 상점아이디를 발급받았다면, <b>nice.MID1</b> 또는 <b>nice.MID2</b>로 구분 가능</li></ul>",
+            "description": "API 방식 비인증 PG설정이 2개 이상인 경우, 결제가 진행되길 원하는 PG사를 지정하실 수 있습니다. pg 파라메터는 <b>{PG사}</b> 혹은 <b>{PG사}.{PG상점아이디}</b> 형태의 문자열입니다. <br>지정하지 않거나 유효하지 않은 값이 전달되면 기본PG설정된 값을 이용해 결제하게 됩니다. <br><ul><li>나이스페이먼츠, KCP 2가지 PG설정이 되어있다면, pg 파라메터로 <b>nice</b> 또는 <b>kcp</b>로 구분 가능</li><li>나이스페이먼츠로부터 2개 이상의 상점아이디를 발급받았다면, <b>nice.MID1</b> 또는 <b>nice.MID2</b>로 구분 가능</li></ul>",
             "required": false,
             "type": "string",
             "maxLength": 80,
@@ -930,7 +928,6 @@
         },
         "x-portone-supported-pgs": [
           "nice",
-          "jtnet",
           "kcp",
           "daou",
           "html5_inicis",
@@ -959,12 +956,12 @@
           {
             "name": "customer_uid",
             "in": "path",
-            "description": "빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호",
+            "description": "빌링키와 매핑되며 고객사에서 채번하는 구매자의 결제 수단 식별 고유번호",
             "required": true,
             "type": "string",
             "default": "customer_1234",
             "x-portone-name": "구매자의 결제 수단 식별 고유번호",
-            "x-portone-description": "<p>빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n"
+            "x-portone-description": "<p>빌링키와 매핑되며 고객사에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n"
           },
           {
             "name": "reason",
@@ -1010,7 +1007,6 @@
           "daou",
           "html5_inicis",
           "inicis",
-          "jtnet",
           "kakaopay",
           "kcp",
           "kcp_billing",
@@ -1053,12 +1049,12 @@
           {
             "name": "customer_uid",
             "in": "path",
-            "description": "빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호",
+            "description": "빌링키와 매핑되며 고객사에서 채번하는 구매자의 결제 수단 식별 고유번호",
             "required": true,
             "type": "string",
             "default": "customer_1234",
             "x-portone-name": "구매자의 결제 수단 식별 고유번호",
-            "x-portone-description": "<p>빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n"
+            "x-portone-description": "<p>빌링키와 매핑되며 고객사에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n"
           },
           {
             "name": "page",
@@ -1092,7 +1088,6 @@
           "daou",
           "html5_inicis",
           "inicis",
-          "jtnet",
           "kakaopay",
           "kcp",
           "kcp_billing",
@@ -1204,7 +1199,6 @@
           "daou",
           "html5_inicis",
           "inicis",
-          "jtnet",
           "kakaopay",
           "kcp",
           "kcp_billing",
@@ -1247,12 +1241,12 @@
           {
             "name": "merchant_uid",
             "in": "formData",
-            "description": "가맹점 주문번호<br>\n     이미 결제가 이뤄진 적이 있는 merchant_uid로는 추가적인 편의점결제 수납번호(barcode) 발급 또는 등록이 불가능합니다.",
+            "description": "고객사 주문번호<br>\n     이미 결제가 이뤄진 적이 있는 merchant_uid로는 추가적인 편의점결제 수납번호(barcode) 발급 또는 등록이 불가능합니다.",
             "required": true,
             "type": "string",
             "maxLength": 40,
-            "x-portone-name": "가맹점 주문번호",
-            "x-portone-summary": "<p>가맹점 거래 고유번호</p>\n",
+            "x-portone-name": "고객사 주문번호",
+            "x-portone-summary": "<p>고객사 거래 고유번호</p>\n",
             "x-portone-description": "<p>이미 결제가 이뤄진 적이 있는 merchant_uid로는 추가적인 편의점결제 수납번호(barcode) 발급 또는 등록이 불가능합니다.</p>\n"
           },
           {
@@ -1267,11 +1261,11 @@
           {
             "name": "barcode",
             "in": "formData",
-            "description": "가맹점에서 직접 생성, 관리하는 바코드(barcode)번호가 있는 경우, 갤럭시아컴즈로부터 신규 수납번호(barcode)를 발급요청하지 않고 가맹점에서 관리하는 바코드(barcode)번호를 등록하여 수납번호로 활용할 수 있습니다.",
+            "description": "고객사에서 직접 생성, 관리하는 바코드(barcode)번호가 있는 경우, 갤럭시아컴즈로부터 신규 수납번호(barcode)를 발급요청하지 않고 고객사에서 관리하는 바코드(barcode)번호를 등록하여 수납번호로 활용할 수 있습니다.",
             "required": false,
             "type": "string",
             "x-portone-name": "바코드",
-            "x-portone-description": "<p>가맹점에서 직접 생성, 관리하는 바코드(barcode)번호가 있는 경우, 갤럭시아컴즈로부터 신규 수납번호(barcode)를 발급요청하지 않고 가맹점에서 관리하는 바코드(barcode)번호를 등록하여 수납번호로 활용할 수 있습니다.</p>\n"
+            "x-portone-description": "<p>고객사에서 직접 생성, 관리하는 바코드(barcode)번호가 있는 경우, 갤럭시아컴즈로부터 신규 수납번호(barcode)를 발급요청하지 않고 고객사에서 관리하는 바코드(barcode)번호를 등록하여 수납번호로 활용할 수 있습니다.</p>\n"
           },
           {
             "name": "expired_at",
@@ -1764,55 +1758,6 @@
             "description": "<p>API로 에스크로 배송 정보 등록은 가능하지만 PUT 배송정보 단건수정 API로 수정은 <span>불가능</span>합니다.</p>\n"
           }
         }
-      }
-    },
-    "/kakao/payment/orders": {
-      "get": {
-        "tags": [
-          "kakao"
-        ],
-        "summary": "(카카오페이) 주문내역조회 API",
-        "description": "<b> 해당 API는 카카오페이 정책이슈로 인해 2022년 하반기에 지원이 종료될 예정입니다.</b>\n     <br><del>(카카오페이) <a href=\"https://developers.kakao.com/docs/restapi/kakaopay-api#주문내역조회\">카카오페이 주문내조회 API</a>를 래핑한 API 입니다. 지원되는 request가 유사하며 응답되는 response는 카카오페이 API 와 동일합니다.</del>",
-        "operationId": "getOrders",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "payment_request_date",
-            "in": "query",
-            "description": "YYYYMMDD 형식의 조회 날짜를 지정하시면 됩니다.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "cid",
-            "in": "query",
-            "description": "포트원 내 설정된 카카오페이 CID를 기본값으로 합니다. 포트원 계정 내 복수의 카카오페이 CID가 설정된 경우 지정하시면 됩니다.",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "description": "페이지 숫자(1부터 시작, 1이 기본값)",
-            "required": false,
-            "type": "integer"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "카카오페이 주문내역조회 성공. 응답데이터는 <a href=\"https://developers.kakao.com/docs/restapi/kakaopay-api#주문내역조회\">카카오페이 주문내조회 API</a> 참조",
-            "schema": {
-              "$ref": "#/definitions/KakaoOrderResponse"
-            }
-          }
-        },
-        "deprecated": true,
-        "x-portone-category": "pg.kakao"
       }
     },
     "/kcpquick/members/{member_id}": {
@@ -3033,11 +2978,11 @@
           {
             "name": "requester",
             "in": "formData",
-            "description": "구매확정 요청자 (admin : 가맹점 관리자 (기본값), customer : 구매자)",
+            "description": "구매확정 요청자 (admin : 고객사 관리자 (기본값), customer : 구매자)",
             "required": false,
             "type": "string",
             "x-portone-name": "구매확정 요청자",
-            "x-portone-description": "<p>구매확정 요청자 (admin : 가맹점 관리자 (기본값), customer : 구매자)</p>\n"
+            "x-portone-description": "<p>구매확정 요청자 (admin : 고객사 관리자 (기본값), customer : 구매자)</p>\n"
           }
         ],
         "responses": {
@@ -3500,7 +3445,7 @@
             "description": "<p>키움페이(구 다우, 페이조아)는 (발급된) 가상계좌에 입금 완료시, 송금자의 정보(은행명, 계좌번호, 송금인) 중 <strong>송금자 이름</strong>만 알려줍니다.\n     따라서 송금자의 은행코드(<code>bank_code</code>)과 은행명(<code>bank_name</code>)은 모두 <strong>NULL</strong>로 내려가며, 송금자 이름을 확인하기 위해서는 아래 예시와 같이 별도의 쿼리 파라미터(<code>extension</code>)를 <strong>true</strong>로 설정해주셔야 합니다.</p>\n<div class=\"highlight highlight-source-text notranslate\"><pre>GET http://api.iamport.kr/payments/{포트원 거래고유번호}?**extension=true**</pre></div><pre><code>{\n    // ... 중략\n    \"bank_code\": null, // 송금자 은행 코드 알 수 없음\n    \"bank_name\": null, // 송금자 은행 이름 알 수 없음\n    \"extension\": {\n       // ... 중략\n       \"REMITTER\": \"홍길동\" // 송금자 이름\n    }\n}</code></pre>"
           },
           "paypal_v2": {
-            "description": "<p>페이팔 결제 건은 승인 요청 시 바로 승인 되지 않고 일정 시간 후 처리되는 승인 대기(<code>pending</code>) 상태가 존재합니다.\n     따라서 가맹점은 트랜잭션 종료시 결제 내역을 조회(GET /payments/{imp_uid})한 후 응답 되는 status를 보고 각 상황에 맞는 후 처리 로직을 작성해야 합니다.\n     승인 대기 상태에서는 최종적으로 승인(<code>paid</code>)이 될 수도 있고 승인이 되지 않을 수도(<code>failed</code>) 있기 때문에 가맹점은 반드시\n     (가상계좌나 정기결제와 같이 결제가 비동기로 승인되는 경우 포트원 → 가맹점으로 결제 결과를 통보해주는) <span>웹훅 기능을 연동해야 합니다.</span></p>\n"
+            "description": "<p>페이팔 결제 건은 승인 요청 시 바로 승인 되지 않고 일정 시간 후 처리되는 승인 대기(<code>pending</code>) 상태가 존재합니다.\n     따라서 고객사는 트랜잭션 종료시 결제 내역을 조회(GET /payments/{imp_uid})한 후 응답 되는 status를 보고 각 상황에 맞는 후 처리 로직을 작성해야 합니다.\n     승인 대기 상태에서는 최종적으로 승인(<code>paid</code>)이 될 수도 있고 승인이 되지 않을 수도(<code>failed</code>) 있기 때문에 고객사는 반드시\n     (가상계좌나 정기결제와 같이 결제가 비동기로 승인되는 경우 포트원 → 고객사로 결제 결과를 통보해주는) <span>웹훅 기능을 연동해야 합니다.</span></p>\n"
           }
         }
       }
@@ -3511,7 +3456,7 @@
           "payments"
         ],
         "summary": "결제내역 복수조회 API",
-        "description": "여러 개의 포트원 거래고유번호 또는 가맹점 주문번호로 결제내역을 한 번에 조회합니다.(최대 100개)\n     <br>(예시) /payments?imp_uid[]=imp_448280090638&imp_uid[]=imp_448280090639&merchant_uid[]=merchant_143434085216",
+        "description": "여러 개의 포트원 거래고유번호 또는 고객사 주문번호로 결제내역을 한 번에 조회합니다.(최대 100개)\n     <br>(예시) /payments?imp_uid[]=imp_448280090638&imp_uid[]=imp_448280090639&merchant_uid[]=merchant_143434085216",
         "operationId": "getPaymentListByImpUid",
         "consumes": [
           "application/json",
@@ -3538,7 +3483,7 @@
           {
             "name": "merchant_uid[]",
             "in": "query",
-            "description": "결제요청 시 가맹점에서 요청한 merchant_uid",
+            "description": "결제요청 시 고객사에서 요청한 merchant_uid",
             "required": false,
             "type": "array",
             "items": {
@@ -3546,8 +3491,8 @@
             },
             "collectionFormat": "multi",
             "default": "merchant_143434085216",
-            "x-portone-name": "가맹점 주문번호",
-            "x-portone-description": "<p>결제요청 시 가맹점에서 요청한 가맹점 주문번호</p>\n"
+            "x-portone-name": "고객사 주문번호",
+            "x-portone-description": "<p>결제요청 시 고객사에서 요청한 고객사 주문번호</p>\n"
           }
         ],
         "responses": {
@@ -3578,8 +3523,8 @@
         "tags": [
           "payments"
         ],
-        "summary": "결제 단건조회(고유 가맹점 주문번호 조회) API",
-        "description": "가맹점지정 고유번호로 결제내역을 확인합니다 <br>\n     동일한 merchant_uid가 여러 건 존재하는 경우, 정렬 기준에 따라 가장 첫 번째 해당되는 건을 반환합니다.\n     (모든 내역에 대한 조회가 필요하시면 GET 결제 복수조회(가맹점 주문번호 중복 포함) API를 사용해주세요.)<br><br>\n     payment_status를 추가로 지정하시면, 해당 status에 해당하는 가장 최신 데이터를 반환합니다.",
+        "summary": "결제 단건조회(고유 고객사 주문번호 조회) API",
+        "description": "고객사지정 고유번호로 결제내역을 확인합니다 <br>\n     동일한 merchant_uid가 여러 건 존재하는 경우, 정렬 기준에 따라 가장 첫 번째 해당되는 건을 반환합니다.\n     (모든 내역에 대한 조회가 필요하시면 GET 결제 복수조회(고객사 주문번호 중복 포함) API를 사용해주세요.)<br><br>\n     payment_status를 추가로 지정하시면, 해당 status에 해당하는 가장 최신 데이터를 반환합니다.",
         "operationId": "getPaymentByMerchantUid",
         "consumes": [
           "application/json",
@@ -3592,12 +3537,12 @@
           {
             "name": "merchant_uid",
             "in": "path",
-            "description": "결제요청 시 가맹점에서 요청한 merchant_uid",
+            "description": "결제요청 시 고객사에서 요청한 merchant_uid",
             "required": true,
             "type": "string",
             "default": "merchant_1448280088556",
-            "x-portone-name": "가맹점 주문번호",
-            "x-portone-description": "<p>결제요청 시 가맹점에서 요청한 가맹점 주문번호</p>\n"
+            "x-portone-name": "고객사 주문번호",
+            "x-portone-description": "<p>결제요청 시 고객사에서 요청한 고객사 주문번호</p>\n"
           },
           {
             "name": "payment_status",
@@ -3650,8 +3595,8 @@
         "tags": [
           "payments"
         ],
-        "summary": "결제 복수조회(가맹점 주문번호 중복 포함) API",
-        "description": "가맹점지정 고유번호 및 상태기준으로 결제내역을 확인합니다<br> 동일한 merchant_uid가 여러 건 존재하는 경우, 존재하는 모든 거래가 조회됩니다.\n     <br><br>payment_status를 추가로 지정하시면, 해당 status에 해당하는 가장 최신 데이터를 반환합니다.",
+        "summary": "결제 복수조회(고객사 주문번호 중복 포함) API",
+        "description": "고객사지정 고유번호 및 상태기준으로 결제내역을 확인합니다<br> 동일한 merchant_uid가 여러 건 존재하는 경우, 존재하는 모든 거래가 조회됩니다.\n     <br><br>payment_status를 추가로 지정하시면, 해당 status에 해당하는 가장 최신 데이터를 반환합니다.",
         "operationId": "getAllPaymentsByMerchantUid",
         "consumes": [
           "application/json",
@@ -3664,12 +3609,12 @@
           {
             "name": "merchant_uid",
             "in": "path",
-            "description": "결제요청 시 가맹점에서 요청한 merchant_uid",
+            "description": "결제요청 시 고객사에서 요청한 merchant_uid",
             "required": true,
             "type": "string",
             "default": "merchant_1448280088556",
-            "x-portone-name": "가맹점 주문번호",
-            "x-portone-description": "<p>결제요청 시 가맹점에서 요청한 가맹점 주문번호</p>\n"
+            "x-portone-name": "고객사 주문번호",
+            "x-portone-description": "<p>결제요청 시 고객사에서 요청한 고객사 주문번호</p>\n"
           },
           {
             "name": "payment_status",
@@ -3876,11 +3821,11 @@
           {
             "name": "merchant_uid",
             "in": "formData",
-            "description": "가맹점에서 전달한 거래 고유번호.<br>imp_uid, merchant_uid 중 하나는 필수이어야 합니다.<br>두 값이 모두 넘어오면 imp_uid를 우선 적용합니다.",
+            "description": "고객사에서 전달한 거래 고유번호.<br>imp_uid, merchant_uid 중 하나는 필수이어야 합니다.<br>두 값이 모두 넘어오면 imp_uid를 우선 적용합니다.",
             "required": false,
             "type": "string",
-            "x-portone-name": "가맹점 주문번호",
-            "x-portone-description": "<p>가맹점에서 전달한 거래 고유번호로 imp_uid, merchant_uid 중 하나는 필수이어야 합니다. (두 값이 모두 넘어오면 <strong>imp_uid를 우선 적용</strong>합니다.)</p>\n"
+            "x-portone-name": "고객사 주문번호",
+            "x-portone-description": "<p>고객사에서 전달한 거래 고유번호로 imp_uid, merchant_uid 중 하나는 필수이어야 합니다. (두 값이 모두 넘어오면 <strong>imp_uid를 우선 적용</strong>합니다.)</p>\n"
           },
           {
             "name": "amount",
@@ -3895,16 +3840,13 @@
           {
             "name": "tax_free",
             "in": "formData",
-            "description": "(부분)취소요청금액 중 면세금액(누락되면 0원처리)<br><h5>단, 아래 PG사의 경우 자동으로 0원 처리 되지 않으므로 면세 결제에 한하여 필수 입력 바랍니다.</h5><ul><li>kakao</li><li>kcp</li><li>kcp_quick</li><li>kicc</li><li>nice</li><li>payco</li></ul>",
+            "description": "(부분)취소요청금액 중 면세금액(누락되면 0원처리)<br><h5>단, 아래 PG사의 경우 자동으로 0원 처리 되지 않으므로 면세 결제에 한하여 필수 입력 바랍니다.</h5><ul><li>kcp</li><li>kcp_quick</li><li>kicc</li><li>nice</li><li>payco</li></ul>",
             "required": false,
             "type": "number",
             "x-portone-name": "(부분)취소요청 금액 중 면세금액",
             "x-portone-summary": "<p>(부분)취소요청금액 중 면세금액으로 누락되면 0원처리합니다.</p>\n",
             "x-portone-description": "<p>단, 아래 PG사의 경우 자동으로 0원 처리 되지 않으므로 면세 결제에 한하여 <strong>필수 입력</strong> 바랍니다.</p>\n",
             "x-portone-per-pg": {
-              "kakao": {
-                "description": "<p>누락시 자동으로 0원 처리 되지 않으므로 면세 결제에 한하여 필수 입력 바랍니다.</p>\n"
-              },
               "kcp": {
                 "description": "<p>누락시 자동으로 0원 처리 되지 않으므로 면세 결제에 한하여 필수 입력 바랍니다.</p>\n"
               },
@@ -3924,7 +3866,7 @@
                 "description": "<p>부분취소시 면세 금액이 포함된 경우 반드시 취소 면세금액(tax_free)을 필수 입력 바랍니다</p>\n"
               },
               "welcome": {
-                "description": "<p><strong><code>부가세업체정함</code> 설정 가맹점에 한해 결제 시 면세금액을 지정했던 경우 필수</strong> 입력 바라며, 입력한 면세금액이 그대로 취소 승인되기 때문에 정확한 금액을 입력해 주시길 바랍니다.</p>\n"
+                "description": "<p><strong><code>부가세업체정함</code> 설정 고객사에 한해 결제 시 면세금액을 지정했던 경우 필수</strong> 입력 바라며, 입력한 면세금액이 그대로 취소 승인되기 때문에 정확한 금액을 입력해 주시길 바랍니다.</p>\n"
               }
             }
           },
@@ -3951,7 +3893,7 @@
                 "description": "<p><strong>결제 시 부가세를 지정했던 경우 필수</strong> 입력 바랍니다.</p>\n"
               },
               "welcome": {
-                "description": "<p><strong><code>부가세업체정함</code> 설정 가맹점에 한해 결제 시 부가세를 지정했던 경우 필수</strong> 입력이 필요하며, 입력한 부가세가 그대로 취소 승인되기 때문에 정확한 금액을 입력해 주시길 바랍니다.</p>\n"
+                "description": "<p><strong><code>부가세업체정함</code> 설정 고객사에 한해 결제 시 부가세를 지정했던 경우 필수</strong> 입력이 필요하며, 입력한 부가세가 그대로 취소 승인되기 때문에 정확한 금액을 입력해 주시길 바랍니다.</p>\n"
               }
             }
           },
@@ -4085,10 +4027,10 @@
             "description": "<p>결제 취소 특이사항\n     - 휴대폰 결제는 부분취소가 불가능합니다.\n     - 카드결제, 가상계좌, 계좌이체, 간편결제의 경우 부분취소는 총 <strong>9번</strong> 가능하며 취소는 결제일 기준 <strong>6개월 이내</strong>에만 가능합니다.\n     - 계좌입금 거래 시 발급한 현금영수증은 경우 거래 취소 시 <strong>자동으로 취소 되지 않습니다.</strong> 수동으로 취소해야 합니다.\n     - 복합과세의 계좌입금 거래를 부분취소하는 경우 기존에 발급한 현금영수증을 취소하고 부분취소 금액이 반영된 금액 정보로 다시 현금영수증을 발급해야합니다.\n     - 가상계좌 결제건 취소는 <strong>23:00~06:00</strong> 시간 외에만 가능합니다.</p>\n"
           },
           "smartro_v2": {
-            "description": "<p>테스트 모드 특이사항\n     - 체크카드 결제 건의 경우 전액 취소만 가능하며 <strong>부분취소는 불가능</strong>합니다.\n     - 카카오페이에서 등록된 카드로 결제시, 결제 된 금액이 자동으로 취소되지 않으므로 반드시 포트 REST 결제취소 API(POST /payments/cancel)로 직접 취소하셔야 합니다.</p>\n<p>연동 특이사항\n     - 가상 계좌 결제건 취소에 한해 취소 요청이후 즉시 환불 처리가 되는 것이 아니라 스마트로에서 입력한 환불계좌로 최종 환불 처리하면,\n     가맹점은 결과를 핑백(웹훅)으로 응답받은 후에 최종 취소 완료 처리를 해주셔야 합니다.\n     - 현금영수증 미발행 가상 계좌 결제건은 스마트로에서 면세금액에 대한 검증을 따로 지원하지 않기 때문에, 취소시 정확한 취소 면세금액을 요청해야합니다.</p>\n"
+            "description": "<p>테스트 모드 특이사항\n     - 체크카드 결제 건의 경우 전액 취소만 가능하며 <strong>부분취소는 불가능</strong>합니다.\n     - 카카오페이에서 등록된 카드로 결제시, 결제 된 금액이 자동으로 취소되지 않으므로 반드시 포트 REST 결제취소 API(POST /payments/cancel)로 직접 취소하셔야 합니다.</p>\n<p>연동 특이사항\n     - 가상 계좌 결제건 취소에 한해 취소 요청이후 즉시 환불 처리가 되는 것이 아니라 스마트로에서 입력한 환불계좌로 최종 환불 처리하면,\n     고객사는 결과를 핑백(웹훅)으로 응답받은 후에 최종 취소 완료 처리를 해주셔야 합니다.\n     - 현금영수증 미발행 가상 계좌 결제건은 스마트로에서 면세금액에 대한 검증을 따로 지원하지 않기 때문에, 취소시 정확한 취소 면세금액을 요청해야합니다.</p>\n"
           },
           "naverpay": {
-            "description": "<p>API 호출시 아래 파라미터를 반드시 설정해 주셔야 합니다. (<strong>해당 파라미터 누락시 네이버페이 실 검수를 통과할 수 없습니다.</strong>)\n     - <code>extra.requester</code>: API를 호출하는 출처\n     - <code>customer</code>: 구매자에 의한 요청\n     - <code>admin</code>(기본값): 어드민에 의한 요청\n     - <code>reason</code>: 결제 취소 사유</p>\n<h4 id=\"예시json\"><a class=\"anchor\" aria-hidden=\"true\" tabindex=\"-1\" href=\"#예시json\"><svg class=\"octicon octicon-link\" viewbox=\"0 0 16 16\" width=\"16\" height=\"16\" aria-hidden=\"true\"><path fill-rule=\"evenodd\" d=\"M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z\"></path></svg></a>예시(json)</h4><pre><code>```ts\n{\n\"imp_uid\" : \"imp_123412341234\", //환불처리할 포트원 거래고유번호\n\"amount\" : 3000, //환불할 금액\n\"reason\": \"결제 취소 사유\", //실제 사유와 같아야 함\n\"extra\" : {\n\"requester\" : \"customer\"\n}\n}\n```</code></pre><h4 id=\"예시form-urlencoded\"><a class=\"anchor\" aria-hidden=\"true\" tabindex=\"-1\" href=\"#예시form-urlencoded\"><svg class=\"octicon octicon-link\" viewbox=\"0 0 16 16\" width=\"16\" height=\"16\" aria-hidden=\"true\"><path fill-rule=\"evenodd\" d=\"M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z\"></path></svg></a>예시(form-urlencoded)</h4><pre><code>```\nimp_uid=imp_123412341234&amp;amount=3000&amp;extra[requester]=customer\n```\n </code></pre>"
+            "description": "<p>API 호출시 아래 파라미터를 반드시 설정해 주셔야 합니다. (<strong>해당 파라미터 누락시 네이버페이 실 검수를 통과할 수 없습니다.</strong>)\n     - <code>extra.requester</code>: API를 호출하는 출처\n     - <code>customer</code>: 구매자에 의한 요청\n     - <code>admin</code>(기본값): 어드민에 의한 요청\n     - <code>reason</code>: 결제 취소 사유</p>\n<h4 id=\"예시json\"><a class=\"anchor\" aria-hidden=\"true\" tabindex=\"-1\" href=\"#예시json\"><svg class=\"octicon octicon-link\" viewbox=\"0 0 16 16\" width=\"16\" height=\"16\" aria-hidden=\"true\"><path fill-rule=\"evenodd\" d=\"M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z\"></path></svg></a>예시(json)</h4><pre><code>```javascript\n{\n\"imp_uid\" : \"imp_123412341234\", //환불처리할 포트원 거래고유번호\n\"amount\" : 3000, //환불할 금액\n\"reason\": \"결제 취소 사유\", //실제 사유와 같아야 함\n\"extra\" : {\n\"requester\" : \"customer\"\n}\n}\n```</code></pre><h4 id=\"예시form-urlencoded\"><a class=\"anchor\" aria-hidden=\"true\" tabindex=\"-1\" href=\"#예시form-urlencoded\"><svg class=\"octicon octicon-link\" viewbox=\"0 0 16 16\" width=\"16\" height=\"16\" aria-hidden=\"true\"><path fill-rule=\"evenodd\" d=\"M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z\"></path></svg></a>예시(form-urlencoded)</h4><pre><code>```\nimp_uid=imp_123412341234&amp;amount=3000&amp;extra[requester]=customer\n```\n </code></pre>"
           },
           "html5_inicis": {
             "description": "<p>취소 시 <strong>요청된 값 그대로 이니시스에서 취소</strong>가 되므로, 취소할 금액, 부가세, 면세금액을 정확하게 전달해 주셔야 부가세, 면세금액이 설정되어 정상적으로 취소가 된다는 점 주의해주시기 바랍니다.</p>\n"
@@ -4097,16 +4039,16 @@
             "description": "<p>상점 아이디 설정이 지정금액 방식인 경우에는 취소 시에 공급가액, 부가세, 봉사료, 면세금액 등을 설정하도록 하고 있습니다.(<a href=\"https://developers.nicepay.co.kr/tip.php\" rel=\"noopener noreferrer\">링크</a>의 1617 코드 참조). 취소 시 취소할 금액, 부가세, 면세금액을 정확하게 전달해 주셔야 공급가액, 부가세, 면세금액, 봉사료(0원)가 설정되어 정상적으로 취소가 된다는 점 주의해주시기 바랍니다.</p>\n"
           },
           "daou": {
-            "description": "<p>가상계좌 결제 취소시, PG사와 특약 필요하며, 실제 환불 금액 입금까지 <strong>7 영업일 이상</strong> 소요됩니다.</p>\n<ul>\n<li>가상계좌 입금 완료 건에 대한 결제 취소(환불)은 가상계좌 발급 시 부과되는 수수료 이슈로 인해 키움페이(구 다우, 페이조아)와 특약을 맺어야지만 가능합니다. 이 특약 없이는 기본적으로 가상계좌 결제 건의 환불은 <strong>불가능</strong>합니다.</li>\n<li>키움페이(구 다우, 페이조아) 가상계좌 결제 취소(환불)는 가맹점 → 포트원 → 키움페이(구 다우, 페이조아)로 환불 요청 접수 시, 키움페이(구 다우, 페이조아) 담당자가 수기로 확인 후 환불 처리를 해 주는 프로세스로 진행되기 때문에 환불 금액이 실제로 입금 될때까지 <strong>7 영업일 이상</strong> 소요됩니다.</li>\n</ul>\n"
+            "description": "<p>가상계좌 결제 취소시, PG사와 특약 필요하며, 실제 환불 금액 입금까지 <strong>7 영업일 이상</strong> 소요됩니다.</p>\n<ul>\n<li>가상계좌 입금 완료 건에 대한 결제 취소(환불)은 가상계좌 발급 시 부과되는 수수료 이슈로 인해 키움페이(구 다우, 페이조아)와 특약을 맺어야지만 가능합니다. 이 특약 없이는 기본적으로 가상계좌 결제 건의 환불은 <strong>불가능</strong>합니다.</li>\n<li>키움페이(구 다우, 페이조아) 가상계좌 결제 취소(환불)는 고객사 → 포트원 → 키움페이(구 다우, 페이조아)로 환불 요청 접수 시, 키움페이(구 다우, 페이조아) 담당자가 수기로 확인 후 환불 처리를 해 주는 프로세스로 진행되기 때문에 환불 금액이 실제로 입금 될때까지 <strong>7 영업일 이상</strong> 소요됩니다.</li>\n</ul>\n"
           },
           "paypal_v2": {
-            "description": "<p>결제 취소 요청 시 취소 요청이 바로 승인 되지 않고 일정 시간 후 승인처리되는 경우가 존재합니다.\n     가맹점은 결제 취소 요청 응답 처리 시 취소가 승인되었는지 여부를 확인해야 합니다.</p>\n<p>결제 취소 API를 통해 취소 요청을 한 경우 API 응답의 <strong>status</strong>와 <strong>cancel_history</strong> 값을 기준으로 취소 승인 여부를 판단해야 합니다. status가 cancelled 이고 cancel_history에 취소 요청 내역이 있는 경우 취소가 승인된 것이고 그렇지 않은 경우 취소 승인대기 상태입니다.\n콘솔을 통한 취소 요청이 승인대기인 경우 결제내역에서 결제상태는 결제취소로 변경되지 않고 진행중인 취소요청 내역이 있음이 표시되며 결제내역 상세 화면에서 취소요청내역이 조회됩니다.</p>\n<p>취소 요청이 승인대기 상태인 경우 최종적으로 승인되거나 승인되지 않을 수 있기 때문에 <span>가맹점은 최종 취소 처리 결과를 전달받기 위해 가맹점 통보 웹훅 기능을 연동해야 합니다.</span></p>\n<h3 id=\"취소-요청이-승인대기-중인-결제-상태\"><a class=\"anchor\" aria-hidden=\"true\" tabindex=\"-1\" href=\"#취소-요청이-승인대기-중인-결제-상태\"><svg class=\"octicon octicon-link\" viewbox=\"0 0 16 16\" width=\"16\" height=\"16\" aria-hidden=\"true\"><path fill-rule=\"evenodd\" d=\"M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z\"></path></svg></a>취소 요청이 승인대기 중인 결제 상태</h3><p><img src=\"https://raw.githubusercontent.com/portone-io/developers.portone.io/e206047c43ed15bc364b58e0647dda4584964c9c/public/gitbook-assets/ko/image%20%283%29%20%282%29.png\" alt /></p>\n<h3 id=\"취소-요청이-승인대기-중인-결제내역-상세\"><a class=\"anchor\" aria-hidden=\"true\" tabindex=\"-1\" href=\"#취소-요청이-승인대기-중인-결제내역-상세\"><svg class=\"octicon octicon-link\" viewbox=\"0 0 16 16\" width=\"16\" height=\"16\" aria-hidden=\"true\"><path fill-rule=\"evenodd\" d=\"M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z\"></path></svg></a>취소 요청이 승인대기 중인 결제내역 상세</h3><p><img src=\"https://raw.githubusercontent.com/portone-io/developers.portone.io/e206047c43ed15bc364b58e0647dda4584964c9c/public/gitbook-assets/ko/image%20%281%29%20%282%29.png\" alt />\n     </p>\n"
+            "description": "<p>결제 취소 요청 시 취소 요청이 바로 승인 되지 않고 일정 시간 후 승인처리되는 경우가 존재합니다.\n     고객사는 결제 취소 요청 응답 처리 시 취소가 승인되었는지 여부를 확인해야 합니다.</p>\n<p>결제 취소 API를 통해 취소 요청을 한 경우 API 응답의 <strong>status</strong>와 <strong>cancel_history</strong> 값을 기준으로 취소 승인 여부를 판단해야 합니다. status가 cancelled 이고 cancel_history에 취소 요청 내역이 있는 경우 취소가 승인된 것이고 그렇지 않은 경우 취소 승인대기 상태입니다.\n콘솔을 통한 취소 요청이 승인대기인 경우 결제내역에서 결제상태는 결제취소로 변경되지 않고 진행중인 취소요청 내역이 있음이 표시되며 결제내역 상세 화면에서 취소요청내역이 조회됩니다.</p>\n<p>취소 요청이 승인대기 상태인 경우 최종적으로 승인되거나 승인되지 않을 수 있기 때문에 <span>고객사는 최종 취소 처리 결과를 전달받기 위해 고객사 통보 웹훅 기능을 연동해야 합니다.</span></p>\n<h3 id=\"취소-요청이-승인대기-중인-결제-상태\"><a class=\"anchor\" aria-hidden=\"true\" tabindex=\"-1\" href=\"#취소-요청이-승인대기-중인-결제-상태\"><svg class=\"octicon octicon-link\" viewbox=\"0 0 16 16\" width=\"16\" height=\"16\" aria-hidden=\"true\"><path fill-rule=\"evenodd\" d=\"M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z\"></path></svg></a>취소 요청이 승인대기 중인 결제 상태</h3><p><img src=\"https://raw.githubusercontent.com/portone-io/developers.portone.io/e206047c43ed15bc364b58e0647dda4584964c9c/public/gitbook-assets/ko/image%20%283%29%20%282%29.png\" alt /></p>\n<h3 id=\"취소-요청이-승인대기-중인-결제내역-상세\"><a class=\"anchor\" aria-hidden=\"true\" tabindex=\"-1\" href=\"#취소-요청이-승인대기-중인-결제내역-상세\"><svg class=\"octicon octicon-link\" viewbox=\"0 0 16 16\" width=\"16\" height=\"16\" aria-hidden=\"true\"><path fill-rule=\"evenodd\" d=\"M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z\"></path></svg></a>취소 요청이 승인대기 중인 결제내역 상세</h3><p><img src=\"https://raw.githubusercontent.com/portone-io/developers.portone.io/e206047c43ed15bc364b58e0647dda4584964c9c/public/gitbook-assets/ko/image%20%281%29%20%282%29.png\" alt />\n     </p>\n"
           },
           "tosspayments": {
             "description": "<p>결제수단이 <strong>상품권</strong>인 결제건은 부분취소가 불가능합니다</p>\n"
           },
           "welcome": {
-            "description": "<p>부분 취소는 지불수단 별로 <strong>부분 환불 사용 서비스 신청</strong> 가맹점에 한해 지원 가능합니다. 부분 환불 사용 서비스 사용 신청 및 사용 여부 문의는 웰컴페이먼츠 계약 담당자에게 확인해주시기를 바랍니다.</p>\n"
+            "description": "<p>부분 취소는 지불수단 별로 <strong>부분 환불 사용 서비스 신청</strong> 고객사에 한해 지원 가능합니다. 부분 환불 사용 서비스 사용 신청 및 사용 여부 문의는 웰컴페이먼츠 계약 담당자에게 확인해주시기를 바랍니다.</p>\n"
           }
         }
       }
@@ -4130,12 +4072,12 @@
           {
             "name": "merchant_uid",
             "in": "formData",
-            "description": "이미 사전등록한 가맹점 주문번호",
+            "description": "이미 사전등록한 고객사 주문번호",
             "required": true,
             "type": "string",
             "maxLength": 40,
-            "x-portone-name": "가맹점 주문번호",
-            "x-portone-description": "<p>이미 사전등록한 가맹점 주문번호</p>\n"
+            "x-portone-name": "고객사 주문번호",
+            "x-portone-description": "<p>이미 사전등록한 고객사 주문번호</p>\n"
           },
           {
             "name": "amount",
@@ -4168,7 +4110,7 @@
           "payments.validation"
         ],
         "summary": "결제금액 사전등록 API",
-        "description": "(포트원 javascript사용)인증방식의 결제를 진행할 때 결제금액 위변조시 결제진행자체를 block하기 위해 결제예정금액을 사전등록하는 기능입니다.\n     <br>이 API를 통해 사전등록된 가맹점 주문번호(merchant_uid)에 대해, IMP.request_pay()에 전달된 merchant_uid가 일치하는 주문의 결제금액이 다른 경우 PG사 결제창 호출이 중단됩니다.",
+        "description": "(포트원 javascript사용)인증방식의 결제를 진행할 때 결제금액 위변조시 결제진행자체를 block하기 위해 결제예정금액을 사전등록하는 기능입니다.\n     <br>이 API를 통해 사전등록된 고객사 주문번호(merchant_uid)에 대해, IMP.request_pay()에 전달된 merchant_uid가 일치하는 주문의 결제금액이 다른 경우 PG사 결제창 호출이 중단됩니다.",
         "operationId": "preparePayment",
         "consumes": [
           "application/json",
@@ -4181,12 +4123,12 @@
           {
             "name": "merchant_uid",
             "in": "formData",
-            "description": "가맹점 주문번호",
+            "description": "고객사 주문번호",
             "required": true,
             "type": "string",
             "maxLength": 40,
-            "x-portone-name": "가맹점 주문번호",
-            "x-portone-description": "<p>결제금액을 사전 등록할 결제건의 가맹점 주문번호</p>\n"
+            "x-portone-name": "고객사 주문번호",
+            "x-portone-description": "<p>결제금액을 사전 등록할 결제건의 고객사 주문번호</p>\n"
           },
           {
             "name": "amount",
@@ -4231,11 +4173,11 @@
           {
             "name": "merchant_uid",
             "in": "path",
-            "description": "가맹점 주문번호",
+            "description": "고객사 주문번호",
             "required": true,
             "type": "string",
-            "x-portone-name": "가맹점 주문번호",
-            "x-portone-description": "<p>결제금액을 조회할 결제건의 가맹점 주문번호</p>\n"
+            "x-portone-name": "고객사 주문번호",
+            "x-portone-description": "<p>결제금액을 조회할 결제건의 고객사 주문번호</p>\n"
           }
         ],
         "responses": {
@@ -4281,12 +4223,12 @@
           {
             "name": "merchant_uid",
             "in": "formData",
-            "description": "가맹점 주문번호",
+            "description": "고객사 주문번호",
             "required": true,
             "type": "string",
             "maxLength": 40,
-            "x-portone-name": "가맹점 주문번호",
-            "x-portone-description": "<p>배송등록 할 결제건의 가맹점 주문번호</p>\n"
+            "x-portone-name": "고객사 주문번호",
+            "x-portone-description": "<p>배송등록 할 결제건의 고객사 주문번호</p>\n"
           },
           {
             "name": "type",
@@ -4791,11 +4733,11 @@
           {
             "name": "vat_amount",
             "in": "formData",
-            "description": "부가세 지정 가맹점에 한해 현금영수증 발행 금액 중 부가세 금액으로 부가세를 지정할 수 있습니다.",
+            "description": "부가세 지정 고객사에 한해 현금영수증 발행 금액 중 부가세 금액으로 부가세를 지정할 수 있습니다.",
             "required": false,
             "type": "number",
             "x-portone-name": "부가세 지정 금액",
-            "x-portone-description": "<p>부가세 지정 가맹점에 한해 현금영수증 발행 금액 중 부가세 금액으로 부가세를 지정할 수 있습니다.</p>\n"
+            "x-portone-description": "<p>부가세 지정 고객사에 한해 현금영수증 발행 금액 중 부가세 금액으로 부가세를 지정할 수 있습니다.</p>\n"
           }
         ],
         "responses": {
@@ -4924,11 +4866,11 @@
           {
             "name": "merchant_uid",
             "in": "path",
-            "description": "현금영수증 발행 대상 가맹점 주문번호",
+            "description": "현금영수증 발행 대상 고객사 주문번호",
             "required": true,
             "type": "string",
-            "x-portone-name": "가맹점 주문번호",
-            "x-portone-description": "<p>현금영수증 발행 대상 가맹점 주문번호</p>\n"
+            "x-portone-name": "고객사 주문번호",
+            "x-portone-description": "<p>현금영수증 발행 대상 고객사 주문번호</p>\n"
           }
         ],
         "responses": {
@@ -4977,12 +4919,12 @@
           {
             "name": "merchant_uid",
             "in": "path",
-            "description": "현금영수증 발행을 위한 가맹점 주문번호 (스마트로 - 신모듈의 경우, 특수문자 포함이 불가능합니다.) <br>가맹점 주문번호는 현금거래 주문번호와 동일한 번호를 기재해야 추후 대사가 가능한점 유념하시기 바랍니다.",
+            "description": "현금영수증 발행을 위한 고객사 주문번호 (스마트로 - 신모듈의 경우, 특수문자 포함이 불가능합니다.) <br>고객사 주문번호는 현금거래 주문번호와 동일한 번호를 기재해야 추후 대사가 가능한점 유념하시기 바랍니다.",
             "required": true,
             "type": "string",
-            "x-portone-name": "가맹점 주문번호",
-            "x-portone-summary": "<p>현금영수증 발행을 위한 가맹점 주문번호</p>\n",
-            "x-portone-description": "<p>가맹점 주문번호는 현금거래 주문번호와 동일한 번호를 기재해야 추후 대사가 가능한점 유념하시기 바랍니다.</p>\n",
+            "x-portone-name": "고객사 주문번호",
+            "x-portone-summary": "<p>현금영수증 발행을 위한 고객사 주문번호</p>\n",
+            "x-portone-description": "<p>고객사 주문번호는 현금거래 주문번호와 동일한 번호를 기재해야 추후 대사가 가능한점 유념하시기 바랍니다.</p>\n",
             "x-portone-per-pg": {
               "smartro_v2": {
                 "description": "<p><strong>특수문자 포함이 불가능</strong>합니다.</p>\n"
@@ -5163,7 +5105,7 @@
           {
             "name": "pg",
             "in": "formData",
-            "description": "PG설정이 2개 이상인 경우, 현금영수증 발행처리를 원하는 PG사를 지정하실 수 있습니다.\n     pg 파라메터는 <b>{PG사}</b> 혹은 <b>{PG사}.{PG상점아이디}</b> 형태의 문자열입니다. <br>\n     지정하지 않거나 유효하지 않은 값이 전달되면 기본PG설정된 값을 이용해 결제하게 됩니다. <br>\n     <ul><li>나이스페이먼츠, JTNet 2가지 PG설정이 되어있다면, pg 파라메터로 <b>nice</b> 또는 <b>jtnet</b>로 구분 가능</li>\n     <li>나이스페이먼츠로부터 2개 이상의 상점아이디를 발급받았다면, <b>nice.MID1</b> 또는 <b>nice.MID2</b>로 구분 가능</li></ul>",
+            "description": "PG설정이 2개 이상인 경우, 현금영수증 발행처리를 원하는 PG사를 지정하실 수 있습니다.\n     pg 파라메터는 <b>{PG사}</b> 혹은 <b>{PG사}.{PG상점아이디}</b> 형태의 문자열입니다. <br>\n     지정하지 않거나 유효하지 않은 값이 전달되면 기본PG설정된 값을 이용해 결제하게 됩니다. <br>\n     <ul><li>나이스페이먼츠, KCP 2가지 PG설정이 되어있다면, pg 파라메터로 <b>nice</b> 또는 <b>kcp</b>로 구분 가능</li>\n     <li>나이스페이먼츠로부터 2개 이상의 상점아이디를 발급받았다면, <b>nice.MID1</b> 또는 <b>nice.MID2</b>로 구분 가능</li></ul>",
             "required": false,
             "type": "string",
             "maxLength": 80,
@@ -5173,11 +5115,11 @@
           {
             "name": "vat_amount",
             "in": "formData",
-            "description": "부가세 지정 가맹점에 한해 현금영수증 발행 금액 중 부가세 금액으로 부가세를 지정할 수 있습니다.",
+            "description": "부가세 지정 고객사에 한해 현금영수증 발행 금액 중 부가세 금액으로 부가세를 지정할 수 있습니다.",
             "required": false,
             "type": "number",
             "x-portone-name": "부가세 지정 금액",
-            "x-portone-description": "<p>부가세 지정 가맹점에 한해 현금영수증 발행 금액 중 부가세 금액으로 부가세를 지정할 수 있습니다.</p>\n"
+            "x-portone-description": "<p>부가세 지정 고객사에 한해 현금영수증 발행 금액 중 부가세 금액으로 부가세를 지정할 수 있습니다.</p>\n"
           },
           {
             "name": "corp_reg_no",
@@ -5282,11 +5224,11 @@
           {
             "name": "merchant_uid",
             "in": "path",
-            "description": "발급취소대상 가맹점 주문번호 <br> merchant_uid는 현금결제를 구분할 고유주문번호를 의미하며 발행에 사용된 값을 전달하면 됩니다.",
+            "description": "발급취소대상 고객사 주문번호 <br> merchant_uid는 현금결제를 구분할 고유주문번호를 의미하며 발행에 사용된 값을 전달하면 됩니다.",
             "required": true,
             "type": "string",
-            "x-portone-name": "가맹점 주문번호",
-            "x-portone-summary": "<p>발급취소대상 가맹점 주문번호</p>\n",
+            "x-portone-name": "고객사 주문번호",
+            "x-portone-summary": "<p>발급취소대상 고객사 주문번호</p>\n",
             "x-portone-description": "<p>merchant_uid는 현금결제를 구분할 고유주문번호를 의미하며 발행에 사용된 값을 전달하면 됩니다.</p>\n"
           }
         ],
@@ -5492,12 +5434,12 @@
           {
             "name": "merchant_uid",
             "in": "formData",
-            "description": "가맹점 거래 고유번호 <br> 매 결제요청 시 고유값으로 요청해야 합니다.",
+            "description": "고객사 거래 고유번호 <br> 매 결제요청 시 고유값으로 요청해야 합니다.",
             "required": true,
             "type": "string",
             "maxLength": 40,
-            "x-portone-name": "가맹점 주문번호",
-            "x-portone-description": "<p>가맹점 거래 고유번호로 매 결제요청 시 고유값으로 요청해야 합니다.</p>\n"
+            "x-portone-name": "고객사 주문번호",
+            "x-portone-description": "<p>고객사 거래 고유번호로 매 결제요청 시 고유값으로 요청해야 합니다.</p>\n"
           },
           {
             "name": "currency",
@@ -5535,14 +5477,14 @@
                 "description": "<p>면세 설정 상점아이디에서 면세처리를 위해 결제 금액과 동일한 면세 금액을 반드시 입력해야 합니다. 그렇지 않은 경우 매출전표에 전액 면세가 아닌 것으로 표시되고 실제 처리 내역이 다를 수 있습니다.</p>\n<p>과세 설정 상점아이디에서 면세 금액을 전달하지 않아야 합니다. 면세 금액을 전달하는 경우 매출전표에 면세 처리된 것으로 표시되지만 실제 처리 내역과 다를 수 있습니다.</p>\n"
               },
               "welcome": {
-                "description": "<p><code>부가세업체정함</code> 설정 가맹점에 한해 사용 가능합니다.</p>\n"
+                "description": "<p><code>부가세업체정함</code> 설정 고객사에 한해 사용 가능합니다.</p>\n"
               }
             }
           },
           {
             "name": "vat_amount",
             "in": "formData",
-            "description": "amount 중 부가세 금액.<br/>부가세를 지정할 수 있으며, tax_free=0, vat_amount=0으로 영세율로 결제 가능합니다.(기본값: null)<br><h5>지원되는 PG사</h5><ul><li>나이스페이먼츠</li><li>이니시스</li><li>(신) 나이스페이</li><li>웰컴페이먼츠</li><li>(신) 토스페이</li></ul>",
+            "description": "amount 중 부가세 금액.<br/>부가세를 지정할 수 있으며, tax_free=0, vat_amount=0으로 영세율로 결제 가능합니다.(기본값: null)<br><h5>지원되는 PG사</h5><ul><li>나이스페이먼츠</li><li>이니시스</li><li>(신) 나이스페이</li><li>웰컴페이먼츠</li></ul>",
             "required": false,
             "type": "number",
             "x-portone-name": "부가세",
@@ -5552,12 +5494,11 @@
               "nice",
               "html5_inicis",
               "nice_v2",
-              "welcome",
-              "tosspay_v2"
+              "welcome"
             ],
             "x-portone-per-pg": {
               "welcome": {
-                "description": "<p><code>부가세업체정함</code> 설정 가맹점에 한해 사용 가능하며 전체금액의 10% 이하로 설정해야 합니다. vat_amount가 <span>총 상품가격의 10%를 초과할 경우는 결제가 거절됩니다.</span></p>\n"
+                "description": "<p><code>부가세업체정함</code> 설정 고객사에 한해 사용 가능하며 전체금액의 10% 이하로 설정해야 합니다. vat_amount가 <span>총 상품가격의 10%를 초과할 경우는 결제가 거절됩니다.</span></p>\n"
               }
             }
           },
@@ -5637,12 +5578,12 @@
           {
             "name": "customer_uid",
             "in": "formData",
-            "description": "빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호.<br><br>(결제에 사용된 카드정보를 빌링키 형태로 저장해두고 재결제에 사용하시려면 customer_uid를 지정해주세요. 비 인증 결제(빌링키) API, 결제 예약 API로 재결제를 진행하실 수 있습니다. customer_uid가 없는 경우 저장되지 않습니다.)",
+            "description": "빌링키와 매핑되며 고객사에서 채번하는 구매자의 결제 수단 식별 고유번호.<br><br>(결제에 사용된 카드정보를 빌링키 형태로 저장해두고 재결제에 사용하시려면 customer_uid를 지정해주세요. 비 인증 결제(빌링키) API, 결제 예약 API로 재결제를 진행하실 수 있습니다. customer_uid가 없는 경우 저장되지 않습니다.)",
             "required": false,
             "type": "string",
             "maxLength": 80,
             "x-portone-name": "구매자의 결제 수단 식별 고유번호",
-            "x-portone-description": "<p>빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n",
+            "x-portone-description": "<p>빌링키와 매핑되며 고객사에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n",
             "x-portone-unsupported-pgs": [
               "ksnet",
               "tosspayments"
@@ -5651,7 +5592,7 @@
           {
             "name": "pg",
             "in": "formData",
-            "description": "API 방식 비인증 PG설정이 2개 이상인 경우, 결제가 진행되길 원하는 PG사를 지정하실 수 있습니다. pg 파라메터는 <b>{PG사}</b> 혹은 <b>{PG사}.{PG상점아이디}</b> 형태의 문자열입니다. <br>지정하지 않거나 유효하지 않은 값이 전달되면 기본PG설정된 값을 이용해 결제하게 됩니다. <br><ul><li>나이스페이먼츠, JTNet 2가지 PG설정이 되어있다면, pg 파라메터로 <b>nice</b> 또는 <b>jtnet</b>로 구분 가능</li><li>나이스페이먼츠로부터 2개 이상의 상점아이디를 발급받았다면, <b>nice.MID1</b> 또는 <b>nice.MID2</b>로 구분 가능</li></ul>",
+            "description": "API 방식 비인증 PG설정이 2개 이상인 경우, 결제가 진행되길 원하는 PG사를 지정하실 수 있습니다. pg 파라메터는 <b>{PG사}</b> 혹은 <b>{PG사}.{PG상점아이디}</b> 형태의 문자열입니다. <br>지정하지 않거나 유효하지 않은 값이 전달되면 기본PG설정된 값을 이용해 결제하게 됩니다. <br><ul><li>나이스페이먼츠, KCP 2가지 PG설정이 되어있다면, pg 파라메터로 <b>nice</b> 또는 <b>kcp</b>로 구분 가능</li><li>나이스페이먼츠로부터 2개 이상의 상점아이디를 발급받았다면, <b>nice.MID1</b> 또는 <b>nice.MID2</b>로 구분 가능</li></ul>",
             "required": false,
             "type": "string",
             "maxLength": 80,
@@ -5760,12 +5701,12 @@
           {
             "name": "interest_free_by_merchant",
             "in": "formData",
-            "description": "카드할부처리할 때, 할부이자가 발생하는 경우(카드사 무이자 프로모션 제외) 부과되는 할부이자를 고객대신 가맹점이 지불하고자 PG사와 계약된 경우 <br>(현재, 나이스페이먼츠, (신) 나이스페이만 지원됨)",
+            "description": "카드할부처리할 때, 할부이자가 발생하는 경우(카드사 무이자 프로모션 제외) 부과되는 할부이자를 고객대신 고객사가 지불하고자 PG사와 계약된 경우 <br>(현재, 나이스페이먼츠, (신) 나이스페이만 지원됨)",
             "required": false,
             "type": "boolean",
             "default": false,
-            "x-portone-name": "가맹점 부담 무이자 할부여부",
-            "x-portone-description": "<p>카드할부처리할 때, 할부이자가 발생하는 경우(카드사 무이자 프로모션 제외) 부과되는 할부이자를 고객대신 가맹점이 지불하는지에 대한 여부 (<strong>PG사와 사전 계약이 필요</strong>)</p>\n",
+            "x-portone-name": "고객사 부담 무이자 할부여부",
+            "x-portone-description": "<p>카드할부처리할 때, 할부이자가 발생하는 경우(카드사 무이자 프로모션 제외) 부과되는 할부이자를 고객대신 고객사가 지불하는지에 대한 여부 (<strong>PG사와 사전 계약이 필요</strong>)</p>\n",
             "x-portone-supported-pgs": [
               "nice_v2",
               "nice"
@@ -5881,7 +5822,6 @@
           "nice",
           "nice_v2",
           "html5_inicis",
-          "jtnet",
           "paymentwall",
           "settle",
           "tosspayments",
@@ -5910,22 +5850,22 @@
           {
             "name": "customer_uid",
             "in": "formData",
-            "description": "빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호<br> PG사가 발급한 빌링키와 1:1로 맵핑되는 가맹점이 지정한 고유값입니다. <br>customer_uid는 카드번호 단위로 구분되서 저장되어야 합니다.",
+            "description": "빌링키와 매핑되며 고객사에서 채번하는 구매자의 결제 수단 식별 고유번호<br> PG사가 발급한 빌링키와 1:1로 맵핑되는 고객사가 지정한 고유값입니다. <br>customer_uid는 카드번호 단위로 구분되서 저장되어야 합니다.",
             "required": true,
             "type": "string",
             "maxLength": 80,
             "x-portone-name": "구매자의 결제 수단 식별 고유번호",
-            "x-portone-description": "<p>빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n"
+            "x-portone-description": "<p>빌링키와 매핑되며 고객사에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n"
           },
           {
             "name": "merchant_uid",
             "in": "formData",
-            "description": "가맹점 거래 고유번호 (스마트로 - 신모듈의 경우, 특수문자 포함이 불가능합니다.)",
+            "description": "고객사 거래 고유번호 (스마트로 - 신모듈의 경우, 특수문자 포함이 불가능합니다.)",
             "required": true,
             "type": "string",
             "maxLength": 40,
-            "x-portone-name": "가맹점 주문번호",
-            "x-portone-description": "<p>결제 요청할 결제건의 가맹점 거래 고유번호</p>\n",
+            "x-portone-name": "고객사 주문번호",
+            "x-portone-description": "<p>결제 요청할 결제건의 고객사 거래 고유번호</p>\n",
             "x-portone-per-pg": {
               "smartro_v2": {
                 "description": "<p>스마트로는 주문 번호(merchant_uid)에 <strong>특수문자를 허용하고 있지 않습니다.</strong></p>\n<p>따라서 결제창에서 일반결제를 할때와 발급 된 빌링키로 API를 통해 재결제를 하는 경우 숫자, 문자(알파벳 소문자와 대문자) 또는 그 조합으로 이루어진 주문 번호를 사용해주세요.\n또한, 주문번호(merchant_uid)가 <strong>최대 40자</strong>를 넘을 수 없습니다. 40자가 넘을 경우 40자까지 잘려서 저장되기 때문에 유의 바랍니다.</p>\n"
@@ -5972,14 +5912,14 @@
                 "description": "<p>면세 설정 상점아이디에서 면세처리를 위해 결제 금액과 동일한 면세 금액을 반드시 입력해야 합니다. 그렇지 않은 경우 매출전표에 전액 면세가 아닌 것으로 표시되고 실제 처리 내역이 다를 수 있습니다.</p>\n<p>과세 설정 상점아이디에서 면세 금액을 전달하지 않아야 합니다. 면세 금액을 전달하는 경우 매출전표에 면세 처리된 것으로 표시되지만 실제 처리 내역과 다를 수 있습니다.</p>\n"
               },
               "welcome": {
-                "description": "<p><code>부가세업체정함</code> 설정 가맹점에 한해 사용 가능합니다.</p>\n"
+                "description": "<p><code>부가세업체정함</code> 설정 고객사에 한해 사용 가능합니다.</p>\n"
               }
             }
           },
           {
             "name": "vat_amount",
             "in": "formData",
-            "description": "amount 중 부가세 금액.<br/>부가세를 지정할 수 있으며, tax_free=0, vat_amount=0으로 영세율로 결제 가능합니다.(기본값: null)<br><h5>지원되는 PG사</h5><ul><li>나이스페이먼츠</li><li>이니시스</li><li>(신) 나이스페이</li><li>웰컴페이먼츠</li></ul>",
+            "description": "amount 중 부가세 금액.<br/>부가세를 지정할 수 있으며, tax_free=0, vat_amount=0으로 영세율로 결제 가능합니다.(기본값: null)<br><h5>지원되는 PG사</h5><ul><li>나이스페이먼츠</li><li>이니시스</li><li>(신) 나이스페이</li><li>웰컴페이먼츠</li><li>(신) 토스페이</li></ul>",
             "required": false,
             "type": "number",
             "x-portone-name": "부가세",
@@ -5989,11 +5929,12 @@
               "nice",
               "html5_inicis",
               "nice_v2",
-              "welcome"
+              "welcome",
+              "tosspay_v2"
             ],
             "x-portone-per-pg": {
               "welcome": {
-                "description": "<p><code>부가세업체정함</code> 설정 가맹점에 한해 사용 가능하며 전체금액의 10% 이하로 설정해야 합니다. vat_amount가 <span>총 상품가격의 10%를 초과할 경우는 결제가 거절됩니다.</span></p>\n"
+                "description": "<p><code>부가세업체정함</code> 설정 고객사에 한해 사용 가능하며 전체금액의 10% 이하로 설정해야 합니다. vat_amount가 <span>총 상품가격의 10%를 초과할 경우는 결제가 거절됩니다.</span></p>\n"
               }
             }
           },
@@ -6113,12 +6054,12 @@
           {
             "name": "interest_free_by_merchant",
             "in": "formData",
-            "description": "카드할부처리할 때, 할부이자가 발생하는 경우(카드사 무이자 프로모션 제외) 부과되는 할부이자를 고객대신 가맹점이 지불하고자 PG사와 계약된 경우<br>(현재, 나이스페이먼츠, (신) 나이스페이만 지원됨)",
+            "description": "카드할부처리할 때, 할부이자가 발생하는 경우(카드사 무이자 프로모션 제외) 부과되는 할부이자를 고객대신 고객사가 지불하고자 PG사와 계약된 경우<br>(현재, 나이스페이먼츠, (신) 나이스페이만 지원됨)",
             "required": false,
             "type": "boolean",
             "default": false,
-            "x-portone-name": "가맹점부담 무이자 할부여부",
-            "x-portone-description": "<p>카드할부처리할 때, 할부이자가 발생하는 경우(카드사 무이자 프로모션 제외) 부과되는 할부이자를 고객대신 가맹점이 지불하는지에 대한 여부 (<strong>PG사와 사전 계약이 필요</strong>)</p>\n",
+            "x-portone-name": "상점분담 무이자 할부여부",
+            "x-portone-description": "<p>카드할부처리할 때, 할부이자가 발생하는 경우(카드사 무이자 프로모션 제외) 부과되는 할부이자를 고객대신 고객사가 지불하는지에 대한 여부 (<strong>PG사와 사전 계약이 필요</strong>)</p>\n",
             "x-portone-supported-pgs": [
               "nice",
               "ksnet",
@@ -6146,7 +6087,7 @@
             "description": "거래정보와 함께 저장할 추가 정보",
             "required": false,
             "type": "string",
-            "x-portone-name": "빌링키 발급 시 같이 저장할 가맹점 custom 데이터",
+            "x-portone-name": "빌링키 발급 시 같이 저장할 고객사 custom 데이터",
             "x-portone-description": "<p>거래정보와 함께 저장할 추가 정보</p>\n"
           },
           {
@@ -6265,7 +6206,6 @@
           "daou",
           "html5_inicis",
           "inicis",
-          "jtnet",
           "kakaopay",
           "kcp",
           "kcp_billing",
@@ -6288,7 +6228,7 @@
         "x-portone-category": "nonAuthPayment",
         "x-portone-per-pg": {
           "paypal_v2": {
-            "description": "<h3 id=\"manges--fraudnet-이상-거래-대응-필요\"><a class=\"anchor\" aria-hidden=\"true\" tabindex=\"-1\" href=\"#manges--fraudnet-이상-거래-대응-필요\"><svg class=\"octicon octicon-link\" viewbox=\"0 0 16 16\" width=\"16\" height=\"16\" aria-hidden=\"true\"><path fill-rule=\"evenodd\" d=\"M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z\"></path></svg></a>Manges &amp; Fraudnet 이상 거래 대응 필요</h3><p>페이팔은 이상 거래를 줄이기 위해 Risk Data Acquisition 정책을 시행하고 있습니다. 일반 결제나 빌링키 발급은 페이팔 버튼을 통해 진행되기 때문에 페이팔이 이상 거래 판단을 위한 구매자 접속 정보를 얻을 수 있지만, 발급 된 빌링키로 재결제 (again API 호출) 할때는 가맹점 서버에서 포트원 API를 통해 페이팔 API가 호출되는 구조이기 때문에 이상 거래 판단을 위한 구매자 접속 정보를 얻을 수 없습니다.\n따라서 발급 된 빌링키로 재결제를 할때는 구매자의 브라우저/디바이스 접속 정보를 페이팔에 전달할 수 있도록 again API가 호출되는 <strong>가맹점 클라이언트 페이지에 반드시 페이팔 Fraudnet 스크립트/Manges SDK를 아래와 같이 추가</strong>해야 합니다.</p>\n<p><strong>페이팔 RT를 통한 again API 호출시에는 Manges &amp; Fraudnet 조치가 필수적으로 요구됩니다.</strong>\n브라우저/앱에 페이팔 Fraudnet Script/Manges SDK를 추가한 후 again API를 호출할때 진행되는 플로우는 아래와 같습니다.</p>\n<p><img src=\"https://raw.githubusercontent.com/portone-io/developers.portone.io/e206047c43ed15bc364b58e0647dda4584964c9c/public/gitbook-assets/ko/paypal-rt/manges-fraudnet-flow.png\" alt=\"플로우\" /></p>\n<h4 id=\"브라우저\"><a class=\"anchor\" aria-hidden=\"true\" tabindex=\"-1\" href=\"#브라우저\"><svg class=\"octicon octicon-link\" viewbox=\"0 0 16 16\" width=\"16\" height=\"16\" aria-hidden=\"true\"><path fill-rule=\"evenodd\" d=\"M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z\"></path></svg></a>브라우저</h4><div class=\"highlight highlight-source-html notranslate\"><pre><span class=\"token comment\">&lt;!-- again API가 호출되는 가맹점 클라이언트 --&gt;</span>\n<span class=\"token tag\"><span class=\"token tag\"><span class=\"token punctuation\">&lt;</span>script</span>\n    <span class=\"token attr-name\">type</span><span class=\"token\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>application/json<span class=\"token punctuation\">\"</span></span>\n    <span class=\"token attr-name\">fncls</span><span class=\"token\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>fnparams-dede7cc5-15fd-4c75-a9f4-36c430ee3a99<span class=\"token punctuation\">\"</span></span>\n<span class=\"token punctuation\">&gt;</span></span><span class=\"token script\"><span class=\"token\">\n<span class=\"token punctuation\">{</span>\n    <span class=\"token property\">\"f\"</span><span class=\"token operator\">:</span> <span class=\"token string\">\"RISK_SESSION_CORRELATION_ID\"</span><span class=\"token punctuation\">,</span>\n    <span class=\"token property\">\"s\"</span><span class=\"token operator\">:</span> <span class=\"token string\">\"SOURCE_IDENTIFIER\"</span><span class=\"token punctuation\">,</span>\n    <span class=\"token property\">\"sandbox\"</span><span class=\"token operator\">:</span> <span class=\"token boolean\">true</span>\n<span class=\"token punctuation\">}</span>\n</span></span><span class=\"token tag\"><span class=\"token tag\"><span class=\"token punctuation\">&lt;/</span>script</span><span class=\"token punctuation\">&gt;</span></span>\n<span class=\"token tag\"><span class=\"token tag\"><span class=\"token punctuation\">&lt;</span>script</span> <span class=\"token attr-name\">type</span><span class=\"token\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>text/javascript<span class=\"token punctuation\">\"</span></span> <span class=\"token attr-name\">src</span><span class=\"token\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>https://c.paypal.com/da/r/fb.js<span class=\"token punctuation\">\"</span></span><span class=\"token punctuation\">&gt;</span></span><span class=\"token script\"></span><span class=\"token tag\"><span class=\"token tag\"><span class=\"token punctuation\">&lt;/</span>script</span><span class=\"token punctuation\">&gt;</span></span>\n<span class=\"token tag\"><span class=\"token tag\"><span class=\"token punctuation\">&lt;</span>noscript</span><span class=\"token punctuation\">&gt;</span></span>\n<span class=\"token tag\"><span class=\"token tag\"><span class=\"token punctuation\">&lt;</span>img</span>\n    <span class=\"token attr-name\">src</span><span class=\"token\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>https://c.paypal.com/v1/r/d/b/ns?f=RISK_SESSION_CORRELATION_ID&amp;s=SOURCE_IDENTIFIER&amp;js=0&amp;r=1<span class=\"token punctuation\">\"</span></span>\n<span class=\"token punctuation\">/&gt;</span></span>\n<span class=\"token tag\"><span class=\"token tag\"><span class=\"token punctuation\">&lt;/</span>noscript</span><span class=\"token punctuation\">&gt;</span></span></pre></div><table>\n<thead>\n<tr>\n<th>파라미터</th>\n<th>의미</th>\n<th>예시</th>\n</tr>\n</thead>\n<tbody><tr>\n<td>fncls</td>\n<td>fnparams-dede7cc5-15fd-4c75-a9f4-36c430ee3a99로 항상 고정</td>\n<td>fnparams-dede7cc5-15fd-4c75-a9f4-36c430ee3a99</td>\n</tr>\n<tr>\n<td>f</td>\n<td>주문번호(merchant_uid) 전달</td>\n<td>mid_1683690731602</td>\n</tr>\n<tr>\n<td>s</td>\n<td>string</td>\n<td>7WBB3CKT63FRG_checkout-page</td>\n</tr>\n<tr>\n<td>sandbox</td>\n<td>페이팔 Account ID가 테스트 용인지 운영 용인지 여부</td>\n<td>true</td>\n</tr>\n</tbody></table>\n<h4 id=\"앱\"><a class=\"anchor\" aria-hidden=\"true\" tabindex=\"-1\" href=\"#앱\"><svg class=\"octicon octicon-link\" viewbox=\"0 0 16 16\" width=\"16\" height=\"16\" aria-hidden=\"true\"><path fill-rule=\"evenodd\" d=\"M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z\"></path></svg></a>앱</h4><h5 id=\"안드로이드\"><a class=\"anchor\" aria-hidden=\"true\" tabindex=\"-1\" href=\"#안드로이드\"><svg class=\"octicon octicon-link\" viewbox=\"0 0 16 16\" width=\"16\" height=\"16\" aria-hidden=\"true\"><path fill-rule=\"evenodd\" d=\"M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z\"></path></svg></a>안드로이드</h5><p><a href=\"https://developer.paypal.com/limited-release/magnes/integrate/android/\" rel=\"noopener noreferrer\"><strong>Android Integration of Magnes</strong></a> 가이드 문서에 따라 아래와 같이 collectAndSubmit 메소드 호출을 통해 페이팔로 디바이스 정보를 보내야합니다. 이때 두번째 파라미터(<code>paypalClientMetaDataId</code>)로는 주문번호(<code>merchant_uid</code>)를 전달해주시면 됩니다.</p>\n<pre><code>MagnesResult magnesResult = MagnesSDK.getInstance()\n.collectAndSubmit(Context context, String paypalClientMetaDataId,\nHashMap&lt;String, String&gt;\nadditionalData)</code></pre><h5 id=\"ios-swift\"><a class=\"anchor\" aria-hidden=\"true\" tabindex=\"-1\" href=\"#ios-swift\"><svg class=\"octicon octicon-link\" viewbox=\"0 0 16 16\" width=\"16\" height=\"16\" aria-hidden=\"true\"><path fill-rule=\"evenodd\" d=\"M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z\"></path></svg></a>IOS Swift</h5><p><a href=\"https://developer.paypal.com/limited-release/magnes/integrate/ios-swift/\" rel=\"noopener noreferrer\"><strong>iOS Swift SDK Integration</strong></a> 가이드 문서에 따라 아래와 같이 collectAndSubmit 메소드 호출을 통해 페이팔로 디바이스 정보를 보내야합니다. 이때 첫번째 파라미터(<code>withPayPalClientMetadataId</code>)로는 주문번호(<code>merchant_uid</code>)를 전달해주시면 됩니다.</p>\n<pre><code>let magnesResult:MagnesResult =\nMagnesSDK.shared().collectAndSubmit(withPayPalClientMetadataId:\n\"YOUR-PAYPAL-CLIENT-METADATA-ID\", withAdditionalData: [String: String])</code></pre><h5 id=\"ios-objective-c\"><a class=\"anchor\" aria-hidden=\"true\" tabindex=\"-1\" href=\"#ios-objective-c\"><svg class=\"octicon octicon-link\" viewbox=\"0 0 16 16\" width=\"16\" height=\"16\" aria-hidden=\"true\"><path fill-rule=\"evenodd\" d=\"M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z\"></path></svg></a>IOS Objective-C</h5><p><a href=\"https://developer.paypal.com/limited-release/magnes/integrate/ios-objective-c/\" rel=\"noopener noreferrer\"><strong>iOS Objective-C SDK Integration of Magnes</strong></a> 가이드 문서에 따라 아래와 같이 collectAndSubmitWithPayPalClientMetadataId 메소드 호출을 통해 페이팔로 디바이스 정보를 보내야합니다. 이때 첫번째 파라미터(<code>YOUR-PAYPAL-CLIENT-METADATA-ID</code>)로는 주문번호(<code>merchant_uid</code>)를 전달해주시면 됩니다.</p>\n<pre><code>//PPRMOCMagnesSDK *magnesSDK = [PPRMOCMagnesSDK shared];\nPPRMOCMagnesSDKResult *magnesResult =\n[magnesSDK\ncollectAndSubmitWithPayPalClientMetadataId:@\"YOUR-PAYPAL-CLIENT-METADATA-ID\"\nwithAdditionalData:@{}];</code></pre><h3 id=\"고위험-결제-처리\"><a class=\"anchor\" aria-hidden=\"true\" tabindex=\"-1\" href=\"#고위험-결제-처리\"><svg class=\"octicon octicon-link\" viewbox=\"0 0 16 16\" width=\"16\" height=\"16\" aria-hidden=\"true\"><path fill-rule=\"evenodd\" d=\"M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z\"></path></svg></a>고위험 결제 처리</h3><p>페이팔은 판매자 보호 정책을 통해 가맹점 거래에서 이상 거래나 사기 등이 발생 시, 판매자 보호 정책을 통해 가맹점이 손해 입을 수 있는 부분을 보존하는 판매자 보호 프로그램을 가지고 있습니다. 이 판매자 보호 정책을 적용하기 위해서는 페이팔 측에서 제공하는 <strong>STC 기능</strong>을 사용해야 합니다.</p>\n<p>STC 기능을 사용하시기 위해 다음 정보를 확인하셔야 합니다.</p>\n<ol>\n<li>페이팔 Business 계정 가입시 산업 종류(Industry)를 결정하는데, 계정의 산업 종류를 확인해야 합니다.</li>\n<li>계정의 산업 종류를 확인하신 뒤, loadUI 호출 해 빌링키를 발급 받을때 그리고 발급 된 빌링키로 재결제(again API 호출)할때 모두 bypass.paypal_v2 객체에 아래와 같은 형식으로 전달해주셔야 합니다.</li>\n</ol>\n<h4 id=\"발급-된-빌링키로-단건-결제again-api-호출시-stc-적용하기\"><a class=\"anchor\" aria-hidden=\"true\" tabindex=\"-1\" href=\"#발급-된-빌링키로-단건-결제again-api-호출시-stc-적용하기\"><svg class=\"octicon octicon-link\" viewbox=\"0 0 16 16\" width=\"16\" height=\"16\" aria-hidden=\"true\"><path fill-rule=\"evenodd\" d=\"M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z\"></path></svg></a>발급 된 빌링키로 단건 결제(again API 호출)시 STC 적용하기</h4><div class=\"highlight highlight-source-javascript notranslate\"><pre><span class=\"token keyword\">await</span> <span class=\"token function\">fetch</span><span class=\"token punctuation\">(</span>\n   <span class=\"token string\">\"https://api.iamport.kr/subscribe/payments/again\"</span><span class=\"token punctuation\">,</span>\n   <span class=\"token punctuation\">{</span>\n       <span class=\"token property\">method</span><span class=\"token operator\">:</span> <span class=\"token string\">\"POST\"</span><span class=\"token punctuation\">,</span>\n       <span class=\"token property\">headers</span><span class=\"token operator\">:</span> <span class=\"token punctuation\">{</span>\n           <span class=\"token property\">Authorization</span><span class=\"token operator\">:</span> <span class=\"token\"><span class=\"token string\">`</span><span class=\"token string\">Basic </span><span class=\"token\"><span class=\"token punctuation\">${</span><span class=\"token\">ACCESS_TOKEN</span><span class=\"token punctuation\">}</span></span><span class=\"token string\">`</span></span><span class=\"token punctuation\">,</span>\n           <span class=\"token property\">\"Content-Type\"</span><span class=\"token operator\">:</span> <span class=\"token string\">\"application/json\"</span><span class=\"token punctuation\">,</span>\n       <span class=\"token punctuation\">}</span><span class=\"token punctuation\">,</span>\n       <span class=\"token property\">body</span><span class=\"token operator\">:</span> <span class=\"token\">JSON</span><span class=\"token punctuation\">.</span><span class=\"token function\">stringify</span><span class=\"token punctuation\">(</span><span class=\"token punctuation\">{</span>\n           customer_uid<span class=\"token punctuation\">,</span> <span class=\"token comment\">// [필수 입력] 빌링키 발급시 전달 한 빌링키와 1:1 매핑되는 UUID</span>\n           merchant_uid<span class=\"token punctuation\">,</span> <span class=\"token comment\">// [필수 입력] 주문 번호</span>\n           currency<span class=\"token punctuation\">,</span> <span class=\"token comment\">// [필수 입력] 결제 통화 (페이팔은 KRW 불가능)</span>\n           amount<span class=\"token punctuation\">,</span> <span class=\"token comment\">// [필수 입력] 결제 금액</span>\n           name<span class=\"token punctuation\">,</span> <span class=\"token comment\">// 주문명</span>\n           <span class=\"token property\">bypass</span><span class=\"token operator\">:</span> <span class=\"token\">JSON</span><span class=\"token punctuation\">.</span><span class=\"token function\">stringify</span><span class=\"token punctuation\">(</span><span class=\"token punctuation\">{</span>\n               <span class=\"token property\">paypal_v2</span><span class=\"token operator\">:</span> <span class=\"token punctuation\">{</span>\n                   <span class=\"token property\">additional_data</span><span class=\"token operator\">:</span> <span class=\"token punctuation\">[</span><span class=\"token punctuation\">{</span>\n                       <span class=\"token property\">key</span><span class=\"token operator\">:</span> <span class=\"token string\">\"sender_account_id\"</span><span class=\"token punctuation\">,</span> <span class=\"token comment\">// 가맹점 account ID(merchant-id)</span>\n                       <span class=\"token property\">value</span><span class=\"token operator\">:</span> <span class=\"token string\">\"A12345N343\"</span>\n                   <span class=\"token punctuation\">}</span><span class=\"token punctuation\">,</span> <span class=\"token punctuation\">{</span>\n                       <span class=\"token property\">key</span><span class=\"token operator\">:</span> <span class=\"token string\">\"sender_first_name\"</span><span class=\"token punctuation\">,</span> <span class=\"token comment\">// 가맹점의 account에 등록 된 구매자의 이름</span>\n                       <span class=\"token property\">value</span><span class=\"token operator\">:</span> <span class=\"token string\">\"John\"</span>\n                   <span class=\"token punctuation\">}</span><span class=\"token punctuation\">,</span> <span class=\"token punctuation\">{</span>\n                       <span class=\"token property\">key</span><span class=\"token operator\">:</span> <span class=\"token string\">\"sender_last_name\"</span><span class=\"token punctuation\">,</span> <span class=\"token comment\">// 가맹점의 account에 등록 된 구매자의 이름</span>\n                       <span class=\"token property\">value</span><span class=\"token operator\">:</span> <span class=\"token string\">\"Doe\"</span>\n                   <span class=\"token punctuation\">}</span><span class=\"token punctuation\">,</span> <span class=\"token punctuation\">{</span>\n                       <span class=\"token property\">key</span><span class=\"token operator\">:</span> <span class=\"token string\">\"sender_email\"</span><span class=\"token punctuation\">,</span> <span class=\"token comment\">// 가맹점의 account에 등록 된 구매자의 이메일 주소</span>\n                       <span class=\"token property\">value</span><span class=\"token operator\">:</span> <span class=\"token string\">\"example@example.com\"</span>\n                   <span class=\"token punctuation\">}</span><span class=\"token punctuation\">,</span> <span class=\"token punctuation\">{</span>\n                       <span class=\"token property\">key</span><span class=\"token operator\">:</span> <span class=\"token string\">\"sender_phone\"</span><span class=\"token punctuation\">,</span> <span class=\"token comment\">// 가맹점의 account에 등록 된 구매자의 연락처</span>\n                       <span class=\"token property\">value</span><span class=\"token operator\">:</span> <span class=\"token string\">\"(02)16705176\"</span>\n                   <span class=\"token punctuation\">}</span><span class=\"token punctuation\">,</span> <span class=\"token punctuation\">{</span>\n                       <span class=\"token property\">key</span><span class=\"token operator\">:</span> <span class=\"token string\">\"sender_country_code\"</span><span class=\"token punctuation\">,</span> <span class=\"token comment\">// 가맹점의 account에 등록 된 국가 코드</span>\n                       <span class=\"token property\">value</span><span class=\"token operator\">:</span> <span class=\"token string\">\"KR\"</span> <span class=\"token comment\">// ISO Alpha-2 형식 국가 코드</span>\n                   <span class=\"token punctuation\">}</span><span class=\"token punctuation\">,</span> <span class=\"token punctuation\">{</span>\n                       <span class=\"token property\">key</span><span class=\"token operator\">:</span> <span class=\"token string\">\"sender_create_date\"</span><span class=\"token punctuation\">,</span> <span class=\"token comment\">// 가맹점의 account에 등록 된 국가 코드</span>\n                       <span class=\"token property\">value</span><span class=\"token operator\">:</span> <span class=\"token string\">\"2023-10-10T23:59:59+09:00\"</span> <span class=\"token comment\">// IOS8601 형식</span>\n                   <span class=\"token punctuation\">}</span><span class=\"token punctuation\">]</span>\n               <span class=\"token punctuation\">}</span>\n           <span class=\"token punctuation\">}</span><span class=\"token punctuation\">)</span> <span class=\"token comment\">// end of bypass string</span>\n       <span class=\"token punctuation\">}</span><span class=\"token punctuation\">)</span> <span class=\"token comment\">// end of body</span>\n   <span class=\"token punctuation\">}</span>\n<span class=\"token punctuation\">)</span></pre></div>"
+            "description": "<h3 id=\"manges--fraudnet-이상-거래-대응-필요\"><a class=\"anchor\" aria-hidden=\"true\" tabindex=\"-1\" href=\"#manges--fraudnet-이상-거래-대응-필요\"><svg class=\"octicon octicon-link\" viewbox=\"0 0 16 16\" width=\"16\" height=\"16\" aria-hidden=\"true\"><path fill-rule=\"evenodd\" d=\"M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z\"></path></svg></a>Manges &amp; Fraudnet 이상 거래 대응 필요</h3><p>페이팔은 이상 거래를 줄이기 위해 Risk Data Acquisition 정책을 시행하고 있습니다. 일반 결제나 빌링키 발급은 페이팔 버튼을 통해 진행되기 때문에 페이팔이 이상 거래 판단을 위한 구매자 접속 정보를 얻을 수 있지만, 발급 된 빌링키로 재결제 (again API 호출) 할때는 고객사 서버에서 포트원 API를 통해 페이팔 API가 호출되는 구조이기 때문에 이상 거래 판단을 위한 구매자 접속 정보를 얻을 수 없습니다.\n따라서 발급 된 빌링키로 재결제를 할때는 구매자의 브라우저/디바이스 접속 정보를 페이팔에 전달할 수 있도록 again API가 호출되는 <strong>고객사 클라이언트 페이지에 반드시 페이팔 Fraudnet 스크립트/Manges SDK를 아래와 같이 추가</strong>해야 합니다.</p>\n<p><strong>페이팔 RT를 통한 again API 호출시에는 Manges &amp; Fraudnet 조치가 필수적으로 요구됩니다.</strong>\n브라우저/앱에 페이팔 Fraudnet Script/Manges SDK를 추가한 후 again API를 호출할때 진행되는 플로우는 아래와 같습니다.</p>\n<p><img src=\"https://raw.githubusercontent.com/portone-io/developers.portone.io/e206047c43ed15bc364b58e0647dda4584964c9c/public/gitbook-assets/ko/paypal-rt/manges-fraudnet-flow.png\" alt=\"플로우\" /></p>\n<h4 id=\"브라우저\"><a class=\"anchor\" aria-hidden=\"true\" tabindex=\"-1\" href=\"#브라우저\"><svg class=\"octicon octicon-link\" viewbox=\"0 0 16 16\" width=\"16\" height=\"16\" aria-hidden=\"true\"><path fill-rule=\"evenodd\" d=\"M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z\"></path></svg></a>브라우저</h4><div class=\"highlight highlight-source-html notranslate\"><pre><span class=\"token comment\">&lt;!-- again API가 호출되는 고객사 클라이언트 --&gt;</span>\n<span class=\"token tag\"><span class=\"token tag\"><span class=\"token punctuation\">&lt;</span>script</span>\n    <span class=\"token attr-name\">type</span><span class=\"token\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>application/json<span class=\"token punctuation\">\"</span></span>\n    <span class=\"token attr-name\">fncls</span><span class=\"token\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>fnparams-dede7cc5-15fd-4c75-a9f4-36c430ee3a99<span class=\"token punctuation\">\"</span></span>\n<span class=\"token punctuation\">&gt;</span></span><span class=\"token script\"><span class=\"token\">\n<span class=\"token punctuation\">{</span>\n    <span class=\"token property\">\"f\"</span><span class=\"token operator\">:</span> <span class=\"token string\">\"RISK_SESSION_CORRELATION_ID\"</span><span class=\"token punctuation\">,</span>\n    <span class=\"token property\">\"s\"</span><span class=\"token operator\">:</span> <span class=\"token string\">\"SOURCE_IDENTIFIER\"</span><span class=\"token punctuation\">,</span>\n    <span class=\"token property\">\"sandbox\"</span><span class=\"token operator\">:</span> <span class=\"token boolean\">true</span>\n<span class=\"token punctuation\">}</span>\n</span></span><span class=\"token tag\"><span class=\"token tag\"><span class=\"token punctuation\">&lt;/</span>script</span><span class=\"token punctuation\">&gt;</span></span>\n<span class=\"token tag\"><span class=\"token tag\"><span class=\"token punctuation\">&lt;</span>script</span> <span class=\"token attr-name\">type</span><span class=\"token\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>text/javascript<span class=\"token punctuation\">\"</span></span> <span class=\"token attr-name\">src</span><span class=\"token\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>https://c.paypal.com/da/r/fb.js<span class=\"token punctuation\">\"</span></span><span class=\"token punctuation\">&gt;</span></span><span class=\"token script\"></span><span class=\"token tag\"><span class=\"token tag\"><span class=\"token punctuation\">&lt;/</span>script</span><span class=\"token punctuation\">&gt;</span></span>\n<span class=\"token tag\"><span class=\"token tag\"><span class=\"token punctuation\">&lt;</span>noscript</span><span class=\"token punctuation\">&gt;</span></span>\n<span class=\"token tag\"><span class=\"token tag\"><span class=\"token punctuation\">&lt;</span>img</span>\n    <span class=\"token attr-name\">src</span><span class=\"token\"><span class=\"token punctuation\">=</span><span class=\"token punctuation\">\"</span>https://c.paypal.com/v1/r/d/b/ns?f=RISK_SESSION_CORRELATION_ID&amp;s=SOURCE_IDENTIFIER&amp;js=0&amp;r=1<span class=\"token punctuation\">\"</span></span>\n<span class=\"token punctuation\">/&gt;</span></span>\n<span class=\"token tag\"><span class=\"token tag\"><span class=\"token punctuation\">&lt;/</span>noscript</span><span class=\"token punctuation\">&gt;</span></span></pre></div><table>\n<thead>\n<tr>\n<th>파라미터</th>\n<th>의미</th>\n<th>예시</th>\n</tr>\n</thead>\n<tbody><tr>\n<td>fncls</td>\n<td>fnparams-dede7cc5-15fd-4c75-a9f4-36c430ee3a99로 항상 고정</td>\n<td>fnparams-dede7cc5-15fd-4c75-a9f4-36c430ee3a99</td>\n</tr>\n<tr>\n<td>f</td>\n<td>주문번호(merchant_uid) 전달</td>\n<td>mid_1683690731602</td>\n</tr>\n<tr>\n<td>s</td>\n<td>string</td>\n<td>7WBB3CKT63FRG_checkout-page</td>\n</tr>\n<tr>\n<td>sandbox</td>\n<td>페이팔 Account ID가 테스트 용인지 운영 용인지 여부</td>\n<td>true</td>\n</tr>\n</tbody></table>\n<h4 id=\"앱\"><a class=\"anchor\" aria-hidden=\"true\" tabindex=\"-1\" href=\"#앱\"><svg class=\"octicon octicon-link\" viewbox=\"0 0 16 16\" width=\"16\" height=\"16\" aria-hidden=\"true\"><path fill-rule=\"evenodd\" d=\"M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z\"></path></svg></a>앱</h4><h5 id=\"안드로이드\"><a class=\"anchor\" aria-hidden=\"true\" tabindex=\"-1\" href=\"#안드로이드\"><svg class=\"octicon octicon-link\" viewbox=\"0 0 16 16\" width=\"16\" height=\"16\" aria-hidden=\"true\"><path fill-rule=\"evenodd\" d=\"M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z\"></path></svg></a>안드로이드</h5><p><a href=\"https://developer.paypal.com/limited-release/magnes/integrate/android/\" rel=\"noopener noreferrer\"><strong>Android Integration of Magnes</strong></a> 가이드 문서에 따라 아래와 같이 collectAndSubmit 메소드 호출을 통해 페이팔로 디바이스 정보를 보내야합니다. 이때 두번째 파라미터(<code>paypalClientMetaDataId</code>)로는 주문번호(<code>merchant_uid</code>)를 전달해주시면 됩니다.</p>\n<pre><code>MagnesResult magnesResult = MagnesSDK.getInstance()\n.collectAndSubmit(Context context, String paypalClientMetaDataId,\nHashMap&lt;String, String&gt;\nadditionalData)</code></pre><h5 id=\"ios-swift\"><a class=\"anchor\" aria-hidden=\"true\" tabindex=\"-1\" href=\"#ios-swift\"><svg class=\"octicon octicon-link\" viewbox=\"0 0 16 16\" width=\"16\" height=\"16\" aria-hidden=\"true\"><path fill-rule=\"evenodd\" d=\"M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z\"></path></svg></a>IOS Swift</h5><p><a href=\"https://developer.paypal.com/limited-release/magnes/integrate/ios-swift/\" rel=\"noopener noreferrer\"><strong>iOS Swift SDK Integration</strong></a> 가이드 문서에 따라 아래와 같이 collectAndSubmit 메소드 호출을 통해 페이팔로 디바이스 정보를 보내야합니다. 이때 첫번째 파라미터(<code>withPayPalClientMetadataId</code>)로는 주문번호(<code>merchant_uid</code>)를 전달해주시면 됩니다.</p>\n<pre><code>let magnesResult:MagnesResult =\nMagnesSDK.shared().collectAndSubmit(withPayPalClientMetadataId:\n\"YOUR-PAYPAL-CLIENT-METADATA-ID\", withAdditionalData: [String: String])</code></pre><h5 id=\"ios-objective-c\"><a class=\"anchor\" aria-hidden=\"true\" tabindex=\"-1\" href=\"#ios-objective-c\"><svg class=\"octicon octicon-link\" viewbox=\"0 0 16 16\" width=\"16\" height=\"16\" aria-hidden=\"true\"><path fill-rule=\"evenodd\" d=\"M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z\"></path></svg></a>IOS Objective-C</h5><p><a href=\"https://developer.paypal.com/limited-release/magnes/integrate/ios-objective-c/\" rel=\"noopener noreferrer\"><strong>iOS Objective-C SDK Integration of Magnes</strong></a> 가이드 문서에 따라 아래와 같이 collectAndSubmitWithPayPalClientMetadataId 메소드 호출을 통해 페이팔로 디바이스 정보를 보내야합니다. 이때 첫번째 파라미터(<code>YOUR-PAYPAL-CLIENT-METADATA-ID</code>)로는 주문번호(<code>merchant_uid</code>)를 전달해주시면 됩니다.</p>\n<pre><code>//PPRMOCMagnesSDK *magnesSDK = [PPRMOCMagnesSDK shared];\nPPRMOCMagnesSDKResult *magnesResult =\n[magnesSDK\ncollectAndSubmitWithPayPalClientMetadataId:@\"YOUR-PAYPAL-CLIENT-METADATA-ID\"\nwithAdditionalData:@{}];</code></pre><h3 id=\"고위험-결제-처리\"><a class=\"anchor\" aria-hidden=\"true\" tabindex=\"-1\" href=\"#고위험-결제-처리\"><svg class=\"octicon octicon-link\" viewbox=\"0 0 16 16\" width=\"16\" height=\"16\" aria-hidden=\"true\"><path fill-rule=\"evenodd\" d=\"M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z\"></path></svg></a>고위험 결제 처리</h3><p>페이팔은 판매자 보호 정책을 통해 고객사 거래에서 이상 거래나 사기 등이 발생 시, 판매자 보호 정책을 통해 고객사가 손해 입을 수 있는 부분을 보존하는 판매자 보호 프로그램을 가지고 있습니다. 이 판매자 보호 정책을 적용하기 위해서는 페이팔 측에서 제공하는 <strong>STC 기능</strong>을 사용해야 합니다.</p>\n<p>STC 기능을 사용하시기 위해 다음 정보를 확인하셔야 합니다.</p>\n<ol>\n<li>페이팔 Business 계정 가입시 산업 종류(Industry)를 결정하는데, 계정의 산업 종류를 확인해야 합니다.</li>\n<li>계정의 산업 종류를 확인하신 뒤, loadUI 호출 해 빌링키를 발급 받을때 그리고 발급 된 빌링키로 재결제(again API 호출)할때 모두 bypass.paypal_v2 객체에 아래와 같은 형식으로 전달해주셔야 합니다.</li>\n</ol>\n<h4 id=\"발급-된-빌링키로-단건-결제again-api-호출시-stc-적용하기\"><a class=\"anchor\" aria-hidden=\"true\" tabindex=\"-1\" href=\"#발급-된-빌링키로-단건-결제again-api-호출시-stc-적용하기\"><svg class=\"octicon octicon-link\" viewbox=\"0 0 16 16\" width=\"16\" height=\"16\" aria-hidden=\"true\"><path fill-rule=\"evenodd\" d=\"M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z\"></path></svg></a>발급 된 빌링키로 단건 결제(again API 호출)시 STC 적용하기</h4><div class=\"highlight highlight-source-javascript notranslate\"><pre><span class=\"token keyword\">await</span> <span class=\"token function\">fetch</span><span class=\"token punctuation\">(</span>\n   <span class=\"token string\">\"https://api.iamport.kr/subscribe/payments/again\"</span><span class=\"token punctuation\">,</span>\n   <span class=\"token punctuation\">{</span>\n       <span class=\"token property\">method</span><span class=\"token operator\">:</span> <span class=\"token string\">\"POST\"</span><span class=\"token punctuation\">,</span>\n       <span class=\"token property\">headers</span><span class=\"token operator\">:</span> <span class=\"token punctuation\">{</span>\n           <span class=\"token property\">Authorization</span><span class=\"token operator\">:</span> <span class=\"token\"><span class=\"token string\">`</span><span class=\"token string\">Basic </span><span class=\"token\"><span class=\"token punctuation\">${</span><span class=\"token\">ACCESS_TOKEN</span><span class=\"token punctuation\">}</span></span><span class=\"token string\">`</span></span><span class=\"token punctuation\">,</span>\n           <span class=\"token property\">\"Content-Type\"</span><span class=\"token operator\">:</span> <span class=\"token string\">\"application/json\"</span><span class=\"token punctuation\">,</span>\n       <span class=\"token punctuation\">}</span><span class=\"token punctuation\">,</span>\n       <span class=\"token property\">body</span><span class=\"token operator\">:</span> <span class=\"token\">JSON</span><span class=\"token punctuation\">.</span><span class=\"token function\">stringify</span><span class=\"token punctuation\">(</span><span class=\"token punctuation\">{</span>\n           customer_uid<span class=\"token punctuation\">,</span> <span class=\"token comment\">// [필수 입력] 빌링키 발급시 전달 한 빌링키와 1:1 매핑되는 UUID</span>\n           merchant_uid<span class=\"token punctuation\">,</span> <span class=\"token comment\">// [필수 입력] 주문 번호</span>\n           currency<span class=\"token punctuation\">,</span> <span class=\"token comment\">// [필수 입력] 결제 통화 (페이팔은 KRW 불가능)</span>\n           amount<span class=\"token punctuation\">,</span> <span class=\"token comment\">// [필수 입력] 결제 금액</span>\n           name<span class=\"token punctuation\">,</span> <span class=\"token comment\">// 주문명</span>\n           <span class=\"token property\">bypass</span><span class=\"token operator\">:</span> <span class=\"token\">JSON</span><span class=\"token punctuation\">.</span><span class=\"token function\">stringify</span><span class=\"token punctuation\">(</span><span class=\"token punctuation\">{</span>\n               <span class=\"token property\">paypal_v2</span><span class=\"token operator\">:</span> <span class=\"token punctuation\">{</span>\n                   <span class=\"token property\">additional_data</span><span class=\"token operator\">:</span> <span class=\"token punctuation\">[</span><span class=\"token punctuation\">{</span>\n                       <span class=\"token property\">key</span><span class=\"token operator\">:</span> <span class=\"token string\">\"sender_account_id\"</span><span class=\"token punctuation\">,</span> <span class=\"token comment\">// 고객사 account ID(merchant-id)</span>\n                       <span class=\"token property\">value</span><span class=\"token operator\">:</span> <span class=\"token string\">\"A12345N343\"</span>\n                   <span class=\"token punctuation\">}</span><span class=\"token punctuation\">,</span> <span class=\"token punctuation\">{</span>\n                       <span class=\"token property\">key</span><span class=\"token operator\">:</span> <span class=\"token string\">\"sender_first_name\"</span><span class=\"token punctuation\">,</span> <span class=\"token comment\">// 고객사의 account에 등록 된 구매자의 이름</span>\n                       <span class=\"token property\">value</span><span class=\"token operator\">:</span> <span class=\"token string\">\"John\"</span>\n                   <span class=\"token punctuation\">}</span><span class=\"token punctuation\">,</span> <span class=\"token punctuation\">{</span>\n                       <span class=\"token property\">key</span><span class=\"token operator\">:</span> <span class=\"token string\">\"sender_last_name\"</span><span class=\"token punctuation\">,</span> <span class=\"token comment\">// 고객사의 account에 등록 된 구매자의 이름</span>\n                       <span class=\"token property\">value</span><span class=\"token operator\">:</span> <span class=\"token string\">\"Doe\"</span>\n                   <span class=\"token punctuation\">}</span><span class=\"token punctuation\">,</span> <span class=\"token punctuation\">{</span>\n                       <span class=\"token property\">key</span><span class=\"token operator\">:</span> <span class=\"token string\">\"sender_email\"</span><span class=\"token punctuation\">,</span> <span class=\"token comment\">// 고객사의 account에 등록 된 구매자의 이메일 주소</span>\n                       <span class=\"token property\">value</span><span class=\"token operator\">:</span> <span class=\"token string\">\"example@example.com\"</span>\n                   <span class=\"token punctuation\">}</span><span class=\"token punctuation\">,</span> <span class=\"token punctuation\">{</span>\n                       <span class=\"token property\">key</span><span class=\"token operator\">:</span> <span class=\"token string\">\"sender_phone\"</span><span class=\"token punctuation\">,</span> <span class=\"token comment\">// 고객사의 account에 등록 된 구매자의 연락처</span>\n                       <span class=\"token property\">value</span><span class=\"token operator\">:</span> <span class=\"token string\">\"(02)16705176\"</span>\n                   <span class=\"token punctuation\">}</span><span class=\"token punctuation\">,</span> <span class=\"token punctuation\">{</span>\n                       <span class=\"token property\">key</span><span class=\"token operator\">:</span> <span class=\"token string\">\"sender_country_code\"</span><span class=\"token punctuation\">,</span> <span class=\"token comment\">// 고객사의 account에 등록 된 국가 코드</span>\n                       <span class=\"token property\">value</span><span class=\"token operator\">:</span> <span class=\"token string\">\"KR\"</span> <span class=\"token comment\">// ISO Alpha-2 형식 국가 코드</span>\n                   <span class=\"token punctuation\">}</span><span class=\"token punctuation\">,</span> <span class=\"token punctuation\">{</span>\n                       <span class=\"token property\">key</span><span class=\"token operator\">:</span> <span class=\"token string\">\"sender_create_date\"</span><span class=\"token punctuation\">,</span> <span class=\"token comment\">// 고객사의 account에 등록 된 국가 코드</span>\n                       <span class=\"token property\">value</span><span class=\"token operator\">:</span> <span class=\"token string\">\"2023-10-10T23:59:59+09:00\"</span> <span class=\"token comment\">// IOS8601 형식</span>\n                   <span class=\"token punctuation\">}</span><span class=\"token punctuation\">]</span>\n               <span class=\"token punctuation\">}</span>\n           <span class=\"token punctuation\">}</span><span class=\"token punctuation\">)</span> <span class=\"token comment\">// end of bypass string</span>\n       <span class=\"token punctuation\">}</span><span class=\"token punctuation\">)</span> <span class=\"token comment\">// end of body</span>\n   <span class=\"token punctuation\">}</span>\n<span class=\"token punctuation\">)</span></pre></div>"
           }
         }
       }
@@ -6393,7 +6333,6 @@
           "daou",
           "html5_inicis",
           "inicis",
-          "jtnet",
           "kakaopay",
           "kcp",
           "kcp_billing",
@@ -6433,12 +6372,12 @@
           {
             "name": "customer_uid",
             "in": "formData",
-            "description": "빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호",
+            "description": "빌링키와 매핑되며 고객사에서 채번하는 구매자의 결제 수단 식별 고유번호",
             "required": true,
             "type": "string",
             "maxLength": 80,
             "x-portone-name": "구매자의 결제 수단 식별 고유번호",
-            "x-portone-description": "<p>빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n"
+            "x-portone-description": "<p>빌링키와 매핑되며 고객사에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n"
           },
           {
             "name": "customer_id",
@@ -6566,18 +6505,18 @@
           {
             "name": "pg",
             "in": "formData",
-            "description": "신규 customer_uid를 등록하는 경우에만 유효합니다.(기존에 등록된 customer_uid로만 schedule 하는 경우에는 pg파라메터 적용되지 않습니다.)<br><br>API 방식 비인증 PG설정이 2개 이상인 경우, 결제가 진행되길 원하는 PG사를 지정하실 수 있습니다. pg 파라메터는 <b>{PG사}</b> 혹은 <b>{PG사}.{PG상점아이디}</b> 형태의 문자열입니다. <br>지정하지 않거나 유효하지 않은 값이 전달되면 기본PG설정된 값을 이용해 결제하게 됩니다. <br><ul><li>나이스페이먼츠, JTNet 2가지 PG설정이 되어있다면, pg 파라메터로 <b>nice</b> 또는 <b>jtnet</b>로 구분 가능</li><li>나이스페이먼츠로부터 2개 이상의 상점아이디를 발급받았다면, <b>nice.MID1</b> 또는 <b>nice.MID2</b>로 구분 가능</li></ul>",
+            "description": "신규 customer_uid를 등록하는 경우에만 유효합니다.(기존에 등록된 customer_uid로만 schedule 하는 경우에는 pg파라메터 적용되지 않습니다.)<br><br>API 방식 비인증 PG설정이 2개 이상인 경우, 결제가 진행되길 원하는 PG사를 지정하실 수 있습니다. pg 파라메터는 <b>{PG사}</b> 혹은 <b>{PG사}.{PG상점아이디}</b> 형태의 문자열입니다. <br>지정하지 않거나 유효하지 않은 값이 전달되면 기본PG설정된 값을 이용해 결제하게 됩니다. <br><ul><li>나이스페이먼츠, KCP 2가지 PG설정이 되어있다면, pg 파라메터로 <b>nice</b> 또는 <b>kcp</b>로 구분 가능</li><li>나이스페이먼츠로부터 2개 이상의 상점아이디를 발급받았다면, <b>nice.MID1</b> 또는 <b>nice.MID2</b>로 구분 가능</li></ul>",
             "required": false,
             "type": "string",
             "maxLength": 80,
             "x-portone-name": "pg 구분코드",
             "x-portone-summary": "<p>결제 예약을 요청할 PG사 구분코드</p>\n",
-            "x-portone-description": "<p>신규 customer_uid를 등록하는 경우에만 유효합니다.(기존에 등록된 customer_uid로만 schedule 하는 경우에는 pg파라메터 적용되지 않습니다.)</p>\n<p>API 방식 비인증 PG설정이 2개 이상인 경우, 결제가 진행되길 원하는 PG사를 지정하실 수 있습니다. pg 파라메터는 <strong>{PG사}</strong> 혹은 <strong>{PG사}.{PG상점아이디}</strong> 형태의 문자열입니다.</p>\n<p>지정하지 않거나 유효하지 않은 값이 전달되면 기본PG설정된 값을 이용해 결제하게 됩니다.</p>\n<ul>\n<li>나이스페이먼츠, JTNet 2가지 PG설정이 되어있다면, pg 파라메터로 <strong>nice</strong> 또는 <strong>jtnet</strong>로 구분 가능</li>\n<li>나이스페이먼츠로부터 2개 이상의 상점아이디를 발급받았다면, <strong>nice.MID1</strong> 또는 <strong>nice.MID2</strong>로 구분 가능</li>\n</ul>\n"
+            "x-portone-description": "<p>신규 customer_uid를 등록하는 경우에만 유효합니다.(기존에 등록된 customer_uid로만 schedule 하는 경우에는 pg파라메터 적용되지 않습니다.)</p>\n<p>API 방식 비인증 PG설정이 2개 이상인 경우, 결제가 진행되길 원하는 PG사를 지정하실 수 있습니다. pg 파라메터는 <strong>{PG사}</strong> 혹은 <strong>{PG사}.{PG상점아이디}</strong> 형태의 문자열입니다.</p>\n<p>지정하지 않거나 유효하지 않은 값이 전달되면 기본PG설정된 값을 이용해 결제하게 됩니다.</p>\n<ul>\n<li>나이스페이먼츠, KCP 2가지 PG설정이 되어있다면, pg 파라메터로 <strong>nice</strong> 또는 <strong>kcp</strong>로 구분 가능</li>\n<li>나이스페이먼츠로부터 2개 이상의 상점아이디를 발급받았다면, <strong>nice.MID1</strong> 또는 <strong>nice.MID2</strong>로 구분 가능</li>\n</ul>\n"
           },
           {
             "name": "schedules",
             "in": "formData",
-            "description": "결제예약 스케쥴<br>[ 필수항목 ]<br>merchant_uid : 가맹점 주문번호(동일한 주문번호로 중복결제 불가) (스마트로 - 신모듈의 경우, 특수문자 포함이 불가능합니다.)<br>schedule_at : 결제요청 예약시각(초) (UNIX timestamp in seconds)<br>currency : 통화 e.g.) KRW, USD 등(단, (신) 페이팔의 경우 KRW 결제가 불가능하므로 반드시 유효한 값을 필수로 입력해야합니다.)<br>amount : 결제금액<br>[ 선택항목 ]<br>tax_free : amount 중 면세공급가액(기본값 : 0)<br>vat_amount : amount 중 부가세 금액(기본값 : null, 현재 나이스페이먼츠, 이니시스, (신) 나이스페이, 웰컴페이먼츠, (신) 토스페이 지원)<br>name : 주문명(누락되면 포트원 자체 기본값 사용)<br>buyer_name : 주문자명(필수 : KSENT, 스마트로-신모듈)<br>buyer_email : 주문자Email (필수 : 스마트로-신모듈)<br>buyer_tel : 주문자 전화번호 (필수 : 스마트로-신모듈)<br>buyer_addr : 주문자 주소<br>buyer_postcode : 주문자 우편번호<br>custom_data : 결제수행 시 사용될 custom_data 값<br>notice_url : 예약결제수행 후 통지될 Notification URL(지정되지 않으면 관리자페이지의 Notification URL로 발송)<br>product_type :\n                판매 상품에 대한 구분 값 (real : 실물상품, digital : 디지털 컨텐츠) (필수 : KSNET)<br>cash_receipt_type : 현금영수증 발행대상 (person, company, anonymous) ((신) 토스페이의 경우 anonymous 전달 시 미발행 그 외 경우 현금영수증 자동발행으로 동작합니다.)<br>card_quota : 카드할부개월수. 2 이상의 integer 할부개월수 적용(결제금액 50,000원 이상 한정, default = 0(일시불))<br>interest_free_by_merchant : 카드할부처리시, 할부이자가 발생하는 경우(카드사 무이자 프로모션 제외) 부과되는 할부이자를 가맹점이 지불하고자 PG사와 계약된 경우(default : false) (현재, 나이스페이먼츠, KSNET만 지원됨)<br>use_card_point : 승인요청시 카드사 포인트 차감하며 결제승인처리할지 flag. PG사 영업담당자와 계약 당시 사전 협의 필요(default : false) (현재, 나이스페이먼츠만 지원됨) <br>product_count : 결제 상품의 개수 (Default : 1) <br>bypass : 포트원이 정규화하기 어려운 JSON string 형식의 PG사별 specific 파라미터.전달 한 값은 가공 없이 그대로 PG사로 전달 됩니다. <br><br>extra.naverUseCfm : 이용완료일 YYYYMMDD (네이버페이 반복결제 계약 시 이용완료일 필수로 설정된 가맹점에 한함)",
+            "description": "결제예약 스케쥴<br>[ 필수항목 ]<br>merchant_uid : 고객사 주문번호(동일한 주문번호로 중복결제 불가) (스마트로 - 신모듈의 경우, 특수문자 포함이 불가능합니다.)<br>schedule_at : 결제요청 예약시각(초) (UNIX timestamp in seconds)<br>currency : 통화 e.g.) KRW, USD 등(단, (신) 페이팔의 경우 KRW 결제가 불가능하므로 반드시 유효한 값을 필수로 입력해야합니다.)<br>amount : 결제금액<br>name : 주문명<br>[ 선택항목 ]<br>tax_free : amount 중 면세공급가액(기본값 : 0)<br>vat_amount : amount 중 부가세 금액(기본값 : null, 현재 나이스페이먼츠, 이니시스, (신) 나이스페이, 웰컴페이먼츠, (신) 토스페이 지원)<br>buyer_name : 주문자명(필수 : KSENT, 스마트로-신모듈)<br>buyer_email : 주문자Email (필수 : 스마트로-신모듈)<br>buyer_tel : 주문자 전화번호 (필수 : 스마트로-신모듈)<br>buyer_addr : 주문자 주소<br>buyer_postcode : 주문자 우편번호<br>custom_data : 결제수행 시 사용될 custom_data 값<br>notice_url : 예약결제수행 후 통지될 Notification URL(지정되지 않으면 관리자페이지의 Notification URL로 발송)<br>product_type :\n                판매 상품에 대한 구분 값 (real : 실물상품, digital : 디지털 컨텐츠) (필수 : KSNET)<br>cash_receipt_type : 현금영수증 발행대상 (person, company, anonymous) ((신) 토스페이의 경우 anonymous 전달 시 미발행 그 외 경우 현금영수증 자동발행으로 동작합니다.)<br>card_quota : 카드할부개월수. 2 이상의 integer 할부개월수 적용(결제금액 50,000원 이상 한정, default = 0(일시불))<br>interest_free_by_merchant : 카드할부처리시, 할부이자가 발생하는 경우(카드사 무이자 프로모션 제외) 부과되는 할부이자를 고객사가 지불하고자 PG사와 계약된 경우(default : false) (현재, 나이스페이먼츠, KSNET만 지원됨)<br>use_card_point : 승인요청시 카드사 포인트 차감하며 결제승인처리할지 flag. PG사 영업담당자와 계약 당시 사전 협의 필요(default : false) (현재, 나이스페이먼츠만 지원됨) <br>product_count : 결제 상품의 개수 (Default : 1) <br>bypass : 포트원이 정규화하기 어려운 JSON string 형식의 PG사별 specific 파라미터.전달 한 값은 가공 없이 그대로 PG사로 전달 됩니다. <br><br>extra.naverUseCfm : 이용완료일 YYYYMMDD (네이버페이 반복결제 계약 시 이용완료일 필수로 설정된 고객사에 한함)",
             "required": true,
             "type": "array",
             "items": {
@@ -6606,7 +6545,6 @@
           "daou",
           "html5_inicis",
           "inicis",
-          "jtnet",
           "kakaopay",
           "kcp",
           "kcp_billing",
@@ -6692,23 +6630,22 @@
           {
             "name": "customer_uid",
             "in": "formData",
-            "description": "빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호",
-            "required": true,
+            "description": "빌링키와 매핑되며 고객사에서 채번하는 구매자의 결제 수단 식별 고유번호<br><b>(누락될 경우 merchant_uid들에 해당하는 결제예약정보를 일괄취소)</b>",
             "type": "string",
             "x-portone-name": "구매자의 결제 수단 식별 고유번호",
-            "x-portone-description": "<p>빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n"
+            "x-portone-description": "<p>빌링키와 매핑되며 고객사에서 채번하는 구매자의 결제 수단 식별 고유번호, 누락될 경우 merchant_uid들에 해당하는 결제예약정보를 일괄취소합니다.</p>\n"
           },
           {
             "name": "merchant_uid",
             "in": "formData",
-            "description": "가맹점 거래 고유번호<br><b>(누락되면 customer_uid에 대한 결제예약정보 일괄취소)</b>",
+            "description": "고객사 거래 고유번호<br><b>(누락되면 customer_uid에 대한 결제예약정보 일괄취소)</b>",
             "required": false,
             "schema": {
               "type": "string"
             },
             "type": "array",
-            "x-portone-name": "가맹점 주문번호",
-            "x-portone-summary": "<p>결제 예약 취소할 결제건의 가맹점 거래 고유번호</p>\n",
+            "x-portone-name": "고객사 주문번호",
+            "x-portone-summary": "<p>결제 예약 취소할 결제건의 고객사 거래 고유번호</p>\n",
             "x-portone-description": "<p>누락되면 customer_uid에 대한 결제예약정보를 일괄취소합니다.</p>\n"
           }
         ],
@@ -6730,7 +6667,6 @@
           "daou",
           "html5_inicis",
           "inicis",
-          "jtnet",
           "kakaopay",
           "kcp",
           "kcp_billing",
@@ -6772,11 +6708,11 @@
           {
             "name": "merchant_uid",
             "in": "path",
-            "description": "결제예약에 사용된 가맹점 거래 고유번호",
+            "description": "결제예약에 사용된 고객사 거래 고유번호",
             "required": true,
             "type": "string",
-            "x-portone-name": "가맹점 주문번호",
-            "x-portone-description": "<p>결제예약에 사용된 가맹점 거래 고유번호</p>\n"
+            "x-portone-name": "고객사 주문번호",
+            "x-portone-description": "<p>결제예약에 사용된 고객사 거래 고유번호</p>\n"
           }
         ],
         "responses": {
@@ -6800,7 +6736,6 @@
           "daou",
           "html5_inicis",
           "inicis",
-          "jtnet",
           "kakaopay",
           "kcp",
           "kcp_billing",
@@ -6840,11 +6775,11 @@
           {
             "name": "merchant_uid",
             "in": "path",
-            "description": "결제예약에 사용된 가맹점 거래 고유번호",
+            "description": "결제예약에 사용된 고객사 거래 고유번호",
             "required": true,
             "type": "string",
-            "x-portone-name": "가맹점 주문번호",
-            "x-portone-description": "<p>결제예약에 사용된 가맹점 거래 고유번호</p>\n"
+            "x-portone-name": "고객사 주문번호",
+            "x-portone-description": "<p>결제예약에 사용된 고객사 거래 고유번호</p>\n"
           },
           {
             "name": "schedule_at",
@@ -6880,7 +6815,6 @@
           "daou",
           "html5_inicis",
           "inicis",
-          "jtnet",
           "kakaopay",
           "kcp",
           "kcp_billing",
@@ -6921,11 +6855,11 @@
           {
             "name": "merchant_uid",
             "in": "path",
-            "description": "결제예약에 사용된 가맹점 거래 고유번호",
+            "description": "결제예약에 사용된 고객사 거래 고유번호",
             "required": true,
             "type": "string",
-            "x-portone-name": "가맹점 주문번호",
-            "x-portone-description": "<p>결제예약에 사용된 가맹점 거래 고유번호</p>\n"
+            "x-portone-name": "고객사 주문번호",
+            "x-portone-description": "<p>결제예약에 사용된 고객사 거래 고유번호</p>\n"
           },
           {
             "name": "schedule_at",
@@ -6961,7 +6895,6 @@
           "daou",
           "html5_inicis",
           "inicis",
-          "jtnet",
           "kakaopay",
           "kcp",
           "kcp_billing",
@@ -7002,11 +6935,11 @@
           {
             "name": "merchant_uid",
             "in": "path",
-            "description": "결제예약에 사용된 가맹점 거래 고유번호",
+            "description": "결제예약에 사용된 고객사 거래 고유번호",
             "required": true,
             "type": "string",
-            "x-portone-name": "가맹점 주문번호",
-            "x-portone-description": "<p>결제예약에 사용된 가맹점 거래 고유번호</p>\n"
+            "x-portone-name": "고객사 주문번호",
+            "x-portone-description": "<p>결제예약에 사용된 고객사 거래 고유번호</p>\n"
           }
         ],
         "responses": {
@@ -7033,7 +6966,6 @@
           "daou",
           "html5_inicis",
           "inicis",
-          "jtnet",
           "kakaopay",
           "kcp",
           "kcp_billing",
@@ -7074,7 +7006,7 @@
           {
             "name": "customer_uid",
             "in": "path",
-            "description": "결제예약에 사용된 가맹점 거래 고유번호",
+            "description": "결제예약에 사용된 고객사 거래 고유번호",
             "required": true,
             "type": "string",
             "x-portone-name": "빌링키",
@@ -7143,7 +7075,6 @@
           "daou",
           "html5_inicis",
           "inicis",
-          "jtnet",
           "kakaopay",
           "kcp",
           "kcp_billing",
@@ -7171,8 +7102,8 @@
         "tags": [
           "tiers"
         ],
-        "summary": "하위 가맹점 정보 조회 API",
-        "description": "하위 가맹점(Tier)정보 조회. 등록된 하위 가맹점(Tier) 정보를 반환합니다.",
+        "summary": "하위 상점 정보 조회 API",
+        "description": "하위 상점(Tier)정보 조회. 등록된 하위 상점(Tier) 정보를 반환합니다.",
         "operationId": "GetTier",
         "consumes": [
           "application/json",
@@ -7185,12 +7116,12 @@
           {
             "name": "tier_code",
             "in": "path",
-            "description": "하위 가맹점(Tier) 고유코드. 알파벳 대문자 또는 숫자만 사용(반드시 3자리)",
+            "description": "하위 상점(Tier) 고유코드. 알파벳 대문자 또는 숫자만 사용(반드시 3자리)",
             "required": true,
             "type": "string",
             "default": "XYZ",
             "x-portone-name": "Tier 코드",
-            "x-portone-description": "<p>하위 가맹점의 고유 코드로 알파벳 대문자 또는 숫자만 사용 가능합니다.(<strong>반드시 3자리</strong>)</p>\n"
+            "x-portone-description": "<p>하위 상점의 고유 코드로 알파벳 대문자 또는 숫자만 사용 가능합니다.(<strong>반드시 3자리</strong>)</p>\n"
           }
         ],
         "responses": {
@@ -7213,8 +7144,8 @@
         "tags": [
           "tiers"
         ],
-        "summary": "하위 가맹점 정보 수정 API",
-        "description": "하위 가맹점(Tier)정보 수정. 수정된 하위 가맹점(Tier) 정보를 반환합니다.",
+        "summary": "하위 상점 정보 수정 API",
+        "description": "하위 상점(Tier)정보 수정. 수정된 하위 상점(Tier) 정보를 반환합니다.",
         "operationId": "UpdateTier",
         "consumes": [
           "application/json",
@@ -7227,21 +7158,21 @@
           {
             "name": "tier_code",
             "in": "path",
-            "description": "하위 가맹점(Tier) 고유코드. 알파벳 대문자 또는 숫자만 사용(반드시 3자리)",
+            "description": "하위 상점(Tier) 고유코드. 알파벳 대문자 또는 숫자만 사용(반드시 3자리)",
             "required": true,
             "type": "string",
             "default": "XYZ",
             "x-portone-name": "Tier code",
-            "x-portone-description": "<p>하위 가맹점의 고유 코드로 알파벳 대문자 또는 숫자만 사용 가능합니다.(<strong>반드시 3자리</strong>)</p>\n"
+            "x-portone-description": "<p>하위 상점의 고유 코드로 알파벳 대문자 또는 숫자만 사용 가능합니다.(<strong>반드시 3자리</strong>)</p>\n"
           },
           {
             "name": "tier_name",
             "in": "formData",
-            "description": "가맹점 명칭(내부 관리용)",
+            "description": "상점 명칭(내부 관리용)",
             "required": true,
             "type": "string",
-            "x-portone-name": "하위 가맹점 명칭",
-            "x-portone-description": "<p>내부 관리용으로 사용되는 하위 가맹점의 명칭</p>\n"
+            "x-portone-name": "하위 상점 명칭",
+            "x-portone-description": "<p>내부 관리용으로 사용되는 하위 상점의 명칭</p>\n"
           }
         ],
         "responses": {
@@ -7270,8 +7201,8 @@
         "tags": [
           "tiers"
         ],
-        "summary": "하위 가맹점 정보 등록 API",
-        "description": "하위 가맹점(Tier)정보 등록. 등록된 하위 가맹점(Tier) 정보를 반환합니다.",
+        "summary": "하위 상점 정보 등록 API",
+        "description": "하위 상점(Tier)정보 등록. 등록된 하위 상점(Tier) 정보를 반환합니다.",
         "operationId": "AddTier",
         "consumes": [
           "application/json",
@@ -7284,21 +7215,21 @@
           {
             "name": "tier_code",
             "in": "path",
-            "description": "하위 가맹점(Tier) 고유코드. 알파벳 대문자 또는 숫자만 사용(반드시 3자리)",
+            "description": "하위 상점(Tier) 고유코드. 알파벳 대문자 또는 숫자만 사용(반드시 3자리)",
             "required": true,
             "type": "string",
             "default": "XYZ",
             "x-portone-name": "Tier 코드",
-            "x-portone-description": "<p>하위 가맹점의 고유 코드로 알파벳 대문자 또는 숫자만 사용 가능합니다.(<strong>반드시 3자리</strong>)</p>\n"
+            "x-portone-description": "<p>하위 상점의 고유 코드로 알파벳 대문자 또는 숫자만 사용 가능합니다.(<strong>반드시 3자리</strong>)</p>\n"
           },
           {
             "name": "tier_name",
             "in": "formData",
-            "description": "가맹점 명칭(내부 관리용)",
+            "description": "상점 명칭(내부 관리용)",
             "required": true,
             "type": "string",
-            "x-portone-name": "하위 가맹점 명칭",
-            "x-portone-description": "<p>내부 관리용으로 사용되는 하위 가맹점의 명칭</p>\n"
+            "x-portone-name": "하위 상점 명칭",
+            "x-portone-description": "<p>내부 관리용으로 사용되는 하위 상점의 명칭</p>\n"
           }
         ],
         "responses": {
@@ -7324,8 +7255,8 @@
         "tags": [
           "tiers"
         ],
-        "summary": "하위 가맹점 정보 삭제 API",
-        "description": "하위 가맹점(Tier)정보 삭제. 삭제된 하위 가맹점(Tier) 정보를 반환합니다.",
+        "summary": "하위 상점 정보 삭제 API",
+        "description": "하위 상점(Tier)정보 삭제. 삭제된 하위 상점(Tier) 정보를 반환합니다.",
         "operationId": "DeleteTier",
         "consumes": [
           "application/json",
@@ -7338,12 +7269,12 @@
           {
             "name": "tier_code",
             "in": "path",
-            "description": "하위 가맹점(Tier) 고유코드. 알파벳 대문자 또는 숫자만 사용(반드시 3자리)",
+            "description": "하위 상점(Tier) 고유코드. 알파벳 대문자 또는 숫자만 사용(반드시 3자리)",
             "required": true,
             "type": "string",
             "default": "XYZ",
             "x-portone-name": "Tier code",
-            "x-portone-description": "<p>하위 가맹점의 고유 코드로 알파벳 대문자 또는 숫자만 사용 가능합니다.(<strong>반드시 3자리</strong>)</p>\n"
+            "x-portone-description": "<p>하위 상점의 고유 코드로 알파벳 대문자 또는 숫자만 사용 가능합니다.(<strong>반드시 3자리</strong>)</p>\n"
           }
         ],
         "responses": {
@@ -7411,12 +7342,12 @@
           {
             "name": "merchant_uid",
             "in": "formData",
-            "description": "가맹점 거래 고유번호. 이미 결제가 이뤄진 적이 있는 merchant_uid로는 추가적인 가상계좌 생성이 불가능합니다.<br>\n     (스마트로 - 신모듈의 경우, 특수문자 포함이 불가능합니다.)",
+            "description": "고객사 거래 고유번호. 이미 결제가 이뤄진 적이 있는 merchant_uid로는 추가적인 가상계좌 생성이 불가능합니다.<br>\n     (스마트로 - 신모듈의 경우, 특수문자 포함이 불가능합니다.)",
             "required": true,
             "type": "string",
             "maxLength": 40,
-            "x-portone-name": "가맹점 주문번호",
-            "x-portone-description": "<p>가상계좌를 발급할 결제건의 가맹점 거래 고유번호으로 이미 결제가 이뤄진 적이 있는 merchant_uid로는 추가적인 가상계좌 생성이 불가능합니다.</p>\n",
+            "x-portone-name": "고객사 주문번호",
+            "x-portone-description": "<p>가상계좌를 발급할 결제건의 고객사 거래 고유번호으로 이미 결제가 이뤄진 적이 있는 merchant_uid로는 추가적인 가상계좌 생성이 불가능합니다.</p>\n",
             "x-portone-per-pg": {
               "smartro_v2": {
                 "descripton": "특수문자 포함이 불가능합니다."
@@ -7492,7 +7423,7 @@
           {
             "name": "vbank_holder",
             "in": "formData",
-            "description": "가상계좌 예금주명 <br>\n     (필수 : 이니시스, 나이스, 헥토파이낸셜(구 세틀뱅크), 스마트로 - 신모듈) <br>\n     **토스페이먼츠 - 신모듈, KSNET, 웰컴페이먼츠의 경우 적용되지 않고 가맹점명이 사용됨**",
+            "description": "가상계좌 예금주명 <br>\n     (필수 : 이니시스, 나이스, 헥토파이낸셜(구 세틀뱅크), 스마트로 - 신모듈) <br>\n     **토스페이먼츠 - 신모듈, KSNET, 웰컴페이먼츠의 경우 적용되지 않고 고객사명이 사용됨**",
             "required": false,
             "type": "string",
             "maxLength": 16,
@@ -7512,13 +7443,13 @@
                 "required": true
               },
               "tosspayments": {
-                "description": "<p>해당 파라미터를 입력하셔도 적용되지 않고, <strong>가맹점명이 예금주명으로 사용</strong>됩니다.</p>\n"
+                "description": "<p>해당 파라미터를 입력하셔도 적용되지 않고, <strong>고객사명이 예금주명으로 사용</strong>됩니다.</p>\n"
               },
               "ksnet": {
-                "description": "<p>해당 파라미터를 입력하셔도 적용되지 않고, <strong>가맹점명이 예금주명으로 사용</strong>됩니다.</p>\n"
+                "description": "<p>해당 파라미터를 입력하셔도 적용되지 않고, <strong>고객사명이 예금주명으로 사용</strong>됩니다.</p>\n"
               },
               "welcome": {
-                "description": "<p>해당 파라미터를 입력하셔도 적용되지 않고, <strong>가맹점명이 예금주명으로 사용</strong>됩니다.</p>\n"
+                "description": "<p>해당 파라미터를 입력하셔도 적용되지 않고, <strong>고객사명이 예금주명으로 사용</strong>됩니다.</p>\n"
               }
             },
             "x-portone-unsupported-pgs": [
@@ -7659,7 +7590,7 @@
           {
             "name": "pg",
             "in": "formData",
-            "description": "PG사 구분자.<br>\n     관리자콘솔 API 방식 비인증 PG설정이 2개 이상인 경우 필수적으로 기재해야 하는 항목입니다.\n     동일 PG사에 두개의 MID 를 설정한 경우 아래 양식으로 기재 합니다.\n     <b>{PG사}.{PG상점아이디}</b>\n     <ul><li>나이스페이먼츠, JTNet 2가지 PG설정이 되어있다면, pg 파라미터로 nice 또는 jtnet로 구분 가능\n     </li><li>나이스페이먼츠로부터 2개 이상의 상점아이디를 발급받았다면, nice.MID1 또는 nice.MID2로 구분 가능</li></ul>\n     (단, **이니시스 경우 필수값임** `inicis.{상점아이디}` 형태로 지정)",
+            "description": "PG사 구분자.<br>\n     관리자콘솔 API 방식 비인증 PG설정이 2개 이상인 경우 필수적으로 기재해야 하는 항목입니다.\n     동일 PG사에 두개의 MID 를 설정한 경우 아래 양식으로 기재 합니다.\n     <b>{PG사}.{PG상점아이디}</b>\n     <ul><li>나이스페이먼츠, KCP 2가지 PG설정이 되어있다면, pg 파라미터로 nice 또는 kcp로 구분 가능\n     </li><li>나이스페이먼츠로부터 2개 이상의 상점아이디를 발급받았다면, nice.MID1 또는 nice.MID2로 구분 가능</li></ul>\n     (단, **이니시스 경우 필수값임** `inicis.{상점아이디}` 형태로 지정)",
             "required": false,
             "type": "string",
             "x-portone-name": "PG사 구분코드",
@@ -7692,7 +7623,7 @@
           {
             "name": "tax_free",
             "in": "formData",
-            "description": "면세금액 <br>\n     <h5>지원되는 PG사</h5><ul><li>나이스페이먼츠</li><li>(신) 나이스페이</li><li>웰컴페이먼츠</li></ul>\n     **웰컴페이먼츠**의 경우, `현금영수증 부가세업체정함` 설정 가맹점에 한해 사용이 가능합니다.<br>\n     **나이스페이먼츠, (신) 나이스페이 **의 경우, 상점아이디의 과세설정이 **지정금액방식**(복합과세)으로 설정되어 있는 경우 **필수값** 입니다.\n     과세 혹은 면세로 설정된 상점아이디에서 파라미터 전달 시 가상계좌 생성이 불가능합니다.",
+            "description": "면세금액 <br>\n     <h5>지원되는 PG사</h5><ul><li>나이스페이먼츠</li><li>(신) 나이스페이</li><li>웰컴페이먼츠</li></ul>\n     **웰컴페이먼츠**의 경우, `현금영수증 부가세업체정함` 설정 고객사에 한해 사용이 가능합니다.<br>\n     **나이스페이먼츠, (신) 나이스페이 **의 경우, 상점아이디의 과세설정이 **지정금액방식**(복합과세)으로 설정되어 있는 경우 **필수값** 입니다.\n     과세 혹은 면세로 설정된 상점아이디에서 파라미터 전달 시 가상계좌 생성이 불가능합니다.",
             "required": false,
             "type": "integer",
             "x-portone-name": "면세금액",
@@ -7710,7 +7641,7 @@
                 "description": "<p>상점아이디의 과세설정이 <strong>지정금액방식</strong>(복합과세)으로 설정되어 있는 경우 <strong>필수값</strong> 입니다.</p>\n<p>과세 혹은 면세로 설정된 상점아이디에서 파라미터 전달 시 가상계좌 생성이 불가능합니다.</p>\n"
               },
               "welcome": {
-                "description": "<p><code>현금영수증 부가세업체정함</code> 설정 가맹점에 한해 사용이 가능합니다</p>\n"
+                "description": "<p><code>현금영수증 부가세업체정함</code> 설정 고객사에 한해 사용이 가능합니다</p>\n"
               }
             }
           },
@@ -7729,18 +7660,18 @@
             ],
             "x-portone-per-pg": {
               "welcome": {
-                "description": "<p><code>부가세업체정함</code> 설정 가맹점에 한해 사용 가능하며 전체금액의 10% 이하로 설정해야 합니다. vat_amount가 <span>총 상품가격의 10%를 초과할 경우는 결제가 거절됩니다.</span></p>\n"
+                "description": "<p><code>부가세업체정함</code> 설정 고객사에 한해 사용 가능하며 전체금액의 10% 이하로 설정해야 합니다. vat_amount가 <span>총 상품가격의 10%를 초과할 경우는 결제가 거절됩니다.</span></p>\n"
               }
             }
           },
           {
             "name": "pg_api_key",
             "in": "query",
-            "description": "이니시스의 가맹점 콘솔에서 확인하셔야 하는 API Key 값으로 가상계좌 발급 및 말소 신청에 사용됩니다. 누락하거나 잘못된 키 입력 시 hashData 불일치 오류가 발생합니다. <br>\n     (**이니시스 전용 필수 파라미터로 Query parameter입니다.**)",
+            "description": "이니시스의 가맹점 관리자 페이지에서 확인하셔야 하는 API Key 값으로 가상계좌 발급 및 말소 신청에 사용됩니다. 누락하거나 잘못된 키 입력 시 hashData 불일치 오류가 발생합니다. <br>\n     (**이니시스 전용 필수 파라미터로 Query parameter입니다.**)",
             "required": false,
             "type": "string",
             "x-portone-name": "Api Key",
-            "x-portone-summary": "<p>이니시스의 가맹점 콘솔에서 확인하셔야 하는 API Key 값</p>\n",
+            "x-portone-summary": "<p>이니시스의 가맹점 관리자 페이지에서 확인하셔야 하는 API Key 값</p>\n",
             "x-portone-description": "<p>가상계좌 발급 및 말소 신청에 사용됩니다. 누락하거나 잘못된 키 입력 시 hashData 불일치 오류가 발생합니다. (<strong>이니시스 전용 필수 파라미터로 Query parameter입니다.</strong>)</p>\n",
             "x-portone-supported-pgs": [
               "html5_inicis"
@@ -7881,11 +7812,11 @@
           {
             "name": "pg_api_key",
             "in": "query",
-            "description": "이니시스의 가맹점 콘솔에서 확인하셔야 하는 API Key 값으로 가상계좌 발급 및 말소 신청에 사용됩니다. 누락하거나 잘못된 키 입력 시 hashData 불일치 오류가 발생합니다. <br>\n      POST 가상계좌 발급 API요청의 `pg_api_key`와 동일한 값입니다. <br>\n      (**이니시스 전용 필수 파라미터로 Query parameter입니다.**)",
+            "description": "이니시스의 가맹점 관리자 페이지에서 확인하셔야 하는 API Key 값으로 가상계좌 발급 및 말소 신청에 사용됩니다. 누락하거나 잘못된 키 입력 시 hashData 불일치 오류가 발생합니다. <br>\n      POST 가상계좌 발급 API요청의 `pg_api_key`와 동일한 값입니다. <br>\n      (**이니시스 전용 필수 파라미터로 Query parameter입니다.**)",
             "required": false,
             "type": "string",
             "x-portone-name": "API Key",
-            "x-portone-summary": "<p>이니시스의 가맹점 콘솔에서 확인하셔야 하는 API Key 값</p>\n",
+            "x-portone-summary": "<p>이니시스의 가맹점 관리자 페이지에서 확인하셔야 하는 API Key 값</p>\n",
             "x-portone-description": "<p>가상계좌 발급 및 말소 신청에 사용됩니다. 누락하거나 잘못된 키 입력 시 hashData 불일치 오류가 발생합니다. (<strong>이니시스 전용 필수 파라미터로 Query parameter입니다.</strong>)</p>\n",
             "x-portone-supported-pgs": [
               "html5_inicis"
@@ -8072,10 +8003,10 @@
           "x-portone-description": "<p>본인인증 결과건의 포트원 인증 고유번호</p>\n"
         },
         "merchant_uid": {
-          "description": "가맹점 주문번호",
+          "description": "고객사 주문번호",
           "type": "string",
-          "x-portone-name": "가맹점 주문번호",
-          "x-portone-description": "<p>본인인증 결과건의 포트원 가맹점 주문번호</p>\n"
+          "x-portone-name": "고객사 주문번호",
+          "x-portone-description": "<p>본인인증 결과건의 포트원 고객사 주문번호</p>\n"
         },
         "pg_tid": {
           "description": "PG사 본인인증결과 고유번호",
@@ -8148,11 +8079,11 @@
           "x-portone-description": "<p>개인별로 고유하게 부여하는 개인 식별키(CI)</p>\n"
         },
         "unique_in_site": {
-          "description": "가맹점 내 개인 고유구분 식별키(DI). 본인인증 PG MID별로 할당되는 개인 식별키",
+          "description": "고객사 내 개인 고유구분 식별키(DI). 본인인증 PG MID별로 할당되는 개인 식별키",
           "type": "string",
           "maxLength": "64",
-          "x-portone-name": "가맹점 내 개인 고유구분 식별키",
-          "x-portone-summary": "<p>가맹점 내 개인별로 고유하게 부여하는 개인 식별키(DI)</p>\n",
+          "x-portone-name": "고객사 내 개인 고유구분 식별키",
+          "x-portone-summary": "<p>고객사 내 개인별로 고유하게 부여하는 개인 식별키(DI)</p>\n",
           "x-portone-description": "<p>본인인증 PG MID별로 할당되는 개인 식별키</p>\n"
         },
         "origin": {
@@ -8224,11 +8155,11 @@
       ],
       "properties": {
         "customer_uid": {
-          "description": "빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호",
+          "description": "빌링키와 매핑되며 고객사에서 채번하는 구매자의 결제 수단 식별 고유번호",
           "type": "string",
           "maxLength": "80",
           "x-portone-name": "구매자의 결제 수단 식별 고유번호",
-          "x-portone-description": "<p>빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n"
+          "x-portone-description": "<p>빌링키와 매핑되며 고객사에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n"
         },
         "pg_provider": {
           "description": "빌링키가 등록된 PG사 구분코드",
@@ -8311,11 +8242,11 @@
           "x-portone-description": "<p>빌링키 발급 한 카드의 마스킹된 카드번호</p>\n"
         },
         "card_type": {
-          "description": "카드유형 <br>\n     (주의)해당 정보를 제공하지 않는 일부 PG사의 경우 null 로 응답됨(ex. JTNet, 이니시스-빌링)\n     <ul><li> 0 : 신용카드\n     </li><li> 1 : 체크카드 </li></ul>",
+          "description": "카드유형 <br>\n     (주의)해당 정보를 제공하지 않는 일부 PG사의 경우 null 로 응답됨(ex. 이니시스-빌링)\n     <ul><li> 0 : 신용카드\n     </li><li> 1 : 체크카드 </li></ul>",
           "type": "integer",
           "x-portone-name": "카드유형",
           "x-portone-summary": "<p>빌링키 발급 한 카드의 유형</p>\n",
-          "x-portone-description": "<p><strong>주의 : 해당 정보를 제공하지 않는 일부 PG사의 경우 null 로 응답</strong>됩니다.(ex. JTNet, 이니시스-빌링)</p>\n<ul>\n<li>0 : 신용카드</li>\n<li>1 : 체크카드</li>\n</ul>\n"
+          "x-portone-description": "<p><strong>주의 : 해당 정보를 제공하지 않는 일부 PG사의 경우 null 로 응답</strong>됩니다.(ex. 이니시스-빌링)</p>\n<ul>\n<li>0 : 신용카드</li>\n<li>1 : 체크카드</li>\n</ul>\n"
         },
         "customer_name": {
           "description": "고객(카드소지자) 성함",
@@ -8727,7 +8658,7 @@
           "description": "상품 코드",
           "type": "string",
           "x-portone-name": "상품 코드",
-          "x-portone-description": "<p>가맹점에서 사용하는 상품 관리 코드</p>\n"
+          "x-portone-description": "<p>고객사에서 사용하는 상품 관리 코드</p>\n"
         },
         "amount": {
           "description": "상품 단위 가격 (필수 : 웰컴페이먼츠)",
@@ -9342,11 +9273,11 @@
           "x-portone-description": "<p>결제건의 포트원 거래고유번호</p>\n"
         },
         "merchant_uid": {
-          "description": "가맹점 주문번호",
+          "description": "고객사 주문번호",
           "type": "string",
           "maxLength": "40",
-          "x-portone-name": "가맹점 주문번호",
-          "x-portone-description": "<p>결제건의 가맹점 주문번호</p>\n"
+          "x-portone-name": "고객사 주문번호",
+          "x-portone-description": "<p>결제건의 고객사 주문번호</p>\n"
         },
         "pay_method": {
           "description": "결제수단 구분코드\n     <ul><li>samsung : 삼성페이\n     </li><li> card : 신용카드\n     </li><li>trans : 계좌이체\n     </li><li> vbank : 가상계좌\n     </li><li> phone : 휴대폰\n     </li><li> cultureland : 문화상품권\n     </li><li> smartculture : 스마트문상\n     </li><li> booknlife : 도서문화상품권\n     </li><li> happymoney : 해피머니\n     </li><li> point : 포인트\n     </li><li> ssgpay : SSGPAY\n     </li><li> lpay : LPAY\n     </li><li> payco : 페이코\n     </li><li> kakaopay : 카카오페이\n     </li><li> tosspay : 토스\n     </li><li> naverpay : 네이버페이\n     </li><li> applepay : 애플페이\n     </li><li> paypal : 페이팔</li></ul>",
@@ -9492,11 +9423,11 @@
           "x-portone-description": "<p>7~12번째 자리를 마스킹하는 것이 일반적이지만, PG사의 정책/설정에 따라 상이할 수 있습니다.</p>\n"
         },
         "card_type": {
-          "description": "카드 구분코드 (주의)해당 정보를 제공하지 않는 일부 PG사의 경우 null 로 응답됨(ex. JTNet, 이니시스-빌링)\n     <ul><li> 0 : 신용코드\n     </li><li> 1 : 체크카드</li></ul>",
+          "description": "카드 구분코드 (주의)해당 정보를 제공하지 않는 일부 PG사의 경우 null 로 응답됨(ex. 이니시스-빌링)\n     <ul><li> 0 : 신용코드\n     </li><li> 1 : 체크카드</li></ul>",
           "type": "integer",
           "x-portone-name": "카드 구분코드",
           "x-portone-summary": "<p>결제건에 사용된 카드 구분코드</p>\n",
-          "x-portone-description": "<p><strong>주의 : 해당 정보를 제공하지 않는 일부 PG사의 경우 null로 응답</strong>됩니다.(ex. JTNet, 이니시스-빌링)</p>\n<ul>\n<li>0 : 신용카드</li>\n<li>1 : 체크카드</li>\n</ul>\n"
+          "x-portone-description": "<p><strong>주의 : 해당 정보를 제공하지 않는 일부 PG사의 경우 null로 응답</strong>됩니다.(ex. 이니시스-빌링)</p>\n<ul>\n<li>0 : 신용카드</li>\n<li>1 : 체크카드</li>\n</ul>\n"
         },
         "vbank_code": {
           "description": "가상계좌 은행 표준코드 - (금융결제원기준)",
@@ -9524,7 +9455,7 @@
           "x-portone-description": "<p>결제건의 입금받을 가상계좌 예금주 - 가상계좌 결제 건의 경우</p>\n",
           "x-portone-per-pg": {
             "tosspayments": {
-              "description": "<p>토스페이먼츠는 가상계좌 발급 완료시 발급 된 가상계좌의 예금주 명을 전달해주지 않습니다.\n따라서 <code>vbank_holder</code>가 null로 리턴 되지만, <strong>실제 가상계좌 예금주 명은 토스페이먼츠와 계약된 가맹점 이름과 동일</strong>하다고 하니, 참고 부탁드립니다.</p>\n"
+              "description": "<p>토스페이먼츠는 가상계좌 발급 완료시 발급 된 가상계좌의 예금주 명을 전달해주지 않습니다.\n따라서 <code>vbank_holder</code>가 null로 리턴 되지만, <strong>실제 가상계좌 예금주 명은 토스페이먼츠와 계약된 고객사 이름과 동일</strong>하다고 하니, 참고 부탁드립니다.</p>\n"
             }
           }
         },
@@ -9601,10 +9532,10 @@
           "x-portone-description": "<p>결제건의 주문자 우편번호</p>\n"
         },
         "custom_data": {
-          "description": "가맹점에서 전달한 custom data <br> JSON string으로 전달",
+          "description": "고객사에서 전달한 custom data <br> JSON string으로 전달",
           "type": "string",
           "x-portone-name": "추가정보",
-          "x-portone-description": "<p>결제 요청시 가맹점에서 전달한 추가정보 (JSON string으로 전달)</p>\n"
+          "x-portone-description": "<p>결제 요청시 고객사에서 전달한 추가정보 (JSON string으로 전달)</p>\n"
         },
         "user_agent": {
           "description": "구매자가 결제를 시작한 단말기의 UserAgent 문자열",
@@ -9702,7 +9633,7 @@
           "description": "해당 결제처리에 사용된 customer_uid",
           "type": "string",
           "x-portone-name": "구매자의 결제 수단 식별 고유번호",
-          "x-portone-description": "<p>결제건에 사용된 빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n"
+          "x-portone-description": "<p>결제건에 사용된 빌링키와 매핑되며 고객사에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n"
         },
         "customer_uid_usage": {
           "description": "customer_uid가 결제처리에 사용된 상세 용도\n     <ul><li>null:일반결제\n     </li><li> issue:빌링키 발급\n     </li><li> payment:결제\n     </li><li> payment.scheduled:예약결제</li></ul>",
@@ -9990,10 +9921,10 @@
       ],
       "properties": {
         "merchant_uid": {
-          "description": "가맹점 주문번호",
+          "description": "고객사 주문번호",
           "type": "string",
-          "x-portone-name": "가맹점 주문번호",
-          "x-portone-description": "<p>사전 등록한 가맹점의 주문번호</p>\n"
+          "x-portone-name": "고객사 주문번호",
+          "x-portone-description": "<p>사전 등록한 고객사의 주문번호</p>\n"
         },
         "amount": {
           "description": "결제 예정 금액",
@@ -10150,7 +10081,7 @@
           "type": "string"
         },
         "user_code": {
-          "description": "가맹점 식별코드",
+          "description": "고객사 식별코드",
           "type": "string"
         },
         "issuer": {
@@ -10331,10 +10262,10 @@
       ],
       "properties": {
         "merchant_uid": {
-          "description": "현금영수증 가맹점 주문번호",
+          "description": "현금영수증 고객사 주문번호",
           "type": "string",
-          "x-portone-name": "가맹점 주문번호",
-          "x-portone-description": "<p>현금영수증을 발행한 가맹점의 주문번호</p>\n"
+          "x-portone-name": "고객사 주문번호",
+          "x-portone-description": "<p>현금영수증을 발행한 고객사의 주문번호</p>\n"
         },
         "receipt_tid": {
           "description": "현금영수증 PG사 발행고유번호",
@@ -10422,14 +10353,15 @@
         "merchant_uid",
         "schedule_at",
         "amount",
-        "currency"
+        "currency",
+        "name"
       ],
       "properties": {
         "merchant_uid": {
-          "description": "가맹점 주문번호",
+          "description": "고객사 주문번호",
           "type": "string",
-          "x-portone-name": "가맹점의 주문번호",
-          "x-portone-description": "<p>결제 예약건의 가맹점 주문번호</p>\n",
+          "x-portone-name": "고객사의 주문번호",
+          "x-portone-description": "<p>결제 예약건의 고객사 주문번호</p>\n",
           "x-portone-per-pg": {
             "smartro_v2": {
               "description": "<p>스마트로는 주문 번호(merchant_uid)에 <strong>특수문자를 허용하고 있지 않습니다.</strong></p>\n<p>따라서 결제창에서 일반결제를 할때와 발급 된 빌링키로 API를 통해 재결제를 하는 경우 숫자, 문자(알파벳 소문자와 대문자) 또는 그 조합으로 이루어진 주문 번호를 사용해주세요.\n또한, 주문번호(merchant_uid)가 <strong>최대 40자</strong>를 넘을 수 없습니다. 40자가 넘을 경우 40자까지 잘려서 저장되기 때문에 유의 바랍니다.</p>\n"
@@ -10475,7 +10407,7 @@
               "description": "<p>면세 설정 상점아이디에서 면세처리를 위해 결제 금액과 동일한 면세 금액을 반드시 입력해야 합니다. 그렇지 않은 경우 매출전표에 전액 면세가 아닌 것으로 표시되고 실제 처리 내역이 다를 수 있습니다.</p>\n<p>과세 설정 상점아이디에서 면세 금액을 전달하지 않아야 합니다. 면세 금액을 전달하는 경우 매출전표에 면세 처리된 것으로 표시되지만 실제 처리 내역과 다를 수 있습니다.</p>\n"
             },
             "welcome": {
-              "description": "<p><code>부가세업체정함</code> 설정 가맹점에 한해 사용 가능합니다.</p>\n"
+              "description": "<p><code>부가세업체정함</code> 설정 고객사에 한해 사용 가능합니다.</p>\n"
             }
           }
         },
@@ -10492,7 +10424,7 @@
           ],
           "x-portone-per-pg": {
             "welcome": {
-              "description": "<p><code>부가세업체정함</code> 설정 가맹점에 한해 사용 가능하며 전체금액의 10% 이하로 설정해야 합니다. vat_amount가 <span>총 상품가격의 10%를 초과할 경우는 결제가 거절됩니다.</span></p>\n"
+              "description": "<p><code>부가세업체정함</code> 설정 고객사에 한해 사용 가능하며 전체금액의 10% 이하로 설정해야 합니다. vat_amount가 <span>총 상품가격의 10%를 초과할 경우는 결제가 거절됩니다.</span></p>\n"
             }
           }
         },
@@ -10501,15 +10433,7 @@
           "type": "string",
           "maxLength": 40,
           "x-portone-name": "제품명",
-          "x-portone-description": "<p>결제건의 제품명</p>\n",
-          "x-portone-per-pg": {
-            "html5_inicis": {
-              "required": true
-            },
-            "danal_tpay": {
-              "required": true
-            }
-          }
+          "x-portone-description": "<p>결제건의 제품명</p>\n"
         },
         "buyer_name": {
           "description": "[스마트로 - 신모듈, 웰컴페이먼츠 필수 파라미터] 주문자명",
@@ -10623,12 +10547,12 @@
           "x-portone-description": "<p>결제건의 카드 할부 개월 수로 기본값은 **0(일시불)**입니다.</p>\n"
         },
         "interest_free_by_merchant": {
-          "description": "카드할부처리시, 할부이자가 발생하는 경우(카드사 무이자 프로모션 제외) 부과되는 할부이자를 가맹점이 지불하고자 PG사와 계약된 경우 (default : false)",
+          "description": "카드할부처리시, 할부이자가 발생하는 경우(카드사 무이자 프로모션 제외) 부과되는 할부이자를 고객사가 지불하고자 PG사와 계약된 경우 (default : false)",
           "type": "boolean",
           "example": false,
-          "x-portone-name": "가맹점부담 무이자 할부여부",
-          "x-portone-summary": "<p>카드 할부이자를 가맹점에서 부담하는 지 여부</p>\n",
-          "x-portone-description": "<p>카드할부 처리할 때, 할부이자가 발생하는 경우(카드사 무이자 프로모션 제외) 부과되는 할부이자를 고객대신 가맹점이 지불하고자 PG사와 계약한 경우 (Default : false)</p>\n",
+          "x-portone-name": "상점분담 무이자 할부여부",
+          "x-portone-summary": "<p>카드 할부이자를 고객사에서 부담하는 지 여부</p>\n",
+          "x-portone-description": "<p>카드할부 처리할 때, 할부이자가 발생하는 경우(카드사 무이자 프로모션 제외) 부과되는 할부이자를 고객대신 고객사가 지불하고자 PG사와 계약한 경우 (Default : false)</p>\n",
           "x-portone-supported-pgs": [
             "nice",
             "ksnet",
@@ -10658,7 +10582,7 @@
           "description": "결제 예약 요청시 필요한 추가 정보",
           "properties": {
             "naverUseCfm": {
-              "description": "네이버페이 반복결제 계약 시 이용완료일 필수로 설정된 가맹점에 한함",
+              "description": "네이버페이 반복결제 계약 시 이용완료일 필수로 설정된 고객사에 한함",
               "type": "string",
               "x-portone-name": "이용완료일",
               "x-portone-description": "<p>이용완료일 <code>YYYYMMDD</code></p>\n",
@@ -10683,17 +10607,17 @@
     "ScheduleResultAnnotation": {
       "properties": {
         "customer_uid": {
-          "description": "빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호",
+          "description": "빌링키와 매핑되며 고객사에서 채번하는 구매자의 결제 수단 식별 고유번호",
           "type": "string",
           "x-portone-name": "구매자의 결제 수단 식별 고유번호",
-          "x-portone-description": "<p>빌링키와 매핑되며 가맹점에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n"
+          "x-portone-description": "<p>빌링키와 매핑되며 고객사에서 채번하는 구매자의 결제 수단 식별 고유번호</p>\n"
         },
         "merchant_uid": {
-          "description": "가맹점 주문번호",
+          "description": "고객사 주문번호",
           "type": "string",
           "maxLength": 40,
-          "x-portone-name": "가맹점 주문번호",
-          "x-portone-description": "<p>예약 결제건의 가맹점 주문번호</p>\n"
+          "x-portone-name": "고객사 주문번호",
+          "x-portone-description": "<p>예약 결제건의 고객사 주문번호</p>\n"
         },
         "imp_uid": {
           "description": "포트원 거래고유번호<br> 예약된 결제가 실행 전 철회되거나 아직 실행 전 예약 상태에 있으면 imp_uid 는 null 입니다.",
@@ -10919,17 +10843,17 @@
       ],
       "properties": {
         "tier_code": {
-          "description": "하위 가맹점(Tier) 고유코드(알파벳 대문자 또는 숫자 3자리)",
+          "description": "하위 상점(Tier) 고유코드(알파벳 대문자 또는 숫자 3자리)",
           "type": "string",
           "x-portone-name": "티어코드",
-          "x-portone-summary": "<p>하위가맹점(Tier)의 고유코드</p>\n",
+          "x-portone-summary": "<p>하위 상점(Tier)의 고유코드</p>\n",
           "x-portone-description": "<p>알파벳 대문자 또는 숫자 3자리로 구성됩니다.</p>\n"
         },
         "tier_name": {
-          "description": "하위 가맹점(Tier) 관리명칭",
+          "description": "하위 상점(Tier) 관리명칭",
           "type": "string",
           "x-portone-name": "티어명",
-          "x-portone-description": "<p>하위가맹점(Tier)의 관리명칭</p>\n"
+          "x-portone-description": "<p>하위 상점(Tier)의 관리명칭</p>\n"
         }
       }
     },
@@ -10939,7 +10863,7 @@
           "$ref": "#/definitions/ResponseAnnotation"
         },
         {
-          "description": "하위 가맹점(Tier) 정보",
+          "description": "하위 상점(Tier) 정보",
           "properties": {
             "response": {
               "$ref": "#/definitions/TierAnnotation"
@@ -10983,16 +10907,16 @@
           "x-portone-description": "<p>설정된 PG사의 타입 구분코드</p>\n"
         },
         "channel_name": {
-          "description": "가맹점이 포트원 콘솔에 채널 추가시 설정한 결제 채널 이름",
+          "description": "고객사가 포트원 콘솔에 채널 추가시 설정한 결제 채널 이름",
           "type": "string",
           "x-portone-name": "채널이름",
-          "x-portone-description": "<p>가맹점이 포트원 콘솔에 채널 추가시 설정한 결제 채널 이름</p>\n"
+          "x-portone-description": "<p>고객사가 포트원 콘솔에 채널 추가시 설정한 결제 채널 이름</p>\n"
         },
         "channel_key": {
-          "description": "가맹점이 포트원 콘솔에 채널 추가시 포트원이 자동 생성한 채널 고유 키",
+          "description": "고객사가 포트원 콘솔에 채널 추가시 포트원이 자동 생성한 채널 고유 키",
           "type": "string",
           "x-portone-name": "채널 고유 키",
-          "x-portone-description": "<p>가맹점이 포트원 콘솔에 채널 추가시 포트원이 자동 생성한 채널 고유 키</p>\n"
+          "x-portone-description": "<p>고객사가 포트원 콘솔에 채널 추가시 포트원이 자동 생성한 채널 고유 키</p>\n"
         }
       }
     },
@@ -11116,11 +11040,11 @@
     },
     {
       "name": "users",
-      "description": "가맹점 설정 정보 전용 API"
+      "description": "고객사 설정 정보 전용 API"
     },
     {
       "name": "tiers",
-      "description": "대표가맹점에 대한 하위가맹점 관리"
+      "description": "대표 상점에 대한 하위 상점 관리"
     },
     {
       "name": "partners",
@@ -11216,13 +11140,13 @@
     },
     {
       "id": "user",
-      "title": "가맹점 정보 관련 API",
-      "description": "가맹점 정보를 관리하는 기능을 제공합니다.",
+      "title": "고객사 정보 관련 API",
+      "description": "고객사 정보를 관리하는 기능을 제공합니다.",
       "children": [
         {
           "id": "user.tier",
-          "title": "가맹점의 하위가맹점 관련 API",
-          "description": "대표가맹점에 대한 하위가맹점 관리와 관련된 기능을 제공합니다."
+          "title": "고객사의 하위 상점 관련 API",
+          "description": "대표 상점에 대한 하위 상점 관리와 관련된 기능을 제공합니다."
         }
       ]
     },


### PR DESCRIPTION
V1 openApi 스키마를 업데이트 했습니다.

- cmd:
```
deno run -A ./scripts/download-schema.ts

# select "V1 OpenApi"
```
- 예약결제 등록 시 요청 파라미터 name을 required로 변경(하위 호환을 위해 실제론 optional 동작을 유지함, [참고](https://github.com/portone-io/api-iamport/pull/722/files))
- 표현 변경: 가맹점 => 고객사ㅑ
- 그 외 등등