### PR TITLE
검색 시 index 문서가 잘못된 링크를 생성하지 않도록 수정

### DIFF
--- a/src/layouts/sidebar/search.tsx
+++ b/src/layouts/sidebar/search.tsx
@@ -87,12 +87,17 @@ export function SearchScreen(props: SearchScreenProps) {
   const fuse = createMemo(() => {
     const index = searchIndex.latest;
     if (!index) return;
-    const filteredIndex = index.filter((item) => {
-      const navMenuSystemVersion =
-        props.navMenuSystemVersions[item.slug.replace(/^docs/, "")];
-      if (!navMenuSystemVersion) return true;
-      return navMenuSystemVersion === systemVersion();
-    });
+    const filteredIndex = index
+      .filter((item) => {
+        const navMenuSystemVersion =
+          props.navMenuSystemVersions[item.slug.replace(/^docs/, "")];
+        if (!navMenuSystemVersion) return true;
+        return navMenuSystemVersion === systemVersion();
+      })
+      .map((item) => {
+        const slug = item.slug.replace(/\/index$/, "");
+        return { ...item, slug };
+      });
     return new Fuse(filteredIndex, { keys: ["title", "description", "text"] });
   });
   const searchResult = createMemo(() => {


### PR DESCRIPTION
- `/index` 로 끝나는 slug에 대한 처리 추가
```ts
.map((item) => {
  const slug = item.slug.replace(/\/index$/, "");
  return { ...item, slug };
})
```