### PR TITLE
메인 페이지에 Legacy cipher 지원 중단 Hint 추가

### DIFF
--- a/src/routes/(root)/api/rest-v1/[...slug].tsx
+++ b/src/routes/(root)/api/rest-v1/[...slug].tsx
@@ -2,6 +2,7 @@ import { Title } from "@solidjs/meta";
 import { useParams } from "@solidjs/router";
 import { createSignal } from "solid-js";
 
+import Hint from "~/components/Hint";
 import * as prose from "~/components/prose";
 import RestApi from "~/layouts/rest-api";
 import createSectionDescriptionProps from "~/layouts/rest-api/misc/createSectionDescriptionProps";
@@ -51,6 +52,20 @@ export default function ApiV1Docs() {
           <br />
           비인증 결제, 정기 자동결제 등 부가기능을 위한 REST API도 제공합니다.
         </prose.p>
+        <Hint style="danger">
+          2024년 9월 1일부로 포트원 V1 API에 대해 일부 보안 규격이 지원
+          종료됩니다.
+          <br />
+          자세한 사항은
+          <a
+            href="/docs/ko/tip/tls-support?v=v1"
+            style="color:orange"
+            target="_self"
+          >
+            TLS 지원 범위
+          </a>
+          를 참고해주세요.
+        </Hint>
         <prose.p>
           <strong>V1 API hostname: </strong>
           <code>api.iamport.kr</code>

--- a/src/routes/(root)/docs/ko/readme/index.mdx
+++ b/src/routes/(root)/docs/ko/readme/index.mdx
@@ -7,8 +7,17 @@ targetVersions: ["v1", "v2"]
 import EasyGuideLink from "~/components/EasyGuideLink";
 import ContentRef from "~/components/gitbook/ContentRef";
 import VersionGate from "~/components/gitbook/VersionGate";
+import Hint from "~/components/Hint";
 
 <EasyGuideLink />
+
+<VersionGate v="v1">
+<Hint style="danger">
+2024년 9월 1일부로 포트원 V1 API에 대해 일부 보안 규격이 지원 종료됩니다. 
+
+자세한 사항은 [TLS 지원 범위](/docs/ko/tip/tls-support?v=v1)를 참고해주세요.
+</Hint>
+</VersionGate>
 
 <VersionGate v="v2">
   ## 포트원 V2 신모듈 알아보기


### PR DESCRIPTION
Legacy cipher 지원 중단에 대한 안내를 2024년 3월부터 메일로 보내왔으나 신규 가맹점들에 한해서는 legacy cipher를 사용하는 가맹점을 막을 수 없는 문제가 있습니다.
이에 따라 개발자센터에도 지원 중단 관련된 문구를 노출합니다.

- 메인 페이지
![image](https://github.com/user-attachments/assets/556e20ad-5dfc-48f5-91d7-4f5420b1dba4)

- API 개요 페이지
![image](https://github.com/user-attachments/assets/7fe870c0-89dd-4d55-a4c0-5b84df2c9267)

