### PR TITLE
File 컴포넌트 404 오류 해결

### DIFF
--- a/src/components/gitbook/File.tsx
+++ b/src/components/gitbook/File.tsx
@@ -1,19 +1,23 @@
-import { Show } from "solid-js";
+import { createMemo, Show } from "solid-js";
 
 interface Props {
   src: string;
-  filename: string;
+  filename?: string;
   caption?: string;
   captionInside?: string;
 }
 
 export default function File(props: Props) {
+  const filename = createMemo(() => {
+    if (props.filename) return props.filename;
+    return props.src.split("/").pop();
+  });
   return (
     <div>
-      <a href={props.src} download={props.filename}>
+      <a href={props.src} download={filename()} target="_blank">
         <div class="m-4 flex items-center gap-4 border rounded bg-white p-4 transition-transform hover:translate-y-[-2px] hover:text-orange-5 hover:drop-shadow-[0_12px_13px_rgba(0,0,0,0.02)]">
           <i class="i-ic-baseline-download text-2xl" role="img"></i>
-          {props.captionInside ?? props.filename}
+          {props.captionInside ?? filename()}
         </div>
       </a>
       <Show when={props.caption}>


### PR DESCRIPTION
[Slack 논의](https://portone-io.slack.com/archives/C067FEWAMAQ/p1722835850481659)
- target="_blank" 적용
- filename을 optional로 만들고, 기본값으로 다운로드 경로의 파일 이름을 사용