### PR TITLE
버짓핸들러 기존 메뉴삭제

### DIFF
--- a/src/routes/(root)/docs/en/_nav.yaml
+++ b/src/routes/(root)/docs/en/_nav.yaml
@@ -79,7 +79,6 @@
         - /en/etc/credit-auth/3-send-verification-result
         - /en/etc/credit-auth/4-get-verification-info
     - /en/etc/url
-    - /en/etc/budget
     - /en/etc/native-mobile-sdks
 - label: TIPS
   systemVersion: v1

--- a/src/routes/(root)/docs/en/etc/budget.mdx
+++ b/src/routes/(root)/docs/en/etc/budget.mdx
@@ -1,6 +1,0 @@
----
-title: Integrate budget handler
-description: Learn how to integrate credit card promotion service.
----
-
-###Refer to the [**Budget handler guide**](http://localhost:5000/o/nad6nqI7LNE1TGdY19Od/s/zzqz39hKDV7YEtDAeA1v/).

--- a/src/routes/(root)/docs/en/readme.mdx
+++ b/src/routes/(root)/docs/en/readme.mdx
@@ -42,8 +42,6 @@ Learn how to integrate other useful services to your site.
 
 <ContentRef slug="/en/etc/url" />
 
-<ContentRef slug="/en/etc/budget" />
-
 ## Tips
 
 Make sure to check these useful tips about payment integration.

--- a/src/routes/(root)/docs/ko/_nav.yaml
+++ b/src/routes/(root)/docs/ko/_nav.yaml
@@ -236,7 +236,6 @@
         - /ko/etc/credit-auth/3
         - /ko/etc/credit-auth/4
     - /ko/etc/url
-    - /ko/etc/budget
     - /ko/promotion/promotion
     - /ko/etc/sdk
 

--- a/src/routes/(root)/docs/ko/etc/budget.mdx
+++ b/src/routes/(root)/docs/ko/etc/budget.mdx
@@ -1,7 +1,0 @@
----
-title: 버짓핸들러 연동하기
-description: 카드사 프로모션 서비스를 진행하기 위한 가이드 입니다.
-targetVersions: ["v1"]
----
-
-**[버짓핸들러 연동가이드](https://portone.gitbook.io/promotion) 확인**

--- a/src/routes/(root)/docs/ko/readme/index.mdx
+++ b/src/routes/(root)/docs/ko/readme/index.mdx
@@ -89,8 +89,6 @@ import VersionGate from "~/components/gitbook/VersionGate";
 
   <ContentRef slug="/ko/etc/url" />
 
-  <ContentRef slug="/ko/etc/budget" />
-
   ## TIP
 
   결제창 연동 시 꼭 확인해 보세요.


### PR DESCRIPTION
Gitbook 링크 걸려있던 메뉴 삭제. 해당 가이드는 현재 크림만 쓰기 때문에 크림 요청 시 기존 깃북 주소 전달