### PR TITLE
v2 openapi 스키마에서 markdown을 그대로 사용하도록 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
 		"rehype-stringify": "^10.0.0",
 		"remark-frontmatter": "^5.0.0",
 		"remark-gfm": "^4.0.0",
+		"remark-html": "^16.0.1",
 		"remark-lint-blockquote-indentation": "^4.0.0",
 		"remark-lint-checkbox-character-style": "^5.0.0",
 		"remark-lint-checkbox-content-indent": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,6 +214,9 @@ importers:
       remark-gfm:
         specifier: ^4.0.0
         version: 4.0.0
+      remark-html:
+        specifier: ^16.0.1
+        version: 16.0.1
       remark-lint-blockquote-indentation:
         specifier: ^4.0.0
         version: 4.0.0
@@ -3351,6 +3354,9 @@ packages:
   hast-util-raw@9.0.1:
     resolution: {integrity: sha512-5m1gmba658Q+lO5uqL5YNGQWeh1MYWZbZmWrM5lncdcuiXuo5E2HT/CIOp0rLF8ksfSwiCVJ3twlgVRyTGThGA==}
 
+  hast-util-sanitize@5.0.1:
+    resolution: {integrity: sha512-IGrgWLuip4O2nq5CugXy4GI2V8kx4sFVy5Hd4vF7AR2gxS0N9s7nEAVUyeMtZKZvzrxVsHt73XdTsno1tClIkQ==}
+
   hast-util-to-estree@3.1.0:
     resolution: {integrity: sha512-lfX5g6hqVh9kjS/B9E2gSkvHH4SZNiQFiqWS0x9fENzEl+8W12RqdRxX6d/Cwxi30tPQs3bIO+aolQJNp1bIyw==}
 
@@ -4493,6 +4499,9 @@ packages:
 
   remark-gfm@4.0.0:
     resolution: {integrity: sha512-U92vJgBPkbw4Zfu/IiW2oTZLSL3Zpv+uI7My2eq8JxKgqraFdU8YUGicEJCEgSbeaG+QDFqIcwwfMTOEelPxuA==}
+
+  remark-html@16.0.1:
+    resolution: {integrity: sha512-B9JqA5i0qZe0Nsf49q3OXyGvyXuZFDzAP2iOFLEumymuYJITVpiH1IgsTEwTpdptDmZlMDMWeDmSawdaJIGCXQ==}
 
   remark-lint-blockquote-indentation@4.0.0:
     resolution: {integrity: sha512-hdUvn+KsJbBKpY9jLY01PmfpJ/WGhLu9GJMXQGU8ADXJc+F5DWSgKAr6GQ1IUKqvGYdEML/KZ61WomWFUuecVA==}
@@ -8940,6 +8949,12 @@ snapshots:
       web-namespaces: 2.0.1
       zwitch: 2.0.4
 
+  hast-util-sanitize@5.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@ungap/structured-clone': 1.2.0
+      unist-util-position: 5.0.0
+
   hast-util-to-estree@3.1.0:
     dependencies:
       '@types/estree': 1.0.5
@@ -10503,6 +10518,14 @@ snapshots:
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
+
+  remark-html@16.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      hast-util-sanitize: 5.0.1
+      hast-util-to-html: 9.0.0
+      mdast-util-to-hast: 13.0.2
+      unified: 11.0.5
 
   remark-lint-blockquote-indentation@4.0.0:
     dependencies:

--- a/scripts/calc-api-redir.ts
+++ b/scripts/calc-api-redir.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S deno run -A
 
-import { walkSync } from "https://deno.land/std@0.202.0/fs/walk.ts";
-import { stringify } from "https://deno.land/std@0.202.0/yaml/mod.ts";
+import { walkSync } from "jsr:@std/fs@1.0.2/walk";
+import { stringify } from "jsr:@std/yaml@1.0.4";
 import schema from "../src/schema/v1.openapi.json" with { type: "json" };
 
 const redirList = [];

--- a/scripts/download-schema.ts
+++ b/scripts/download-schema.ts
@@ -1,16 +1,16 @@
 #!/usr/bin/env -S deno run -A
 
-import { ensureFile } from "https://deno.land/std@0.197.0/fs/ensure_file.ts";
-import { parse as parseYaml } from "https://deno.land/std@0.197.0/yaml/mod.ts";
-import { Input } from "https://deno.land/x/cliffy@v1.0.0-rc.3/prompt/input.ts";
+import { ensureFile } from "jsr:@std/fs@1.0.2/ensure-file";
+import { parse as parseYaml } from "jsr:@std/yaml@1.0.4";
+import { Input } from "jsr:@cliffy/prompt@1.0.0-rc.5/input";
 import {
   pollToken,
   requestCode,
   writeGhHosts,
-} from "https://deno.land/x/pbkit@v0.0.61/misc/github/auth.ts";
-import { getToken } from "https://deno.land/x/pbkit@v0.0.61/misc/github/index.ts";
-import { open } from "https://deno.land/x/pbkit@v0.0.61/misc/browser.ts";
-import { render as renderGfm } from "https://deno.land/x/gfm@0.2.5/mod.ts";
+} from "https://deno.land/x/pbkit@v0.0.70/misc/github/auth.ts";
+import { getToken } from "https://deno.land/x/pbkit@v0.0.70/misc/github/index.ts";
+import { open } from "https://deno.land/x/pbkit@v0.0.70/misc/browser.ts";
+import { render as renderGfm } from "jsr:@deno/gfm@0.9.0";
 
 const mdProperties = new Set([
   "summary",

--- a/scripts/download-schema.ts
+++ b/scripts/download-schema.ts
@@ -89,11 +89,6 @@ export function processV2Openapi(schema: any): any {
     }
     delete node["x-portone-fields"];
   });
-  traverseEveryProperty(schema, (node, property) => {
-    if (typeof node[property] !== "string") return;
-    if (!mdProperties.has(property)) return;
-    node[property] = renderGfm(node[property]);
-  });
   return schema;
 }
 

--- a/scripts/nav-labels.ts
+++ b/scripts/nav-labels.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S deno run -A
 
-import { parse as parseYaml } from "https://deno.land/std@0.197.0/yaml/mod.ts";
+import { parse as parseYaml } from "jsr:@std/yaml@1.0.4";
 
 run("ko");
 

--- a/src/layouts/rest-api/category/type-def.tsx
+++ b/src/layouts/rest-api/category/type-def.tsx
@@ -10,6 +10,7 @@ import {
 } from "solid-js";
 
 import * as prose from "~/components/prose";
+import { toHtml } from "~/misc/md";
 import { expandAndScrollTo, useExpand } from "~/state/rest-api/expand-section";
 
 import { interleave } from "..";
@@ -528,9 +529,13 @@ interface DescriptionDocProps {
   showNested?: boolean | undefined;
 }
 function DescriptionDoc(props: DescriptionDocProps) {
-  const description = createMemo(
+  const rawDescription = createMemo(
     () => props.typeDef["x-portone-description"] ?? props.typeDef.description,
   );
+  const description = createMemo(() => {
+    const markdown = rawDescription();
+    return markdown == null ? markdown : toHtml(markdown);
+  });
   const summary = createMemo(
     () => props.typeDef["x-portone-summary"] ?? props.typeDef.summary,
   );

--- a/src/layouts/rest-api/endpoint/EndpointDoc.tsx
+++ b/src/layouts/rest-api/endpoint/EndpointDoc.tsx
@@ -1,6 +1,7 @@
 import { createMemo, For, type JSXElement, Show } from "solid-js";
 
 import * as prose from "~/components/prose";
+import { toHtml } from "~/misc/md";
 
 import { ReqPropertiesDoc, TypeDefDoc } from "../category/type-def";
 import DescriptionArea from "../DescriptionArea";
@@ -267,13 +268,17 @@ interface ReqResProps {
   children: JSXElement;
 }
 function ReqRes(props: ReqResProps) {
+  const description = createMemo(() => {
+    const markdown = props.description;
+    return markdown == null ? markdown : toHtml(markdown);
+  });
   return (
     <div>
       <Show when={props.title}>
         <div class="mb-1 inline-flex gap-2 text-xs">
           <h4 class="shrink-0 font-bold uppercase">{props.title}</h4>
-          <Show when={props.description}>
-            <div class="text-slate-5" innerHTML={props.description} />
+          <Show when={description()}>
+            <div class="text-slate-5" innerHTML={description()} />
           </Show>
         </div>
       </Show>

--- a/src/misc/md.ts
+++ b/src/misc/md.ts
@@ -1,0 +1,13 @@
+import remarkGfm from "remark-gfm";
+import remarkHtml from "remark-html";
+import remarkParse from "remark-parse";
+import { unified } from "unified";
+
+export function toHtml(md: string): string {
+  return unified()
+    .use(remarkParse)
+    .use(remarkGfm)
+    .use(remarkHtml)
+    .processSync(md)
+    .toString();
+}

--- a/src/schema/v2.openapi.json
+++ b/src/schema/v2.openapi.json
@@ -7,15 +7,15 @@
   "servers": [
     {
       "url": "https://api.portone.io",
-      "description": "<p>운영환경 서버</p>\n"
+      "description": "운영환경 서버"
     }
   ],
   "paths": {
     "/login/api-key": {},
     "/login/api-secret": {
       "post": {
-        "summary": "<p>API secret 를 사용한 토큰 발급</p>\n",
-        "description": "<p>API secret 를 사용한 토큰 발급</p>\n<p>API secret 를 통해 API 인증에 사용할 토큰을 가져옵니다.</p>\n",
+        "summary": "API secret 를 사용한 토큰 발급",
+        "description": "API secret 를 사용한 토큰 발급\n\nAPI secret 를 통해 API 인증에 사용할 토큰을 가져옵니다.",
         "operationId": "loginViaApiSecret",
         "requestBody": {
           "content": {
@@ -32,7 +32,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 토큰을 반환합니다.</p>\n",
+            "description": "성공 응답으로 토큰을 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -44,10 +44,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 토큰을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 토큰을 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -57,7 +57,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -69,7 +69,7 @@
         },
         "x-portone-category": "auth",
         "x-portone-title": "API secret 를 사용한 토큰 발급",
-        "x-portone-description": "<p>API secret 를 통해 API 인증에 사용할 토큰을 가져옵니다.</p>\n",
+        "x-portone-description": "API secret 를 통해 API 인증에 사용할 토큰을 가져옵니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/LoginViaApiSecretError"
         }
@@ -77,8 +77,8 @@
     },
     "/token/refresh": {
       "post": {
-        "summary": "<p>토큰 갱신</p>\n",
-        "description": "<p>토큰 갱신</p>\n<p>리프레시 토큰을 사용해 유효기간이 연장된 새로운 토큰을 재발급합니다.</p>\n",
+        "summary": "토큰 갱신",
+        "description": "토큰 갱신\n\n리프레시 토큰을 사용해 유효기간이 연장된 새로운 토큰을 재발급합니다.",
         "operationId": "refreshToken",
         "requestBody": {
           "content": {
@@ -109,7 +109,7 @@
             }
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -119,7 +119,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -131,7 +131,7 @@
         },
         "x-portone-category": "auth",
         "x-portone-title": "토큰 갱신",
-        "x-portone-description": "<p>리프레시 토큰을 사용해 유효기간이 연장된 새로운 토큰을 재발급합니다.</p>\n",
+        "x-portone-description": "리프레시 토큰을 사용해 유효기간이 연장된 새로운 토큰을 재발급합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/RefreshTokenError"
         }
@@ -140,11 +140,11 @@
     "/merchant": {},
     "/platform": {
       "get": {
-        "description": "<p>고객사의 플랫폼 정보를 조회합니다.\n요청된 Authorization header 를 통해 자동으로 요청자의 고객사를 특정합니다.</p>\n",
+        "description": "고객사의 플랫폼 정보를 조회합니다.\n요청된 Authorization header 를 통해 자동으로 요청자의 고객사를 특정합니다.",
         "operationId": "getPlatform",
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 플랫폼 객체를 반환합니다.</p>\n",
+            "description": "성공 응답으로 플랫폼 객체를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -152,10 +152,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 플랫폼 객체를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 플랫폼 객체를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -165,7 +165,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -175,7 +175,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -193,13 +193,13 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>고객사의 플랫폼 정보를 조회합니다.\n요청된 Authorization header 를 통해 자동으로 요청자의 고객사를 특정합니다.</p>\n",
+        "x-portone-description": "고객사의 플랫폼 정보를 조회합니다.\n요청된 Authorization header 를 통해 자동으로 요청자의 고객사를 특정합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPlatformError"
         }
       },
       "patch": {
-        "description": "<p>고객사의 플랫폼 관련 정보를 업데이트합니다.\n요청된 Authorization header 를 통해 자동으로 요청자의 고객사를 특정합니다.</p>\n",
+        "description": "고객사의 플랫폼 관련 정보를 업데이트합니다.\n요청된 Authorization header 를 통해 자동으로 요청자의 고객사를 특정합니다.",
         "operationId": "updatePlatform",
         "requestBody": {
           "content": {
@@ -213,7 +213,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답",
             "content": {
               "application/json": {
                 "schema": {
@@ -224,7 +224,7 @@
             "x-portone-title": "성공 응답"
           },
           "400": {
-            "description": "<ul>\n<li><code>PlatformInvalidSettlementFormulaError</code></li>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `PlatformInvalidSettlementFormulaError`\n* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -234,7 +234,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -244,7 +244,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -262,7 +262,7 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>고객사의 플랫폼 관련 정보를 업데이트합니다.\n요청된 Authorization header 를 통해 자동으로 요청자의 고객사를 특정합니다.</p>\n",
+        "x-portone-description": "고객사의 플랫폼 관련 정보를 업데이트합니다.\n요청된 Authorization header 를 통해 자동으로 요청자의 고객사를 특정합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/UpdatePlatformError"
         }
@@ -270,24 +270,24 @@
     },
     "/platform/discount-share-policy-filter-options": {
       "get": {
-        "description": "<p>할인 분담 정책 다건 조회 시 필요한 필터 옵션을 조회합니다.</p>\n",
+        "description": "할인 분담 정책 다건 조회 시 필요한 필터 옵션을 조회합니다.",
         "operationId": "getPlatformDiscountSharePolicyFilterOptions",
         "parameters": [
           {
             "name": "isArchived",
             "in": "query",
-            "description": "<p>보관 조회 여부</p>\n<p>true 이면 보관된 할인 분담의 필터 옵션을 조회하고, false 이면 보관되지 않은 할인 분담의 필터 옵션을 조회합니다. 기본값은 false 입니다.</p>\n",
+            "description": "보관 조회 여부\n\ntrue 이면 보관된 할인 분담의 필터 옵션을 조회하고, false 이면 보관되지 않은 할인 분담의 필터 옵션을 조회합니다. 기본값은 false 입니다.",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "보관 조회 여부",
-            "x-portone-description": "<p>true 이면 보관된 할인 분담의 필터 옵션을 조회하고, false 이면 보관되지 않은 할인 분담의 필터 옵션을 조회합니다. 기본값은 false 입니다.</p>\n"
+            "x-portone-description": "true 이면 보관된 할인 분담의 필터 옵션을 조회하고, false 이면 보관되지 않은 할인 분담의 필터 옵션을 조회합니다. 기본값은 false 입니다."
           }
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 조회된 할인 분담 정책 필터 옵션을 반환합니다.</p>\n",
+            "description": "성공 응답으로 조회된 할인 분담 정책 필터 옵션을 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -295,10 +295,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 조회된 할인 분담 정책 필터 옵션을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 조회된 할인 분담 정책 필터 옵션을 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -308,7 +308,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -318,7 +318,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -336,7 +336,7 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>할인 분담 정책 다건 조회 시 필요한 필터 옵션을 조회합니다.</p>\n",
+        "x-portone-description": "할인 분담 정책 다건 조회 시 필요한 필터 옵션을 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPlatformDiscountSharePolicyFilterOptionsError"
         },
@@ -345,8 +345,8 @@
     },
     "/platform/discount-share-policies": {
       "get": {
-        "summary": "<p>할인 분담 정책 다건 조회</p>\n",
-        "description": "<p>할인 분담 정책 다건 조회</p>\n<p>여러 할인 분담을 조회합니다.</p>\n",
+        "summary": "할인 분담 정책 다건 조회",
+        "description": "할인 분담 정책 다건 조회\n\n여러 할인 분담을 조회합니다.",
         "operationId": "getPlatformDiscountSharePolicies",
         "parameters": [
           {
@@ -378,7 +378,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 조회된 할인 분담 정책 리스트와 페이지 정보가 반환됩니다.</p>\n",
+            "description": "성공 응답으로 조회된 할인 분담 정책 리스트와 페이지 정보가 반환됩니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -386,10 +386,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 조회된 할인 분담 정책 리스트와 페이지 정보가 반환됩니다.</p>\n"
+            "x-portone-description": "성공 응답으로 조회된 할인 분담 정책 리스트와 페이지 정보가 반환됩니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -399,7 +399,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -409,7 +409,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -429,14 +429,14 @@
         ],
         "x-portone-category": "platform.policy",
         "x-portone-title": "할인 분담 정책 다건 조회",
-        "x-portone-description": "<p>여러 할인 분담을 조회합니다.</p>\n",
+        "x-portone-description": "여러 할인 분담을 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPlatformDiscountSharePoliciesError"
         }
       },
       "post": {
-        "summary": "<p>할인 분담 정책 생성</p>\n",
-        "description": "<p>할인 분담 정책 생성</p>\n<p>새로운 할인 분담을 생성합니다.</p>\n",
+        "summary": "할인 분담 정책 생성",
+        "description": "할인 분담 정책 생성\n\n새로운 할인 분담을 생성합니다.",
         "operationId": "createPlatformDiscountSharePolicy",
         "requestBody": {
           "content": {
@@ -450,7 +450,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 생성된 할인 분담 정책이 반환됩니다.</p>\n",
+            "description": "성공 응답으로 생성된 할인 분담 정책이 반환됩니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -458,10 +458,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 생성된 할인 분담 정책이 반환됩니다.</p>\n"
+            "x-portone-description": "성공 응답으로 생성된 할인 분담 정책이 반환됩니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -471,7 +471,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -481,7 +481,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -491,7 +491,7 @@
             }
           },
           "409": {
-            "description": "<ul>\n<li><code>PlatformDiscountSharePolicyAlreadyExistsError</code></li>\n</ul>\n",
+            "description": "* `PlatformDiscountSharePolicyAlreadyExistsError`",
             "content": {
               "application/json": {
                 "schema": {
@@ -511,7 +511,7 @@
         ],
         "x-portone-category": "platform.policy",
         "x-portone-title": "할인 분담 정책 생성",
-        "x-portone-description": "<p>새로운 할인 분담을 생성합니다.</p>\n",
+        "x-portone-description": "새로운 할인 분담을 생성합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/CreatePlatformDiscountSharePolicyError"
         }
@@ -519,14 +519,14 @@
     },
     "/platform/discount-share-policies/{id}": {
       "get": {
-        "summary": "<p>할인 분담 정책 조회</p>\n",
-        "description": "<p>할인 분담 정책 조회</p>\n<p>주어진 아이디에 대응되는 할인 분담을 조회합니다.</p>\n",
+        "summary": "할인 분담 정책 조회",
+        "description": "할인 분담 정책 조회\n\n주어진 아이디에 대응되는 할인 분담을 조회합니다.",
         "operationId": "getPlatformDiscountSharePolicy",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>조회할 할인 분담 정책 아이디</p>\n",
+            "description": "조회할 할인 분담 정책 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -536,7 +536,7 @@
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 할인 분담 정책을 반환합니다.</p>\n",
+            "description": "성공 응답으로 할인 분담 정책을 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -544,10 +544,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 할인 분담 정책을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 할인 분담 정책을 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -557,7 +557,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -567,7 +567,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -577,7 +577,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PlatformDiscountSharePolicyNotFoundError</code></li>\n</ul>\n",
+            "description": "* `PlatformDiscountSharePolicyNotFoundError`",
             "content": {
               "application/json": {
                 "schema": {
@@ -597,20 +597,20 @@
         ],
         "x-portone-category": "platform.policy",
         "x-portone-title": "할인 분담 정책 조회",
-        "x-portone-description": "<p>주어진 아이디에 대응되는 할인 분담을 조회합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 할인 분담을 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPlatformDiscountSharePolicyError"
         }
       },
       "patch": {
-        "summary": "<p>할인 분담 정책 수정</p>\n",
-        "description": "<p>할인 분담 정책 수정</p>\n<p>주어진 아이디에 대응되는 할인 분담을 업데이트합니다.</p>\n",
+        "summary": "할인 분담 정책 수정",
+        "description": "할인 분담 정책 수정\n\n주어진 아이디에 대응되는 할인 분담을 업데이트합니다.",
         "operationId": "updatePlatformDiscountSharePolicy",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>업데이트할 할인 분담 정책 아이디</p>\n",
+            "description": "업데이트할 할인 분담 정책 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -630,7 +630,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 업데이트된 할인 분담 정책을 반환합니다.</p>\n",
+            "description": "성공 응답으로 업데이트된 할인 분담 정책을 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -638,10 +638,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 업데이트된 할인 분담 정책을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 업데이트된 할인 분담 정책을 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -651,7 +651,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -661,7 +661,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -671,7 +671,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PlatformDiscountSharePolicyNotFoundError</code></li>\n</ul>\n",
+            "description": "* `PlatformDiscountSharePolicyNotFoundError`",
             "content": {
               "application/json": {
                 "schema": {
@@ -681,7 +681,7 @@
             }
           },
           "409": {
-            "description": "<ul>\n<li><code>PlatformArchivedDiscountSharePolicyError</code>: 보관된 할인 분담 정책을 업데이트하려고 하는 경우</li>\n</ul>\n",
+            "description": "* `PlatformArchivedDiscountSharePolicyError`: 보관된 할인 분담 정책을 업데이트하려고 하는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -701,7 +701,7 @@
         ],
         "x-portone-category": "platform.policy",
         "x-portone-title": "할인 분담 정책 수정",
-        "x-portone-description": "<p>주어진 아이디에 대응되는 할인 분담을 업데이트합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 할인 분담을 업데이트합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/UpdatePlatformDiscountSharePolicyError"
         }
@@ -709,13 +709,13 @@
     },
     "/platform/discount-share-policies/{id}/schedule": {
       "get": {
-        "description": "<p>주어진 아이디에 대응되는 할인 분담의 예약 업데이트를 조회합니다.</p>\n",
+        "description": "주어진 아이디에 대응되는 할인 분담의 예약 업데이트를 조회합니다.",
         "operationId": "getPlatformDiscountSharePolicySchedule",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>할인 분담 정책 아이디</p>\n",
+            "description": "할인 분담 정책 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -725,7 +725,7 @@
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 예약된 할인 분담 정책을 반환합니다.</p>\n",
+            "description": "성공 응답으로 예약된 할인 분담 정책을 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -733,10 +733,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 예약된 할인 분담 정책을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 예약된 할인 분담 정책을 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -746,7 +746,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -756,7 +756,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -766,7 +766,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PlatformDiscountSharePolicyNotFoundError</code></li>\n</ul>\n",
+            "description": "* `PlatformDiscountSharePolicyNotFoundError`",
             "content": {
               "application/json": {
                 "schema": {
@@ -784,20 +784,20 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>주어진 아이디에 대응되는 할인 분담의 예약 업데이트를 조회합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 할인 분담의 예약 업데이트를 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPlatformDiscountSharePolicyScheduleError"
         },
         "x-portone-unstable": true
       },
       "put": {
-        "description": "<p>주어진 아이디에 대응되는 할인 분담에 예약 업데이트를 재설정합니다.</p>\n",
+        "description": "주어진 아이디에 대응되는 할인 분담에 예약 업데이트를 재설정합니다.",
         "operationId": "rescheduleDiscountSharePolicy",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>할인 분담 정책 아이디</p>\n",
+            "description": "할인 분담 정책 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -817,7 +817,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 예약된 할인 분담 정책을 반환합니다.</p>\n",
+            "description": "성공 응답으로 예약된 할인 분담 정책을 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -825,10 +825,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 예약된 할인 분담 정책을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 예약된 할인 분담 정책을 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -838,7 +838,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -848,7 +848,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -858,7 +858,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PlatformDiscountSharePolicyNotFoundError</code></li>\n</ul>\n",
+            "description": "* `PlatformDiscountSharePolicyNotFoundError`",
             "content": {
               "application/json": {
                 "schema": {
@@ -876,20 +876,20 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>주어진 아이디에 대응되는 할인 분담에 예약 업데이트를 재설정합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 할인 분담에 예약 업데이트를 재설정합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/RescheduleDiscountSharePolicyError"
         },
         "x-portone-unstable": true
       },
       "post": {
-        "description": "<p>주어진 아이디에 대응되는 할인 분담에 업데이트를 예약합니다.</p>\n",
+        "description": "주어진 아이디에 대응되는 할인 분담에 업데이트를 예약합니다.",
         "operationId": "scheduleDiscountSharePolicy",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>할인 분담 정책 아이디</p>\n",
+            "description": "할인 분담 정책 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -909,7 +909,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 예약된 할인 분담 정책이 반환됩니다.</p>\n",
+            "description": "성공 응답으로 예약된 할인 분담 정책이 반환됩니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -917,10 +917,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 예약된 할인 분담 정책이 반환됩니다.</p>\n"
+            "x-portone-description": "성공 응답으로 예약된 할인 분담 정책이 반환됩니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -930,7 +930,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -940,7 +940,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -950,7 +950,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PlatformDiscountSharePolicyNotFoundError</code></li>\n</ul>\n",
+            "description": "* `PlatformDiscountSharePolicyNotFoundError`",
             "content": {
               "application/json": {
                 "schema": {
@@ -960,7 +960,7 @@
             }
           },
           "409": {
-            "description": "<ul>\n<li><code>PlatformDiscountSharePolicyScheduleAlreadyExistsError</code></li>\n</ul>\n",
+            "description": "* `PlatformDiscountSharePolicyScheduleAlreadyExistsError`",
             "content": {
               "application/json": {
                 "schema": {
@@ -978,20 +978,20 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>주어진 아이디에 대응되는 할인 분담에 업데이트를 예약합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 할인 분담에 업데이트를 예약합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/ScheduleDiscountSharePolicyError"
         },
         "x-portone-unstable": true
       },
       "delete": {
-        "description": "<p>주어진 아이디에 대응되는 할인 분담의 예약 업데이트를 취소합니다.</p>\n",
+        "description": "주어진 아이디에 대응되는 할인 분담의 예약 업데이트를 취소합니다.",
         "operationId": "cancelPlatformDiscountSharePolicySchedule",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>할인 분담 정책 아이디</p>\n",
+            "description": "할인 분담 정책 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -1001,7 +1001,7 @@
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답",
             "content": {
               "application/json": {
                 "schema": {
@@ -1012,7 +1012,7 @@
             "x-portone-title": "성공 응답"
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -1022,7 +1022,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -1032,7 +1032,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -1042,7 +1042,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PlatformDiscountSharePolicyNotFoundError</code></li>\n</ul>\n",
+            "description": "* `PlatformDiscountSharePolicyNotFoundError`",
             "content": {
               "application/json": {
                 "schema": {
@@ -1060,7 +1060,7 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>주어진 아이디에 대응되는 할인 분담의 예약 업데이트를 취소합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 할인 분담의 예약 업데이트를 취소합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/CancelPlatformDiscountSharePolicyScheduleError"
         },
@@ -1069,14 +1069,14 @@
     },
     "/platform/discount-share-policies/{id}/archive": {
       "post": {
-        "summary": "<p>할인 분담 정책 보관</p>\n",
-        "description": "<p>할인 분담 정책 보관</p>\n<p>주어진 아이디에 대응되는 할인 분담을 보관합니다.</p>\n",
+        "summary": "할인 분담 정책 보관",
+        "description": "할인 분담 정책 보관\n\n주어진 아이디에 대응되는 할인 분담을 보관합니다.",
         "operationId": "archivePlatformDiscountSharePolicy",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>할인 분담 아이디</p>\n",
+            "description": "할인 분담 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -1086,7 +1086,7 @@
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 보관된 할인 분담 객체를 반환합니다.</p>\n",
+            "description": "성공 응답으로 보관된 할인 분담 객체를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1094,10 +1094,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 보관된 할인 분담 객체를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 보관된 할인 분담 객체를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -1107,7 +1107,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -1117,7 +1117,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -1127,7 +1127,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PlatformDiscountSharePolicyNotFoundError</code></li>\n</ul>\n",
+            "description": "* `PlatformDiscountSharePolicyNotFoundError`",
             "content": {
               "application/json": {
                 "schema": {
@@ -1137,7 +1137,7 @@
             }
           },
           "409": {
-            "description": "<ul>\n<li><code>PlatformCannotArchiveScheduledDiscountSharePolicyError</code>: 예약된 업데이트가 있는 할인 분담 정책을 보관하려고 하는 경우</li>\n</ul>\n",
+            "description": "* `PlatformCannotArchiveScheduledDiscountSharePolicyError`: 예약된 업데이트가 있는 할인 분담 정책을 보관하려고 하는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -1157,7 +1157,7 @@
         ],
         "x-portone-category": "platform.policy",
         "x-portone-title": "할인 분담 정책 보관",
-        "x-portone-description": "<p>주어진 아이디에 대응되는 할인 분담을 보관합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 할인 분담을 보관합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/ArchivePlatformDiscountSharePolicyError"
         }
@@ -1165,14 +1165,14 @@
     },
     "/platform/discount-share-policies/{id}/recover": {
       "post": {
-        "summary": "<p>할인 분담 정책 복원</p>\n",
-        "description": "<p>할인 분담 정책 복원</p>\n<p>주어진 아이디에 대응되는 할인 분담을 복원합니다.</p>\n",
+        "summary": "할인 분담 정책 복원",
+        "description": "할인 분담 정책 복원\n\n주어진 아이디에 대응되는 할인 분담을 복원합니다.",
         "operationId": "recoverPlatformDiscountSharePolicy",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>할인 분담 아이디</p>\n",
+            "description": "할인 분담 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -1182,7 +1182,7 @@
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 복원된 할인 분담 객체를 반환합니다.</p>\n",
+            "description": "성공 응답으로 복원된 할인 분담 객체를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1190,10 +1190,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 복원된 할인 분담 객체를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 복원된 할인 분담 객체를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -1203,7 +1203,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -1213,7 +1213,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -1223,7 +1223,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PlatformDiscountSharePolicyNotFoundError</code></li>\n</ul>\n",
+            "description": "* `PlatformDiscountSharePolicyNotFoundError`",
             "content": {
               "application/json": {
                 "schema": {
@@ -1243,7 +1243,7 @@
         ],
         "x-portone-category": "platform.policy",
         "x-portone-title": "할인 분담 정책 복원",
-        "x-portone-description": "<p>주어진 아이디에 대응되는 할인 분담을 복원합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 할인 분담을 복원합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/RecoverPlatformDiscountSharePolicyError"
         }
@@ -1251,8 +1251,8 @@
     },
     "/platform/additional-fee-policies": {
       "get": {
-        "summary": "<p>추가 수수료 정책 다건 조회</p>\n",
-        "description": "<p>추가 수수료 정책 다건 조회</p>\n<p>여러 추가 수수료 정책을 조회합니다.</p>\n",
+        "summary": "추가 수수료 정책 다건 조회",
+        "description": "추가 수수료 정책 다건 조회\n\n여러 추가 수수료 정책을 조회합니다.",
         "operationId": "getPlatformAdditionalFeePolicies",
         "parameters": [
           {
@@ -1284,7 +1284,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 조회된 추가 수수료 정책 리스트와 페이지 정보를 반환합니다.</p>\n",
+            "description": "성공 응답으로 조회된 추가 수수료 정책 리스트와 페이지 정보를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1292,10 +1292,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 조회된 추가 수수료 정책 리스트와 페이지 정보를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 조회된 추가 수수료 정책 리스트와 페이지 정보를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -1305,7 +1305,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -1315,7 +1315,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -1335,14 +1335,14 @@
         ],
         "x-portone-category": "platform.policy",
         "x-portone-title": "추가 수수료 정책 다건 조회",
-        "x-portone-description": "<p>여러 추가 수수료 정책을 조회합니다.</p>\n",
+        "x-portone-description": "여러 추가 수수료 정책을 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPlatformAdditionalFeePoliciesError"
         }
       },
       "post": {
-        "summary": "<p>추가 수수료 정책 생성</p>\n",
-        "description": "<p>추가 수수료 정책 생성</p>\n<p>새로운 추가 수수료 정책을 생성합니다.</p>\n",
+        "summary": "추가 수수료 정책 생성",
+        "description": "추가 수수료 정책 생성\n\n새로운 추가 수수료 정책을 생성합니다.",
         "operationId": "createPlatformAdditionalFeePolicy",
         "requestBody": {
           "content": {
@@ -1356,7 +1356,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답",
             "content": {
               "application/json": {
                 "schema": {
@@ -1367,7 +1367,7 @@
             "x-portone-title": "성공 응답"
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -1377,7 +1377,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -1387,7 +1387,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -1397,7 +1397,7 @@
             }
           },
           "409": {
-            "description": "<ul>\n<li><code>PlatformAdditionalFeePolicyAlreadyExistsError</code></li>\n</ul>\n",
+            "description": "* `PlatformAdditionalFeePolicyAlreadyExistsError`",
             "content": {
               "application/json": {
                 "schema": {
@@ -1417,7 +1417,7 @@
         ],
         "x-portone-category": "platform.policy",
         "x-portone-title": "추가 수수료 정책 생성",
-        "x-portone-description": "<p>새로운 추가 수수료 정책을 생성합니다.</p>\n",
+        "x-portone-description": "새로운 추가 수수료 정책을 생성합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/CreatePlatformAdditionalFeePolicyError"
         }
@@ -1425,14 +1425,14 @@
     },
     "/platform/additional-fee-policies/{id}": {
       "get": {
-        "summary": "<p>추가 수수료 정책 조회</p>\n",
-        "description": "<p>추가 수수료 정책 조회</p>\n<p>주어진 아이디에 대응되는 추가 수수료 정책을 조회합니다.</p>\n",
+        "summary": "추가 수수료 정책 조회",
+        "description": "추가 수수료 정책 조회\n\n주어진 아이디에 대응되는 추가 수수료 정책을 조회합니다.",
         "operationId": "getPlatformAdditionalFeePolicy",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>조회할 추가 수수료 정책 아이디</p>\n",
+            "description": "조회할 추가 수수료 정책 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -1442,7 +1442,7 @@
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 추가 수수료 정책을 반환합니다.</p>\n",
+            "description": "성공 응답으로 추가 수수료 정책을 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1450,10 +1450,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 추가 수수료 정책을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 추가 수수료 정책을 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -1463,7 +1463,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -1473,7 +1473,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -1483,7 +1483,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PlatformAdditionalFeePolicyNotFoundError</code></li>\n</ul>\n",
+            "description": "* `PlatformAdditionalFeePolicyNotFoundError`",
             "content": {
               "application/json": {
                 "schema": {
@@ -1503,20 +1503,20 @@
         ],
         "x-portone-category": "platform.policy",
         "x-portone-title": "추가 수수료 정책 조회",
-        "x-portone-description": "<p>주어진 아이디에 대응되는 추가 수수료 정책을 조회합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 추가 수수료 정책을 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPlatformAdditionalFeePolicyError"
         }
       },
       "patch": {
-        "summary": "<p>추가 수수료 정책 수정</p>\n",
-        "description": "<p>추가 수수료 정책 수정</p>\n<p>주어진 아이디에 대응되는 추가 수수료 정책을 업데이트합니다.</p>\n",
+        "summary": "추가 수수료 정책 수정",
+        "description": "추가 수수료 정책 수정\n\n주어진 아이디에 대응되는 추가 수수료 정책을 업데이트합니다.",
         "operationId": "updatePlatformAdditionalFeePolicy",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>업데이트할 추가 수수료 정책 아이디</p>\n",
+            "description": "업데이트할 추가 수수료 정책 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -1536,7 +1536,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 업데이트된 추가 수수료 정책이 반환됩니다.</p>\n",
+            "description": "성공 응답으로 업데이트된 추가 수수료 정책이 반환됩니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1544,10 +1544,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 업데이트된 추가 수수료 정책이 반환됩니다.</p>\n"
+            "x-portone-description": "성공 응답으로 업데이트된 추가 수수료 정책이 반환됩니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -1557,7 +1557,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -1567,7 +1567,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -1577,7 +1577,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PlatformAdditionalFeePolicyNotFoundError</code></li>\n</ul>\n",
+            "description": "* `PlatformAdditionalFeePolicyNotFoundError`",
             "content": {
               "application/json": {
                 "schema": {
@@ -1587,7 +1587,7 @@
             }
           },
           "409": {
-            "description": "<ul>\n<li><code>PlatformArchivedAdditionalFeePolicyError</code>: 보관된 추가 수수료 정책을 업데이트하려고 하는 경우</li>\n</ul>\n",
+            "description": "* `PlatformArchivedAdditionalFeePolicyError`: 보관된 추가 수수료 정책을 업데이트하려고 하는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -1607,7 +1607,7 @@
         ],
         "x-portone-category": "platform.policy",
         "x-portone-title": "추가 수수료 정책 수정",
-        "x-portone-description": "<p>주어진 아이디에 대응되는 추가 수수료 정책을 업데이트합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 추가 수수료 정책을 업데이트합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/UpdatePlatformAdditionalFeePolicyError"
         }
@@ -1615,13 +1615,13 @@
     },
     "/platform/additional-fee-policies/{id}/schedule": {
       "get": {
-        "description": "<p>주어진 아이디에 대응되는 추가 수수료 정책의 예약 업데이트를 조회합니다.</p>\n",
+        "description": "주어진 아이디에 대응되는 추가 수수료 정책의 예약 업데이트를 조회합니다.",
         "operationId": "getPlatformAdditionalFeePolicySchedule",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>추가 수수료 정책 아이디</p>\n",
+            "description": "추가 수수료 정책 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -1631,7 +1631,7 @@
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 예약된 추가 수수료 정책을 반환합니다.</p>\n",
+            "description": "성공 응답으로 예약된 추가 수수료 정책을 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1639,10 +1639,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 예약된 추가 수수료 정책을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 예약된 추가 수수료 정책을 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -1652,7 +1652,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -1662,7 +1662,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -1672,7 +1672,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PlatformAdditionalFeePolicyNotFoundError</code></li>\n</ul>\n",
+            "description": "* `PlatformAdditionalFeePolicyNotFoundError`",
             "content": {
               "application/json": {
                 "schema": {
@@ -1690,7 +1690,7 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>주어진 아이디에 대응되는 추가 수수료 정책의 예약 업데이트를 조회합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 추가 수수료 정책의 예약 업데이트를 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPlatformAdditionalFeePolicyScheduleError"
         },
@@ -1702,7 +1702,7 @@
           {
             "name": "id",
             "in": "path",
-            "description": "<p>추가 수수료 정책 아이디</p>\n",
+            "description": "추가 수수료 정책 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -1722,7 +1722,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 예약된 추가 수수료 정책이 반환됩니다.</p>\n",
+            "description": "성공 응답으로 예약된 추가 수수료 정책이 반환됩니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1730,10 +1730,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 예약된 추가 수수료 정책이 반환됩니다.</p>\n"
+            "x-portone-description": "성공 응답으로 예약된 추가 수수료 정책이 반환됩니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -1743,7 +1743,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -1753,7 +1753,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -1763,7 +1763,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PlatformAdditionalFeePolicyNotFoundError</code></li>\n</ul>\n",
+            "description": "* `PlatformAdditionalFeePolicyNotFoundError`",
             "content": {
               "application/json": {
                 "schema": {
@@ -1787,13 +1787,13 @@
         "x-portone-unstable": true
       },
       "post": {
-        "description": "<p>주어진 아이디에 대응되는 추가 수수료 정책에 업데이트를 예약합니다.</p>\n",
+        "description": "주어진 아이디에 대응되는 추가 수수료 정책에 업데이트를 예약합니다.",
         "operationId": "scheduleAdditionalFeePolicy",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>추가 수수료 정책 아이디</p>\n",
+            "description": "추가 수수료 정책 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -1813,7 +1813,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 예약된 추가 수수료 정책을 반환합니다.</p>\n",
+            "description": "성공 응답으로 예약된 추가 수수료 정책을 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1821,10 +1821,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 예약된 추가 수수료 정책을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 예약된 추가 수수료 정책을 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -1834,7 +1834,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -1844,7 +1844,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -1854,7 +1854,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PlatformAdditionalFeePolicyNotFoundError</code></li>\n</ul>\n",
+            "description": "* `PlatformAdditionalFeePolicyNotFoundError`",
             "content": {
               "application/json": {
                 "schema": {
@@ -1864,7 +1864,7 @@
             }
           },
           "409": {
-            "description": "<ul>\n<li><code>PlatformAdditionalFeePolicyScheduleAlreadyExistsError</code></li>\n<li><code>PlatformArchivedAdditionalFeePolicyError</code>: 보관된 추가 수수료 정책을 업데이트하려고 하는 경우</li>\n</ul>\n",
+            "description": "* `PlatformAdditionalFeePolicyScheduleAlreadyExistsError`\n* `PlatformArchivedAdditionalFeePolicyError`: 보관된 추가 수수료 정책을 업데이트하려고 하는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -1882,20 +1882,20 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>주어진 아이디에 대응되는 추가 수수료 정책에 업데이트를 예약합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 추가 수수료 정책에 업데이트를 예약합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/ScheduleAdditionalFeePolicyError"
         },
         "x-portone-unstable": true
       },
       "delete": {
-        "description": "<p>주어진 아이디에 대응되는 추가 수수료 정책의 예약 업데이트를 취소합니다.</p>\n",
+        "description": "주어진 아이디에 대응되는 추가 수수료 정책의 예약 업데이트를 취소합니다.",
         "operationId": "cancelPlatformAdditionalFeePolicySchedule",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>추가 수수료 정책 아이디</p>\n",
+            "description": "추가 수수료 정책 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -1905,7 +1905,7 @@
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답",
             "content": {
               "application/json": {
                 "schema": {
@@ -1916,7 +1916,7 @@
             "x-portone-title": "성공 응답"
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -1926,7 +1926,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -1936,7 +1936,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -1946,7 +1946,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PlatformAdditionalFeePolicyNotFoundError</code></li>\n</ul>\n",
+            "description": "* `PlatformAdditionalFeePolicyNotFoundError`",
             "content": {
               "application/json": {
                 "schema": {
@@ -1964,7 +1964,7 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>주어진 아이디에 대응되는 추가 수수료 정책의 예약 업데이트를 취소합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 추가 수수료 정책의 예약 업데이트를 취소합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/CancelPlatformAdditionalFeePolicyScheduleError"
         },
@@ -1973,14 +1973,14 @@
     },
     "/platform/additional-fee-policies/{id}/archive": {
       "post": {
-        "summary": "<p>추가 수수료 정책 보관</p>\n",
-        "description": "<p>추가 수수료 정책 보관</p>\n<p>주어진 아이디에 대응되는 추가 수수료 정책을 보관합니다.</p>\n",
+        "summary": "추가 수수료 정책 보관",
+        "description": "추가 수수료 정책 보관\n\n주어진 아이디에 대응되는 추가 수수료 정책을 보관합니다.",
         "operationId": "archivePlatformAdditionalFeePolicy",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>추가 수수료 정책 아이디</p>\n",
+            "description": "추가 수수료 정책 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -1990,7 +1990,7 @@
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 보관된 추가 수수료 정책 객체를 반환합니다.</p>\n",
+            "description": "성공 응답으로 보관된 추가 수수료 정책 객체를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1998,10 +1998,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 보관된 추가 수수료 정책 객체를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 보관된 추가 수수료 정책 객체를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -2011,7 +2011,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -2021,7 +2021,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -2031,7 +2031,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PlatformAdditionalFeePolicyNotFoundError</code></li>\n</ul>\n",
+            "description": "* `PlatformAdditionalFeePolicyNotFoundError`",
             "content": {
               "application/json": {
                 "schema": {
@@ -2041,7 +2041,7 @@
             }
           },
           "409": {
-            "description": "<ul>\n<li><code>PlatformCannotArchiveScheduledAdditionalFeePolicyError</code>: 예약된 업데이트가 있는 추가 수수료 정책을 보관하려고 하는 경우</li>\n</ul>\n",
+            "description": "* `PlatformCannotArchiveScheduledAdditionalFeePolicyError`: 예약된 업데이트가 있는 추가 수수료 정책을 보관하려고 하는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -2061,7 +2061,7 @@
         ],
         "x-portone-category": "platform.policy",
         "x-portone-title": "추가 수수료 정책 보관",
-        "x-portone-description": "<p>주어진 아이디에 대응되는 추가 수수료 정책을 보관합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 추가 수수료 정책을 보관합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/ArchivePlatformAdditionalFeePolicyError"
         }
@@ -2069,14 +2069,14 @@
     },
     "/platform/additional-fee-policies/{id}/recover": {
       "post": {
-        "summary": "<p>추가 수수료 정책 복원</p>\n",
-        "description": "<p>추가 수수료 정책 복원</p>\n<p>주어진 아이디에 대응되는 추가 수수료 정책을 복원합니다.</p>\n",
+        "summary": "추가 수수료 정책 복원",
+        "description": "추가 수수료 정책 복원\n\n주어진 아이디에 대응되는 추가 수수료 정책을 복원합니다.",
         "operationId": "recoverPlatformAdditionalFeePolicy",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>추가 수수료 정책 아이디</p>\n",
+            "description": "추가 수수료 정책 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -2086,7 +2086,7 @@
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 복원된 추가 수수료 정책 객체를 반환합니다.</p>\n",
+            "description": "성공 응답으로 복원된 추가 수수료 정책 객체를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2094,10 +2094,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 복원된 추가 수수료 정책 객체를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 복원된 추가 수수료 정책 객체를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -2107,7 +2107,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -2117,7 +2117,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -2127,7 +2127,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PlatformAdditionalFeePolicyNotFoundError</code></li>\n</ul>\n",
+            "description": "* `PlatformAdditionalFeePolicyNotFoundError`",
             "content": {
               "application/json": {
                 "schema": {
@@ -2147,7 +2147,7 @@
         ],
         "x-portone-category": "platform.policy",
         "x-portone-title": "추가 수수료 정책 복원",
-        "x-portone-description": "<p>주어진 아이디에 대응되는 추가 수수료 정책을 복원합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 추가 수수료 정책을 복원합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/RecoverPlatformAdditionalFeePolicyError"
         }
@@ -2155,24 +2155,24 @@
     },
     "/platform/partner-filter-options": {
       "get": {
-        "description": "<p>파트너 다건 조회 시 필요한 필터 옵션을 조회합니다.</p>\n",
+        "description": "파트너 다건 조회 시 필요한 필터 옵션을 조회합니다.",
         "operationId": "getPlatformPartnerFilterOptions",
         "parameters": [
           {
             "name": "isArchived",
             "in": "query",
-            "description": "<p>보관 조회 여부</p>\n<p>true 이면 보관된 파트너의 필터 옵션을 조회하고, false 이면 보관되지 않은 파트너의 필터 옵션을 조회합니다. 기본값은 false 입니다.</p>\n",
+            "description": "보관 조회 여부\n\ntrue 이면 보관된 파트너의 필터 옵션을 조회하고, false 이면 보관되지 않은 파트너의 필터 옵션을 조회합니다. 기본값은 false 입니다.",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "보관 조회 여부",
-            "x-portone-description": "<p>true 이면 보관된 파트너의 필터 옵션을 조회하고, false 이면 보관되지 않은 파트너의 필터 옵션을 조회합니다. 기본값은 false 입니다.</p>\n"
+            "x-portone-description": "true 이면 보관된 파트너의 필터 옵션을 조회하고, false 이면 보관되지 않은 파트너의 필터 옵션을 조회합니다. 기본값은 false 입니다."
           }
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 조회된 파트너 필터 옵션을 반환합니다.</p>\n",
+            "description": "성공 응답으로 조회된 파트너 필터 옵션을 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2180,10 +2180,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 조회된 파트너 필터 옵션을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 조회된 파트너 필터 옵션을 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -2193,7 +2193,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -2203,7 +2203,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -2221,7 +2221,7 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>파트너 다건 조회 시 필요한 필터 옵션을 조회합니다.</p>\n",
+        "x-portone-description": "파트너 다건 조회 시 필요한 필터 옵션을 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPlatformPartnerFilterOptionsError"
         },
@@ -2230,8 +2230,8 @@
     },
     "/platform/partners": {
       "get": {
-        "summary": "<p>파트너 다건 조회</p>\n",
-        "description": "<p>파트너 다건 조회</p>\n<p>여러 파트너를 조회합니다.</p>\n",
+        "summary": "파트너 다건 조회",
+        "description": "파트너 다건 조회\n\n여러 파트너를 조회합니다.",
         "operationId": "getPlatformPartners",
         "parameters": [
           {
@@ -2263,7 +2263,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 조회된 파트너 리스트와 페이지 정보가 반환됩니다.</p>\n",
+            "description": "성공 응답으로 조회된 파트너 리스트와 페이지 정보가 반환됩니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2271,10 +2271,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 조회된 파트너 리스트와 페이지 정보가 반환됩니다.</p>\n"
+            "x-portone-description": "성공 응답으로 조회된 파트너 리스트와 페이지 정보가 반환됩니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -2284,7 +2284,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -2294,7 +2294,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -2314,14 +2314,14 @@
         ],
         "x-portone-category": "platform.partner",
         "x-portone-title": "파트너 다건 조회",
-        "x-portone-description": "<p>여러 파트너를 조회합니다.</p>\n",
+        "x-portone-description": "여러 파트너를 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPlatformPartnersError"
         }
       },
       "post": {
-        "summary": "<p>파트너 생성</p>\n",
-        "description": "<p>파트너 생성</p>\n<p>새로운 파트너를 생성합니다.</p>\n",
+        "summary": "파트너 생성",
+        "description": "파트너 생성\n\n새로운 파트너를 생성합니다.",
         "operationId": "createPlatformPartner",
         "requestBody": {
           "content": {
@@ -2335,7 +2335,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 생성된 파트너 객체가 반환됩니다.</p>\n",
+            "description": "성공 응답으로 생성된 파트너 객체가 반환됩니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2343,10 +2343,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 생성된 파트너 객체가 반환됩니다.</p>\n"
+            "x-portone-description": "성공 응답으로 생성된 파트너 객체가 반환됩니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n<li><code>PlatformAccountVerificationFailedError</code>: 파트너 계좌 인증이 실패한 경우</li>\n<li><code>PlatformCurrencyNotSupportedError</code>: 지원 되지 않는 통화를 선택한 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우\n* `PlatformAccountVerificationFailedError`: 파트너 계좌 인증이 실패한 경우\n* `PlatformCurrencyNotSupportedError`: 지원 되지 않는 통화를 선택한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -2356,7 +2356,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -2366,7 +2366,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -2376,7 +2376,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PlatformContractNotFoundError</code></li>\n<li><code>PlatformAccountVerificationNotFoundError</code>: 파트너 계좌 검증 아이디를 찾을 수 없는 경우</li>\n<li><code>PlatformUserDefinedPropertyNotFoundError</code>: 사용자 정의 속성이 존재 하지 않는 경우</li>\n</ul>\n",
+            "description": "* `PlatformContractNotFoundError`\n* `PlatformAccountVerificationNotFoundError`: 파트너 계좌 검증 아이디를 찾을 수 없는 경우\n* `PlatformUserDefinedPropertyNotFoundError`: 사용자 정의 속성이 존재 하지 않는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -2386,7 +2386,7 @@
             }
           },
           "409": {
-            "description": "<ul>\n<li><code>PlatformPartnerIdAlreadyExistsError</code></li>\n<li><code>PlatformAccountVerificationAlreadyUsedError</code>: 파트너 계좌 검증 아이디를 이미 사용한 경우</li>\n</ul>\n",
+            "description": "* `PlatformPartnerIdAlreadyExistsError`\n* `PlatformAccountVerificationAlreadyUsedError`: 파트너 계좌 검증 아이디를 이미 사용한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -2406,7 +2406,7 @@
         ],
         "x-portone-category": "platform.partner",
         "x-portone-title": "파트너 생성",
-        "x-portone-description": "<p>새로운 파트너를 생성합니다.</p>\n",
+        "x-portone-description": "새로운 파트너를 생성합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/CreatePlatformPartnerError"
         }
@@ -2415,14 +2415,14 @@
     "/platform/partner-dashboard": {},
     "/platform/partners/{id}": {
       "get": {
-        "summary": "<p>파트너 조회</p>\n",
-        "description": "<p>파트너 조회</p>\n<p>파트너 객체를 조회합니다.</p>\n",
+        "summary": "파트너 조회",
+        "description": "파트너 조회\n\n파트너 객체를 조회합니다.",
         "operationId": "getPlatformPartner",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>조회하고 싶은 파트너 아이디</p>\n",
+            "description": "조회하고 싶은 파트너 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -2432,7 +2432,7 @@
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 파트너 객체가 반환됩니다.</p>\n",
+            "description": "성공 응답으로 파트너 객체가 반환됩니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2440,10 +2440,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 파트너 객체가 반환됩니다.</p>\n"
+            "x-portone-description": "성공 응답으로 파트너 객체가 반환됩니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -2453,7 +2453,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -2463,7 +2463,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -2473,7 +2473,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PlatformPartnerNotFoundError</code></li>\n</ul>\n",
+            "description": "* `PlatformPartnerNotFoundError`",
             "content": {
               "application/json": {
                 "schema": {
@@ -2493,20 +2493,20 @@
         ],
         "x-portone-category": "platform.partner",
         "x-portone-title": "파트너 조회",
-        "x-portone-description": "<p>파트너 객체를 조회합니다.</p>\n",
+        "x-portone-description": "파트너 객체를 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPlatformPartnerError"
         }
       },
       "patch": {
-        "summary": "<p>파트너 수정</p>\n",
-        "description": "<p>파트너 수정</p>\n<p>주어진 아이디에 대응되는 파트너 정보를 업데이트합니다.</p>\n",
+        "summary": "파트너 수정",
+        "description": "파트너 수정\n\n주어진 아이디에 대응되는 파트너 정보를 업데이트합니다.",
         "operationId": "updatePlatformPartner",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>업데이트할 파트너 아이디</p>\n",
+            "description": "업데이트할 파트너 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -2526,7 +2526,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 업데이트된 파트너 객체가 반환됩니다.</p>\n",
+            "description": "성공 응답으로 업데이트된 파트너 객체가 반환됩니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2534,10 +2534,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 업데이트된 파트너 객체가 반환됩니다.</p>\n"
+            "x-portone-description": "성공 응답으로 업데이트된 파트너 객체가 반환됩니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n<li><code>PlatformAccountVerificationFailedError</code>: 파트너 계좌 인증이 실패한 경우</li>\n<li><code>PlatformInsufficientDataToChangePartnerTypeError</code>: 파트너 타입 수정에 필요한 데이터가 부족한 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우\n* `PlatformAccountVerificationFailedError`: 파트너 계좌 인증이 실패한 경우\n* `PlatformInsufficientDataToChangePartnerTypeError`: 파트너 타입 수정에 필요한 데이터가 부족한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -2547,7 +2547,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -2557,7 +2557,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -2567,7 +2567,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PlatformPartnerNotFoundError</code></li>\n<li><code>PlatformContractNotFoundError</code></li>\n<li><code>PlatformAccountVerificationNotFoundError</code>: 파트너 계좌 검증 아이디를 찾을 수 없는 경우</li>\n<li><code>PlatformUserDefinedPropertyNotFoundError</code>: 사용자 정의 속성이 존재 하지 않는 경우</li>\n</ul>\n",
+            "description": "* `PlatformPartnerNotFoundError`\n* `PlatformContractNotFoundError`\n* `PlatformAccountVerificationNotFoundError`: 파트너 계좌 검증 아이디를 찾을 수 없는 경우\n* `PlatformUserDefinedPropertyNotFoundError`: 사용자 정의 속성이 존재 하지 않는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -2577,7 +2577,7 @@
             }
           },
           "409": {
-            "description": "<ul>\n<li><code>PlatformArchivedPartnerError</code>: 보관된 파트너를 업데이트하려고 하는 경우</li>\n<li><code>PlatformAccountVerificationAlreadyUsedError</code>: 파트너 계좌 검증 아이디를 이미 사용한 경우</li>\n</ul>\n",
+            "description": "* `PlatformArchivedPartnerError`: 보관된 파트너를 업데이트하려고 하는 경우\n* `PlatformAccountVerificationAlreadyUsedError`: 파트너 계좌 검증 아이디를 이미 사용한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -2597,7 +2597,7 @@
         ],
         "x-portone-category": "platform.partner",
         "x-portone-title": "파트너 수정",
-        "x-portone-description": "<p>주어진 아이디에 대응되는 파트너 정보를 업데이트합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 파트너 정보를 업데이트합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/UpdatePlatformPartnerError"
         }
@@ -2605,8 +2605,8 @@
     },
     "/platform/partners/batch": {
       "post": {
-        "summary": "<p>파트너 다건 생성</p>\n",
-        "description": "<p>파트너 다건 생성</p>\n<p>새로운 파트너를 다건 생성합니다.</p>\n",
+        "summary": "파트너 다건 생성",
+        "description": "파트너 다건 생성\n\n새로운 파트너를 다건 생성합니다.",
         "operationId": "createPlatformPartners",
         "requestBody": {
           "content": {
@@ -2620,7 +2620,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답",
             "content": {
               "application/json": {
                 "schema": {
@@ -2631,7 +2631,7 @@
             "x-portone-title": "성공 응답"
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n<li><code>PlatformPartnerIdsDuplicatedError</code></li>\n<li><code>PlatformCurrencyNotSupportedError</code>: 지원 되지 않는 통화를 선택한 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우\n* `PlatformPartnerIdsDuplicatedError`\n* `PlatformCurrencyNotSupportedError`: 지원 되지 않는 통화를 선택한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -2641,7 +2641,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -2651,7 +2651,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -2661,7 +2661,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PlatformContractsNotFoundError</code></li>\n<li><code>PlatformUserDefinedPropertyNotFoundError</code>: 사용자 정의 속성이 존재 하지 않는 경우</li>\n</ul>\n",
+            "description": "* `PlatformContractsNotFoundError`\n* `PlatformUserDefinedPropertyNotFoundError`: 사용자 정의 속성이 존재 하지 않는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -2671,7 +2671,7 @@
             }
           },
           "409": {
-            "description": "<ul>\n<li><code>PlatformPartnerIdsAlreadyExistError</code></li>\n</ul>\n",
+            "description": "* `PlatformPartnerIdsAlreadyExistError`",
             "content": {
               "application/json": {
                 "schema": {
@@ -2691,7 +2691,7 @@
         ],
         "x-portone-category": "platform.partner",
         "x-portone-title": "파트너 다건 생성",
-        "x-portone-description": "<p>새로운 파트너를 다건 생성합니다.</p>\n",
+        "x-portone-description": "새로운 파트너를 다건 생성합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/CreatePlatformPartnersError"
         }
@@ -2701,13 +2701,13 @@
     "/platform/partners/{id}/reject": {},
     "/platform/partners/{id}/schedule": {
       "get": {
-        "description": "<p>주어진 아이디에 대응되는 파트너의 예약 업데이트를 조회합니다.</p>\n",
+        "description": "주어진 아이디에 대응되는 파트너의 예약 업데이트를 조회합니다.",
         "operationId": "getPlatformPartnerSchedule",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>파트너 아이디</p>\n",
+            "description": "파트너 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -2717,7 +2717,7 @@
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 예약된 파트너 객체를 반환합니다.</p>\n",
+            "description": "성공 응답으로 예약된 파트너 객체를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2725,10 +2725,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 예약된 파트너 객체를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 예약된 파트너 객체를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -2738,7 +2738,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -2748,7 +2748,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -2758,7 +2758,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PlatformPartnerNotFoundError</code></li>\n</ul>\n",
+            "description": "* `PlatformPartnerNotFoundError`",
             "content": {
               "application/json": {
                 "schema": {
@@ -2776,20 +2776,20 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>주어진 아이디에 대응되는 파트너의 예약 업데이트를 조회합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 파트너의 예약 업데이트를 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPlatformPartnerScheduleError"
         },
         "x-portone-unstable": true
       },
       "put": {
-        "description": "<p>주어진 아이디에 대응되는 파트너에 예약 업데이트를 재설정합니다.</p>\n",
+        "description": "주어진 아이디에 대응되는 파트너에 예약 업데이트를 재설정합니다.",
         "operationId": "reschedulePartner",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>파트너 아이디</p>\n",
+            "description": "파트너 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -2809,7 +2809,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 예약된 파트너 객체를 반환합니다.</p>\n",
+            "description": "성공 응답으로 예약된 파트너 객체를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2817,10 +2817,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 예약된 파트너 객체를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 예약된 파트너 객체를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -2830,7 +2830,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -2840,7 +2840,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -2850,7 +2850,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PlatformPartnerNotFoundError</code></li>\n<li><code>PlatformContractNotFoundError</code></li>\n</ul>\n",
+            "description": "* `PlatformPartnerNotFoundError`\n* `PlatformContractNotFoundError`",
             "content": {
               "application/json": {
                 "schema": {
@@ -2868,20 +2868,20 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>주어진 아이디에 대응되는 파트너에 예약 업데이트를 재설정합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 파트너에 예약 업데이트를 재설정합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/ReschedulePartnerError"
         },
         "x-portone-unstable": true
       },
       "post": {
-        "description": "<p>주어진 아이디에 대응되는 파트너에 업데이트를 예약합니다.</p>\n",
+        "description": "주어진 아이디에 대응되는 파트너에 업데이트를 예약합니다.",
         "operationId": "schedulePartner",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>파트너 아이디</p>\n",
+            "description": "파트너 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -2901,7 +2901,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 예약된 파트너 객체가 반환됩니다.</p>\n",
+            "description": "성공 응답으로 예약된 파트너 객체가 반환됩니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2909,10 +2909,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 예약된 파트너 객체가 반환됩니다.</p>\n"
+            "x-portone-description": "성공 응답으로 예약된 파트너 객체가 반환됩니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n<li><code>PlatformAccountVerificationFailedError</code>: 파트너 계좌 인증이 실패한 경우</li>\n<li><code>PlatformInsufficientDataToChangePartnerTypeError</code>: 파트너 타입 수정에 필요한 데이터가 부족한 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우\n* `PlatformAccountVerificationFailedError`: 파트너 계좌 인증이 실패한 경우\n* `PlatformInsufficientDataToChangePartnerTypeError`: 파트너 타입 수정에 필요한 데이터가 부족한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -2922,7 +2922,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -2932,7 +2932,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -2942,7 +2942,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PlatformPartnerNotFoundError</code></li>\n<li><code>PlatformContractNotFoundError</code></li>\n<li><code>PlatformAccountVerificationNotFoundError</code>: 파트너 계좌 검증 아이디를 찾을 수 없는 경우</li>\n<li><code>PlatformUserDefinedPropertyNotFoundError</code>: 사용자 정의 속성이 존재 하지 않는 경우</li>\n</ul>\n",
+            "description": "* `PlatformPartnerNotFoundError`\n* `PlatformContractNotFoundError`\n* `PlatformAccountVerificationNotFoundError`: 파트너 계좌 검증 아이디를 찾을 수 없는 경우\n* `PlatformUserDefinedPropertyNotFoundError`: 사용자 정의 속성이 존재 하지 않는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -2952,7 +2952,7 @@
             }
           },
           "409": {
-            "description": "<ul>\n<li><code>PlatformPartnerScheduleAlreadyExistsError</code></li>\n<li><code>PlatformArchivedPartnerError</code>: 보관된 파트너를 업데이트하려고 하는 경우</li>\n<li><code>PlatformAccountVerificationAlreadyUsedError</code>: 파트너 계좌 검증 아이디를 이미 사용한 경우</li>\n</ul>\n",
+            "description": "* `PlatformPartnerScheduleAlreadyExistsError`\n* `PlatformArchivedPartnerError`: 보관된 파트너를 업데이트하려고 하는 경우\n* `PlatformAccountVerificationAlreadyUsedError`: 파트너 계좌 검증 아이디를 이미 사용한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -2970,20 +2970,20 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>주어진 아이디에 대응되는 파트너에 업데이트를 예약합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 파트너에 업데이트를 예약합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/SchedulePartnerError"
         },
         "x-portone-unstable": true
       },
       "delete": {
-        "description": "<p>주어진 아이디에 대응되는 파트너의 예약 업데이트를 취소합니다.</p>\n",
+        "description": "주어진 아이디에 대응되는 파트너의 예약 업데이트를 취소합니다.",
         "operationId": "cancelPlatformPartnerSchedule",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>파트너 아이디</p>\n",
+            "description": "파트너 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -2993,7 +2993,7 @@
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답",
             "content": {
               "application/json": {
                 "schema": {
@@ -3004,7 +3004,7 @@
             "x-portone-title": "성공 응답"
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -3014,7 +3014,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -3024,7 +3024,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -3034,7 +3034,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PlatformPartnerNotFoundError</code></li>\n</ul>\n",
+            "description": "* `PlatformPartnerNotFoundError`",
             "content": {
               "application/json": {
                 "schema": {
@@ -3052,7 +3052,7 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>주어진 아이디에 대응되는 파트너의 예약 업데이트를 취소합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 파트너의 예약 업데이트를 취소합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/CancelPlatformPartnerScheduleError"
         },
@@ -3084,7 +3084,7 @@
             }
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -3094,7 +3094,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -3104,7 +3104,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -3114,7 +3114,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PlatformContractNotFoundError</code></li>\n<li><code>PlatformUserDefinedPropertyNotFoundError</code>: 사용자 정의 속성이 존재 하지 않는 경우</li>\n</ul>\n",
+            "description": "* `PlatformContractNotFoundError`\n* `PlatformUserDefinedPropertyNotFoundError`: 사용자 정의 속성이 존재 하지 않는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -3124,7 +3124,7 @@
             }
           },
           "409": {
-            "description": "<ul>\n<li><code>PlatformPartnerSchedulesAlreadyExistError</code></li>\n<li><code>PlatformArchivedPartnersCannotBeScheduledError</code>: 보관된 파트너들을 예약 업데이트하려고 하는 경우</li>\n</ul>\n",
+            "description": "* `PlatformPartnerSchedulesAlreadyExistError`\n* `PlatformArchivedPartnersCannotBeScheduledError`: 보관된 파트너들을 예약 업데이트하려고 하는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -3150,14 +3150,14 @@
     },
     "/platform/partners/{id}/archive": {
       "post": {
-        "summary": "<p>파트너 복원</p>\n",
-        "description": "<p>파트너 복원</p>\n<p>주어진 아이디에 대응되는 파트너를 보관합니다.</p>\n",
+        "summary": "파트너 복원",
+        "description": "파트너 복원\n\n주어진 아이디에 대응되는 파트너를 보관합니다.",
         "operationId": "archivePlatformPartner",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>파트너 아이디</p>\n",
+            "description": "파트너 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -3167,7 +3167,7 @@
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 보관된 파트너 객체를 반환합니다.</p>\n",
+            "description": "성공 응답으로 보관된 파트너 객체를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -3175,10 +3175,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 보관된 파트너 객체를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 보관된 파트너 객체를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -3188,7 +3188,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -3198,7 +3198,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -3208,7 +3208,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PlatformPartnerNotFoundError</code></li>\n</ul>\n",
+            "description": "* `PlatformPartnerNotFoundError`",
             "content": {
               "application/json": {
                 "schema": {
@@ -3218,7 +3218,7 @@
             }
           },
           "409": {
-            "description": "<ul>\n<li><code>PlatformCannotArchiveScheduledPartnerError</code>: 예약된 업데이트가 있는 파트너를 보관하려고 하는 경우</li>\n</ul>\n",
+            "description": "* `PlatformCannotArchiveScheduledPartnerError`: 예약된 업데이트가 있는 파트너를 보관하려고 하는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -3238,7 +3238,7 @@
         ],
         "x-portone-category": "platform.partner",
         "x-portone-title": "파트너 복원",
-        "x-portone-description": "<p>주어진 아이디에 대응되는 파트너를 보관합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 파트너를 보관합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/ArchivePlatformPartnerError"
         }
@@ -3246,14 +3246,14 @@
     },
     "/platform/partners/{id}/recover": {
       "post": {
-        "summary": "<p>파트너 복원</p>\n",
-        "description": "<p>파트너 복원</p>\n<p>주어진 아이디에 대응되는 파트너를 복원합니다.</p>\n",
+        "summary": "파트너 복원",
+        "description": "파트너 복원\n\n주어진 아이디에 대응되는 파트너를 복원합니다.",
         "operationId": "recoverPlatformPartner",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>파트너 아이디</p>\n",
+            "description": "파트너 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -3263,7 +3263,7 @@
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 복원된 파트너 객체를 반환합니다.</p>\n",
+            "description": "성공 응답으로 복원된 파트너 객체를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -3271,10 +3271,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 복원된 파트너 객체를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 복원된 파트너 객체를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -3284,7 +3284,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -3294,7 +3294,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -3304,7 +3304,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PlatformPartnerNotFoundError</code></li>\n</ul>\n",
+            "description": "* `PlatformPartnerNotFoundError`",
             "content": {
               "application/json": {
                 "schema": {
@@ -3324,7 +3324,7 @@
         ],
         "x-portone-category": "platform.partner",
         "x-portone-title": "파트너 복원",
-        "x-portone-description": "<p>주어진 아이디에 대응되는 파트너를 복원합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 파트너를 복원합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/RecoverPlatformPartnerError"
         }
@@ -3332,8 +3332,8 @@
     },
     "/platform/contracts": {
       "get": {
-        "summary": "<p>계약 다건 조회</p>\n",
-        "description": "<p>계약 다건 조회</p>\n<p>여러 계약을 조회합니다.</p>\n",
+        "summary": "계약 다건 조회",
+        "description": "계약 다건 조회\n\n여러 계약을 조회합니다.",
         "operationId": "getPlatformContracts",
         "parameters": [
           {
@@ -3365,7 +3365,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 조회된 계약 리스트와 페이지 정보를 반환합니다.</p>\n",
+            "description": "성공 응답으로 조회된 계약 리스트와 페이지 정보를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -3373,10 +3373,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 조회된 계약 리스트와 페이지 정보를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 조회된 계약 리스트와 페이지 정보를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -3386,7 +3386,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -3396,7 +3396,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -3416,14 +3416,14 @@
         ],
         "x-portone-category": "platform.policy",
         "x-portone-title": "계약 다건 조회",
-        "x-portone-description": "<p>여러 계약을 조회합니다.</p>\n",
+        "x-portone-description": "여러 계약을 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPlatformContractsError"
         }
       },
       "post": {
-        "summary": "<p>계약 생성</p>\n",
-        "description": "<p>계약 생성</p>\n<p>새로운 계약을 생성합니다.</p>\n",
+        "summary": "계약 생성",
+        "description": "계약 생성\n\n새로운 계약을 생성합니다.",
         "operationId": "createPlatformContract",
         "requestBody": {
           "content": {
@@ -3437,7 +3437,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 생성된 계약 객체가 반환됩니다.</p>\n",
+            "description": "성공 응답으로 생성된 계약 객체가 반환됩니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -3445,10 +3445,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 생성된 계약 객체가 반환됩니다.</p>\n"
+            "x-portone-description": "성공 응답으로 생성된 계약 객체가 반환됩니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -3458,7 +3458,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -3468,7 +3468,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -3478,7 +3478,7 @@
             }
           },
           "409": {
-            "description": "<ul>\n<li><code>PlatformContractAlreadyExistsError</code></li>\n</ul>\n",
+            "description": "* `PlatformContractAlreadyExistsError`",
             "content": {
               "application/json": {
                 "schema": {
@@ -3498,7 +3498,7 @@
         ],
         "x-portone-category": "platform.policy",
         "x-portone-title": "계약 생성",
-        "x-portone-description": "<p>새로운 계약을 생성합니다.</p>\n",
+        "x-portone-description": "새로운 계약을 생성합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/CreatePlatformContractError"
         }
@@ -3506,14 +3506,14 @@
     },
     "/platform/contracts/{id}": {
       "get": {
-        "summary": "<p>계약 조회</p>\n",
-        "description": "<p>계약 조회</p>\n<p>주어진 아이디에 대응되는 계약을 조회합니다.</p>\n",
+        "summary": "계약 조회",
+        "description": "계약 조회\n\n주어진 아이디에 대응되는 계약을 조회합니다.",
         "operationId": "getPlatformContract",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>조회할 계약 아이디</p>\n",
+            "description": "조회할 계약 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -3523,7 +3523,7 @@
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 계약 객체를 반환합니다.</p>\n",
+            "description": "성공 응답으로 계약 객체를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -3531,10 +3531,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 계약 객체를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 계약 객체를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -3544,7 +3544,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -3554,7 +3554,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -3564,7 +3564,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PlatformContractNotFoundError</code></li>\n</ul>\n",
+            "description": "* `PlatformContractNotFoundError`",
             "content": {
               "application/json": {
                 "schema": {
@@ -3584,20 +3584,20 @@
         ],
         "x-portone-category": "platform.policy",
         "x-portone-title": "계약 조회",
-        "x-portone-description": "<p>주어진 아이디에 대응되는 계약을 조회합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 계약을 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPlatformContractError"
         }
       },
       "patch": {
-        "summary": "<p>계약 수정</p>\n",
-        "description": "<p>계약 수정</p>\n<p>주어진 아이디에 대응되는 계약을 업데이트합니다.</p>\n",
+        "summary": "계약 수정",
+        "description": "계약 수정\n\n주어진 아이디에 대응되는 계약을 업데이트합니다.",
         "operationId": "updatePlatformContract",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>업데이트할 계약 아이디</p>\n",
+            "description": "업데이트할 계약 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -3617,7 +3617,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 업데이트된 계약 객체가 반환됩니다.</p>\n",
+            "description": "성공 응답으로 업데이트된 계약 객체가 반환됩니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -3625,10 +3625,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 업데이트된 계약 객체가 반환됩니다.</p>\n"
+            "x-portone-description": "성공 응답으로 업데이트된 계약 객체가 반환됩니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -3638,7 +3638,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -3648,7 +3648,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -3658,7 +3658,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PlatformContractNotFoundError</code></li>\n</ul>\n",
+            "description": "* `PlatformContractNotFoundError`",
             "content": {
               "application/json": {
                 "schema": {
@@ -3668,7 +3668,7 @@
             }
           },
           "409": {
-            "description": "<ul>\n<li><code>PlatformArchivedContractError</code>: 보관된 계약을 업데이트하려고 하는 경우</li>\n</ul>\n",
+            "description": "* `PlatformArchivedContractError`: 보관된 계약을 업데이트하려고 하는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -3688,7 +3688,7 @@
         ],
         "x-portone-category": "platform.policy",
         "x-portone-title": "계약 수정",
-        "x-portone-description": "<p>주어진 아이디에 대응되는 계약을 업데이트합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 계약을 업데이트합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/UpdatePlatformContractError"
         }
@@ -3696,13 +3696,13 @@
     },
     "/platform/contracts/{id}/schedule": {
       "get": {
-        "description": "<p>주어진 아이디에 대응되는 계약의 예약 업데이트를 조회합니다.</p>\n",
+        "description": "주어진 아이디에 대응되는 계약의 예약 업데이트를 조회합니다.",
         "operationId": "getPlatformContractSchedule",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>계약 아이디</p>\n",
+            "description": "계약 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -3712,7 +3712,7 @@
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 예약된 계약 객체를 반환합니다.</p>\n",
+            "description": "성공 응답으로 예약된 계약 객체를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -3720,10 +3720,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 예약된 계약 객체를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 예약된 계약 객체를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -3733,7 +3733,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -3743,7 +3743,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -3753,7 +3753,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PlatformContractNotFoundError</code></li>\n</ul>\n",
+            "description": "* `PlatformContractNotFoundError`",
             "content": {
               "application/json": {
                 "schema": {
@@ -3771,20 +3771,20 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>주어진 아이디에 대응되는 계약의 예약 업데이트를 조회합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 계약의 예약 업데이트를 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPlatformContractScheduleError"
         },
         "x-portone-unstable": true
       },
       "put": {
-        "description": "<p>주어진 아이디에 대응되는 계약에 예약 업데이트를 재설정합니다.</p>\n",
+        "description": "주어진 아이디에 대응되는 계약에 예약 업데이트를 재설정합니다.",
         "operationId": "rescheduleContract",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>계약 아이디</p>\n",
+            "description": "계약 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -3804,7 +3804,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 예약된 계약 객체를 반환합니다.</p>\n",
+            "description": "성공 응답으로 예약된 계약 객체를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -3812,10 +3812,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 예약된 계약 객체를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 예약된 계약 객체를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -3825,7 +3825,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -3835,7 +3835,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -3845,7 +3845,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PlatformContractNotFoundError</code></li>\n</ul>\n",
+            "description": "* `PlatformContractNotFoundError`",
             "content": {
               "application/json": {
                 "schema": {
@@ -3863,20 +3863,20 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>주어진 아이디에 대응되는 계약에 예약 업데이트를 재설정합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 계약에 예약 업데이트를 재설정합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/RescheduleContractError"
         },
         "x-portone-unstable": true
       },
       "post": {
-        "description": "<p>주어진 아이디에 대응되는 계약에 업데이트를 예약합니다.</p>\n",
+        "description": "주어진 아이디에 대응되는 계약에 업데이트를 예약합니다.",
         "operationId": "scheduleContract",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>계약 아이디</p>\n",
+            "description": "계약 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -3896,7 +3896,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 예약된 계약 객체를 반환합니다.</p>\n",
+            "description": "성공 응답으로 예약된 계약 객체를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -3904,10 +3904,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 예약된 계약 객체를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 예약된 계약 객체를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -3917,7 +3917,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -3927,7 +3927,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -3937,7 +3937,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PlatformContractNotFoundError</code></li>\n</ul>\n",
+            "description": "* `PlatformContractNotFoundError`",
             "content": {
               "application/json": {
                 "schema": {
@@ -3947,7 +3947,7 @@
             }
           },
           "409": {
-            "description": "<ul>\n<li><code>PlatformContractScheduleAlreadyExistsError</code></li>\n<li><code>PlatformArchivedContractError</code>: 보관된 계약을 업데이트하려고 하는 경우</li>\n</ul>\n",
+            "description": "* `PlatformContractScheduleAlreadyExistsError`\n* `PlatformArchivedContractError`: 보관된 계약을 업데이트하려고 하는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -3965,20 +3965,20 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>주어진 아이디에 대응되는 계약에 업데이트를 예약합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 계약에 업데이트를 예약합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/ScheduleContractError"
         },
         "x-portone-unstable": true
       },
       "delete": {
-        "description": "<p>주어진 아이디에 대응되는 계약의 예약 업데이트를 취소합니다.</p>\n",
+        "description": "주어진 아이디에 대응되는 계약의 예약 업데이트를 취소합니다.",
         "operationId": "cancelPlatformContractSchedule",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>계약 아이디</p>\n",
+            "description": "계약 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -3988,7 +3988,7 @@
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답",
             "content": {
               "application/json": {
                 "schema": {
@@ -3999,7 +3999,7 @@
             "x-portone-title": "성공 응답"
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -4009,7 +4009,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -4019,7 +4019,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -4029,7 +4029,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PlatformContractNotFoundError</code></li>\n</ul>\n",
+            "description": "* `PlatformContractNotFoundError`",
             "content": {
               "application/json": {
                 "schema": {
@@ -4047,7 +4047,7 @@
             "portOne": []
           }
         ],
-        "x-portone-description": "<p>주어진 아이디에 대응되는 계약의 예약 업데이트를 취소합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 계약의 예약 업데이트를 취소합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/CancelPlatformContractScheduleError"
         },
@@ -4056,14 +4056,14 @@
     },
     "/platform/contracts/{id}/archive": {
       "post": {
-        "summary": "<p>계약 보관</p>\n",
-        "description": "<p>계약 보관</p>\n<p>주어진 아이디에 대응되는 계약을 보관합니다.</p>\n",
+        "summary": "계약 보관",
+        "description": "계약 보관\n\n주어진 아이디에 대응되는 계약을 보관합니다.",
         "operationId": "archivePlatformContract",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>계약 아이디</p>\n",
+            "description": "계약 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -4073,7 +4073,7 @@
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 보관된 계약 객체를 반환합니다.</p>\n",
+            "description": "성공 응답으로 보관된 계약 객체를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -4081,10 +4081,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 보관된 계약 객체를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 보관된 계약 객체를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -4094,7 +4094,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -4104,7 +4104,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -4114,7 +4114,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PlatformContractNotFoundError</code></li>\n</ul>\n",
+            "description": "* `PlatformContractNotFoundError`",
             "content": {
               "application/json": {
                 "schema": {
@@ -4124,7 +4124,7 @@
             }
           },
           "409": {
-            "description": "<ul>\n<li><code>PlatformCannotArchiveScheduledContractError</code>: 예약된 업데이트가 있는 계약을 보관하려고 하는 경우</li>\n</ul>\n",
+            "description": "* `PlatformCannotArchiveScheduledContractError`: 예약된 업데이트가 있는 계약을 보관하려고 하는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -4144,7 +4144,7 @@
         ],
         "x-portone-category": "platform.policy",
         "x-portone-title": "계약 보관",
-        "x-portone-description": "<p>주어진 아이디에 대응되는 계약을 보관합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 계약을 보관합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/ArchivePlatformContractError"
         }
@@ -4152,14 +4152,14 @@
     },
     "/platform/contracts/{id}/recover": {
       "post": {
-        "summary": "<p>계약 복원</p>\n",
-        "description": "<p>계약 복원</p>\n<p>주어진 아이디에 대응되는 계약을 복원합니다.</p>\n",
+        "summary": "계약 복원",
+        "description": "계약 복원\n\n주어진 아이디에 대응되는 계약을 복원합니다.",
         "operationId": "recoverPlatformContract",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>계약 아이디</p>\n",
+            "description": "계약 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -4169,7 +4169,7 @@
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 복원된 계약 객체를 반환합니다.</p>\n",
+            "description": "성공 응답으로 복원된 계약 객체를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -4177,10 +4177,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 복원된 계약 객체를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 복원된 계약 객체를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -4190,7 +4190,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -4200,7 +4200,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -4210,7 +4210,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PlatformContractNotFoundError</code></li>\n</ul>\n",
+            "description": "* `PlatformContractNotFoundError`",
             "content": {
               "application/json": {
                 "schema": {
@@ -4230,7 +4230,7 @@
         ],
         "x-portone-category": "platform.policy",
         "x-portone-title": "계약 복원",
-        "x-portone-description": "<p>주어진 아이디에 대응되는 계약을 복원합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 계약을 복원합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/RecoverPlatformContractError"
         }
@@ -4238,14 +4238,14 @@
     },
     "/platform/transfers/{id}": {
       "get": {
-        "summary": "<p>정산건 조회</p>\n",
-        "description": "<p>정산건 조회</p>\n<p>정산건을 조회합니다.</p>\n",
+        "summary": "정산건 조회",
+        "description": "정산건 조회\n\n정산건을 조회합니다.",
         "operationId": "getPlatformTransfer",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>조회하고 싶은 정산건 아이디</p>\n",
+            "description": "조회하고 싶은 정산건 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -4255,7 +4255,7 @@
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 정산건 객체가 반환됩니다.</p>\n",
+            "description": "성공 응답으로 정산건 객체가 반환됩니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -4263,10 +4263,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 정산건 객체가 반환됩니다.</p>\n"
+            "x-portone-description": "성공 응답으로 정산건 객체가 반환됩니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -4276,7 +4276,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -4286,7 +4286,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -4296,7 +4296,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PlatformTransferNotFoundError</code></li>\n</ul>\n",
+            "description": "* `PlatformTransferNotFoundError`",
             "content": {
               "application/json": {
                 "schema": {
@@ -4316,20 +4316,20 @@
         ],
         "x-portone-category": "platform.transfer",
         "x-portone-title": "정산건 조회",
-        "x-portone-description": "<p>정산건을 조회합니다.</p>\n",
+        "x-portone-description": "정산건을 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPlatformTransferError"
         }
       },
       "delete": {
-        "summary": "<p>정산건 삭제</p>\n",
-        "description": "<p>정산건 삭제</p>\n<p>scheduled, in_process 상태의 정산건만 삭제가능합니다.</p>\n",
+        "summary": "정산건 삭제",
+        "description": "정산건 삭제\n\nscheduled, in_process 상태의 정산건만 삭제가능합니다.",
         "operationId": "deletePlatformTransfer",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "<p>정산건 아이디</p>\n",
+            "description": "정산건 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -4349,7 +4349,7 @@
             }
           },
           "400": {
-            "description": "<ul>\n<li><code>PlatformCancelOrderTransfersExistsError</code></li>\n<li><code>PlatformTransferNonDeletableStatusError</code></li>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `PlatformCancelOrderTransfersExistsError`\n* `PlatformTransferNonDeletableStatusError`\n* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -4359,7 +4359,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -4369,7 +4369,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -4379,7 +4379,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PlatformTransferNotFoundError</code></li>\n</ul>\n",
+            "description": "* `PlatformTransferNotFoundError`",
             "content": {
               "application/json": {
                 "schema": {
@@ -4399,7 +4399,7 @@
         ],
         "x-portone-category": "platform.transfer",
         "x-portone-title": "정산건 삭제",
-        "x-portone-description": "<p>scheduled, in_process 상태의 정산건만 삭제가능합니다.</p>\n",
+        "x-portone-description": "scheduled, in_process 상태의 정산건만 삭제가능합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/DeletePlatformTransferError"
         }
@@ -4407,8 +4407,8 @@
     },
     "/platform/transfer-summaries": {
       "get": {
-        "summary": "<p>정산건 다건 조회</p>\n",
-        "description": "<p>정산건 다건 조회</p>\n<p>성공 응답으로 조회된 정산건 요약 리스트와 페이지 정보가 반환됩니다.</p>\n",
+        "summary": "정산건 다건 조회",
+        "description": "정산건 다건 조회\n\n성공 응답으로 조회된 정산건 요약 리스트와 페이지 정보가 반환됩니다.",
         "operationId": "getPlatformTransferSummaries",
         "parameters": [
           {
@@ -4450,7 +4450,7 @@
             }
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -4460,7 +4460,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -4470,7 +4470,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -4490,7 +4490,7 @@
         ],
         "x-portone-category": "platform.transfer",
         "x-portone-title": "정산건 다건 조회",
-        "x-portone-description": "<p>성공 응답으로 조회된 정산건 요약 리스트와 페이지 정보가 반환됩니다.</p>\n",
+        "x-portone-description": "성공 응답으로 조회된 정산건 요약 리스트와 페이지 정보가 반환됩니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPlatformTransferSummariesError"
         }
@@ -4498,8 +4498,8 @@
     },
     "/platform/transfers/order": {
       "post": {
-        "summary": "<p>주문 정산건 생성</p>\n",
-        "description": "<p>주문 정산건 생성</p>\n<p>성공 응답으로 생성된 주문 정산건 객체가 반환됩니다.</p>\n",
+        "summary": "주문 정산건 생성",
+        "description": "주문 정산건 생성\n\n성공 응답으로 생성된 주문 정산건 객체가 반환됩니다.",
         "operationId": "createPlatformOrderTransfer",
         "requestBody": {
           "content": {
@@ -4523,7 +4523,7 @@
             }
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n<li><code>PlatformProductIdDuplicatedError</code></li>\n<li><code>PlatformSettlementPaymentAmountExceededPortOnePaymentError</code>: 정산 요청 결제 금액이 포트원 결제 내역의 결제 금액을 초과한 경우</li>\n<li><code>PlatformSettlementTaxFreeAmountExceededPortOnePaymentError</code>: 정산 요청 면세 금액이 포트원 결제 내역의 면세 금액을 초과한 경우</li>\n<li><code>PlatformSettlementSupplyWithVatAmountExceededPortOnePaymentError</code>: 정산 요청 공급대가가 포트원 결제 내역의 공급대가를 초과한 경우</li>\n<li><code>PlatformSettlementAmountExceededError</code>: 정산 가능한 금액을 초과한 경우</li>\n<li><code>PlatformContractPlatformFixedAmountFeeCurrencyAndSettlementCurrencyMismatchedError</code></li>\n<li><code>PlatformAdditionalFixedAmountFeeCurrencyAndSettlementCurrencyMismatchedError</code></li>\n<li><code>PlatformCurrencyNotSupportedError</code>: 지원 되지 않는 통화를 선택한 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우\n* `PlatformProductIdDuplicatedError`\n* `PlatformSettlementPaymentAmountExceededPortOnePaymentError`: 정산 요청 결제 금액이 포트원 결제 내역의 결제 금액을 초과한 경우\n* `PlatformSettlementTaxFreeAmountExceededPortOnePaymentError`: 정산 요청 면세 금액이 포트원 결제 내역의 면세 금액을 초과한 경우\n* `PlatformSettlementSupplyWithVatAmountExceededPortOnePaymentError`: 정산 요청 공급대가가 포트원 결제 내역의 공급대가를 초과한 경우\n* `PlatformSettlementAmountExceededError`: 정산 가능한 금액을 초과한 경우\n* `PlatformContractPlatformFixedAmountFeeCurrencyAndSettlementCurrencyMismatchedError`\n* `PlatformAdditionalFixedAmountFeeCurrencyAndSettlementCurrencyMismatchedError`\n* `PlatformCurrencyNotSupportedError`: 지원 되지 않는 통화를 선택한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -4533,7 +4533,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -4543,7 +4543,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -4553,7 +4553,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PlatformPartnerNotFoundError</code></li>\n<li><code>PlatformContractNotFoundError</code></li>\n<li><code>PlatformAdditionalFeePoliciesNotFoundError</code></li>\n<li><code>PlatformDiscountSharePoliciesNotFoundError</code></li>\n<li><code>PlatformPaymentNotFoundError</code></li>\n<li><code>PlatformUserDefinedPropertyNotFoundError</code>: 사용자 정의 속성이 존재 하지 않는 경우</li>\n<li><code>PlatformSettlementParameterNotFoundError</code>: 정산 파라미터가 존재하지 않는 경우</li>\n</ul>\n",
+            "description": "* `PlatformPartnerNotFoundError`\n* `PlatformContractNotFoundError`\n* `PlatformAdditionalFeePoliciesNotFoundError`\n* `PlatformDiscountSharePoliciesNotFoundError`\n* `PlatformPaymentNotFoundError`\n* `PlatformUserDefinedPropertyNotFoundError`: 사용자 정의 속성이 존재 하지 않는 경우\n* `PlatformSettlementParameterNotFoundError`: 정산 파라미터가 존재하지 않는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -4563,7 +4563,7 @@
             }
           },
           "409": {
-            "description": "<ul>\n<li><code>PlatformTransferAlreadyExistsError</code></li>\n</ul>\n",
+            "description": "* `PlatformTransferAlreadyExistsError`",
             "content": {
               "application/json": {
                 "schema": {
@@ -4583,7 +4583,7 @@
         ],
         "x-portone-category": "platform.transfer",
         "x-portone-title": "주문 정산건 생성",
-        "x-portone-description": "<p>성공 응답으로 생성된 주문 정산건 객체가 반환됩니다.</p>\n",
+        "x-portone-description": "성공 응답으로 생성된 주문 정산건 객체가 반환됩니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/CreatePlatformOrderTransferError"
         }
@@ -4591,8 +4591,8 @@
     },
     "/platform/transfers/order-cancel": {
       "post": {
-        "summary": "<p>주문 취소 정산건 생성</p>\n",
-        "description": "<p>주문 취소 정산건 생성</p>\n<p>성공 응답으로 생성된 주문 취소 정산건 객체가 반환됩니다.</p>\n",
+        "summary": "주문 취소 정산건 생성",
+        "description": "주문 취소 정산건 생성\n\n성공 응답으로 생성된 주문 취소 정산건 객체가 반환됩니다.",
         "operationId": "createPlatformOrderCancelTransfer",
         "requestBody": {
           "content": {
@@ -4616,7 +4616,7 @@
             }
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n<li><code>PlatformOrderDetailMismatchedError</code></li>\n<li><code>PlatformDiscountSharePolicyIdDuplicatedError</code></li>\n<li><code>PlatformCancellableAmountExceededError</code>: 취소 가능한 금액이 초과한 경우</li>\n<li><code>PlatformCancellableDiscountAmountExceededError</code></li>\n<li><code>PlatformCancellableDiscountTaxFreeAmountExceededError</code></li>\n<li><code>PlatformProductIdDuplicatedError</code></li>\n<li><code>PlatformCancellableProductQuantityExceededError</code></li>\n<li><code>PlatformOrderTransferAlreadyCancelledError</code></li>\n<li><code>PlatformSettlementAmountExceededError</code>: 정산 가능한 금액을 초과한 경우</li>\n<li><code>PlatformCancellationAndPaymentTypeMismatchedError</code></li>\n<li><code>PlatformSettlementCancelAmountExceededPortOneCancelError</code>: 정산 취소 요청 금액이 포트원 결제 취소 내역의 취소 금액을 초과한 경우</li>\n<li><code>PlatformCannotSpecifyTransferError</code>: 정산 건 식별에 실패한 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우\n* `PlatformOrderDetailMismatchedError`\n* `PlatformDiscountSharePolicyIdDuplicatedError`\n* `PlatformCancellableAmountExceededError`: 취소 가능한 금액이 초과한 경우\n* `PlatformCancellableDiscountAmountExceededError`\n* `PlatformCancellableDiscountTaxFreeAmountExceededError`\n* `PlatformProductIdDuplicatedError`\n* `PlatformCancellableProductQuantityExceededError`\n* `PlatformOrderTransferAlreadyCancelledError`\n* `PlatformSettlementAmountExceededError`: 정산 가능한 금액을 초과한 경우\n* `PlatformCancellationAndPaymentTypeMismatchedError`\n* `PlatformSettlementCancelAmountExceededPortOneCancelError`: 정산 취소 요청 금액이 포트원 결제 취소 내역의 취소 금액을 초과한 경우\n* `PlatformCannotSpecifyTransferError`: 정산 건 식별에 실패한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -4626,7 +4626,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -4636,7 +4636,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -4646,7 +4646,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PlatformTransferNotFoundError</code></li>\n<li><code>PlatformCancellationNotFoundError</code></li>\n<li><code>PlatformPaymentNotFoundError</code></li>\n<li><code>PlatformProductIdNotFoundError</code></li>\n<li><code>PlatformTransferDiscountSharePolicyNotFoundError</code></li>\n<li><code>PlatformUserDefinedPropertyNotFoundError</code>: 사용자 정의 속성이 존재 하지 않는 경우</li>\n</ul>\n",
+            "description": "* `PlatformTransferNotFoundError`\n* `PlatformCancellationNotFoundError`\n* `PlatformPaymentNotFoundError`\n* `PlatformProductIdNotFoundError`\n* `PlatformTransferDiscountSharePolicyNotFoundError`\n* `PlatformUserDefinedPropertyNotFoundError`: 사용자 정의 속성이 존재 하지 않는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -4656,7 +4656,7 @@
             }
           },
           "409": {
-            "description": "<ul>\n<li><code>PlatformTransferAlreadyExistsError</code></li>\n</ul>\n",
+            "description": "* `PlatformTransferAlreadyExistsError`",
             "content": {
               "application/json": {
                 "schema": {
@@ -4676,7 +4676,7 @@
         ],
         "x-portone-category": "platform.transfer",
         "x-portone-title": "주문 취소 정산건 생성",
-        "x-portone-description": "<p>성공 응답으로 생성된 주문 취소 정산건 객체가 반환됩니다.</p>\n",
+        "x-portone-description": "성공 응답으로 생성된 주문 취소 정산건 객체가 반환됩니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/CreatePlatformOrderCancelTransferError"
         }
@@ -4684,8 +4684,8 @@
     },
     "/platform/transfers/manual": {
       "post": {
-        "summary": "<p>수기 정산건 생성</p>\n",
-        "description": "<p>수기 정산건 생성</p>\n<p>성공 응답으로 생성된 수기 정산건 객체가 반환됩니다.</p>\n",
+        "summary": "수기 정산건 생성",
+        "description": "수기 정산건 생성\n\n성공 응답으로 생성된 수기 정산건 객체가 반환됩니다.",
         "operationId": "createPlatformManualTransfer",
         "requestBody": {
           "content": {
@@ -4709,7 +4709,7 @@
             }
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -4719,7 +4719,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -4729,7 +4729,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -4739,7 +4739,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PlatformPartnerNotFoundError</code></li>\n<li><code>PlatformUserDefinedPropertyNotFoundError</code>: 사용자 정의 속성이 존재 하지 않는 경우</li>\n</ul>\n",
+            "description": "* `PlatformPartnerNotFoundError`\n* `PlatformUserDefinedPropertyNotFoundError`: 사용자 정의 속성이 존재 하지 않는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -4759,7 +4759,7 @@
         ],
         "x-portone-category": "platform.transfer",
         "x-portone-title": "수기 정산건 생성",
-        "x-portone-description": "<p>성공 응답으로 생성된 수기 정산건 객체가 반환됩니다.</p>\n",
+        "x-portone-description": "성공 응답으로 생성된 수기 정산건 객체가 반환됩니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/CreatePlatformManualTransferError"
         }
@@ -4769,8 +4769,8 @@
     "/platform/transfer-filter-options": {},
     "/platform/transfer-summaries/sheet-file": {
       "get": {
-        "summary": "<p>정산 상세 내역 다운로드</p>\n",
-        "description": "<p>정산 상세 내역 다운로드</p>\n<p>정산 상세 내역을 csv 파일로 다운로드 합니다.</p>\n",
+        "summary": "정산 상세 내역 다운로드",
+        "description": "정산 상세 내역 다운로드\n\n정산 상세 내역을 csv 파일로 다운로드 합니다.",
         "operationId": "downloadPlatformTransferSheet",
         "parameters": [
           {
@@ -4813,7 +4813,7 @@
             }
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -4823,7 +4823,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -4843,7 +4843,7 @@
         ],
         "x-portone-category": "platform.transfer",
         "x-portone-title": "정산 상세 내역 다운로드",
-        "x-portone-description": "<p>정산 상세 내역을 csv 파일로 다운로드 합니다.</p>\n",
+        "x-portone-description": "정산 상세 내역을 csv 파일로 다운로드 합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/DownloadPlatformTransferSheetError"
         }
@@ -4852,8 +4852,8 @@
     "/platform/payable-settlement-dates": {},
     "/platform/partner-settlements": {
       "get": {
-        "summary": "<p>정산 내역 다건 조회</p>\n",
-        "description": "<p>정산 내역 다건 조회</p>\n<p>여러 정산 내역을 조회합니다.</p>\n",
+        "summary": "정산 내역 다건 조회",
+        "description": "정산 내역 다건 조회\n\n여러 정산 내역을 조회합니다.",
         "operationId": "getPlatformPartnerSettlements",
         "parameters": [
           {
@@ -4885,7 +4885,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 조회된 정산 내역 리스트와 페이지 정보 및 상태 별 개수 정보를 반환합니다.</p>\n",
+            "description": "성공 응답으로 조회된 정산 내역 리스트와 페이지 정보 및 상태 별 개수 정보를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -4893,10 +4893,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 조회된 정산 내역 리스트와 페이지 정보 및 상태 별 개수 정보를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 조회된 정산 내역 리스트와 페이지 정보 및 상태 별 개수 정보를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -4906,7 +4906,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -4916,7 +4916,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -4936,7 +4936,7 @@
         ],
         "x-portone-category": "platform.partnerSettlement",
         "x-portone-title": "정산 내역 다건 조회",
-        "x-portone-description": "<p>여러 정산 내역을 조회합니다.</p>\n",
+        "x-portone-description": "여러 정산 내역을 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPlatformPartnerSettlementsError"
         }
@@ -4949,8 +4949,8 @@
     "/platform/payouts/{id}": {},
     "/platform/payouts": {
       "get": {
-        "summary": "<p>지급 내역 다건 조회</p>\n",
-        "description": "<p>지급 내역 다건 조회</p>\n<p>여러 지급 내역을 조회합니다.</p>\n",
+        "summary": "지급 내역 다건 조회",
+        "description": "지급 내역 다건 조회\n\n여러 지급 내역을 조회합니다.",
         "operationId": "getPlatformPayouts",
         "parameters": [
           {
@@ -4982,7 +4982,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 조회된 지급 내역 리스트와 페이지 정보 및 상태 별 개수 정보를 반환합니다.</p>\n",
+            "description": "성공 응답으로 조회된 지급 내역 리스트와 페이지 정보 및 상태 별 개수 정보를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -4990,10 +4990,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 조회된 지급 내역 리스트와 페이지 정보 및 상태 별 개수 정보를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 조회된 지급 내역 리스트와 페이지 정보 및 상태 별 개수 정보를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5003,7 +5003,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5013,7 +5013,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5033,7 +5033,7 @@
         ],
         "x-portone-category": "platform.payout",
         "x-portone-title": "지급 내역 다건 조회",
-        "x-portone-description": "<p>여러 지급 내역을 조회합니다.</p>\n",
+        "x-portone-description": "여러 지급 내역을 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPlatformPayoutsError"
         }
@@ -5042,8 +5042,8 @@
     "/platform/bulk-payouts/{id}": {},
     "/platform/bulk-payouts": {
       "get": {
-        "summary": "<p>일괄 지급 내역 다건 조회</p>\n",
-        "description": "<p>일괄 지급 내역 다건 조회</p>\n<p>성공 응답으로 조회된 일괄 지급 내역 리스트와 페이지 정보 및 상태 별 개수 정보를 반환합니다.</p>\n",
+        "summary": "일괄 지급 내역 다건 조회",
+        "description": "일괄 지급 내역 다건 조회\n\n성공 응답으로 조회된 일괄 지급 내역 리스트와 페이지 정보 및 상태 별 개수 정보를 반환합니다.",
         "operationId": "getPlatformBulkPayouts",
         "parameters": [
           {
@@ -5085,7 +5085,7 @@
             }
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5095,7 +5095,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5105,7 +5105,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5125,7 +5125,7 @@
         ],
         "x-portone-category": "platform.bulkPayout",
         "x-portone-title": "일괄 지급 내역 다건 조회",
-        "x-portone-description": "<p>성공 응답으로 조회된 일괄 지급 내역 리스트와 페이지 정보 및 상태 별 개수 정보를 반환합니다.</p>\n",
+        "x-portone-description": "성공 응답으로 조회된 일괄 지급 내역 리스트와 페이지 정보 및 상태 별 개수 정보를 반환합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPlatformBulkPayoutsError"
         }
@@ -5134,14 +5134,14 @@
     "/platform/bulk-payouts/{bulkPayoutId}/partner-settlements": {},
     "/platform/bank-accounts/{bank}/{accountNumber}/holder": {
       "get": {
-        "summary": "<p>예금주 조회</p>\n",
-        "description": "<p>예금주 조회</p>\n<p>계좌의 예금주를 조회합니다.</p>\n",
+        "summary": "예금주 조회",
+        "description": "예금주 조회\n\n계좌의 예금주를 조회합니다.",
         "operationId": "getPlatformAccountHolder",
         "parameters": [
           {
             "name": "bank",
             "in": "path",
-            "description": "<p>은행</p>\n",
+            "description": "은행",
             "required": true,
             "schema": {
               "$ref": "#/components/schemas/Bank"
@@ -5151,7 +5151,7 @@
           {
             "name": "accountNumber",
             "in": "path",
-            "description": "<p>'-'를 제외한 계좌 번호</p>\n",
+            "description": "'-'를 제외한 계좌 번호",
             "required": true,
             "schema": {
               "type": "string"
@@ -5161,29 +5161,29 @@
           {
             "name": "birthdate",
             "in": "query",
-            "description": "<p>생년월일</p>\n<p>실명 조회를 위해 추가로 보낼 수 있습니다. birthdate과 businessRegistrationNumber 중 하나만 사용해야 합니다.</p>\n",
+            "description": "생년월일\n\n실명 조회를 위해 추가로 보낼 수 있습니다. birthdate과 businessRegistrationNumber 중 하나만 사용해야 합니다.",
             "required": false,
             "schema": {
               "type": "string"
             },
             "x-portone-title": "생년월일",
-            "x-portone-description": "<p>실명 조회를 위해 추가로 보낼 수 있습니다. birthdate과 businessRegistrationNumber 중 하나만 사용해야 합니다.</p>\n"
+            "x-portone-description": "실명 조회를 위해 추가로 보낼 수 있습니다. birthdate과 businessRegistrationNumber 중 하나만 사용해야 합니다."
           },
           {
             "name": "businessRegistrationNumber",
             "in": "query",
-            "description": "<p>사업자등록번호</p>\n<p>실명 조회를 위해 추가로 보낼 수 있습니다. birthdate과 businessRegistrationNumber 중 하나만 사용해야 합니다.</p>\n",
+            "description": "사업자등록번호\n\n실명 조회를 위해 추가로 보낼 수 있습니다. birthdate과 businessRegistrationNumber 중 하나만 사용해야 합니다.",
             "required": false,
             "schema": {
               "type": "string"
             },
             "x-portone-title": "사업자등록번호",
-            "x-portone-description": "<p>실명 조회를 위해 추가로 보낼 수 있습니다. birthdate과 businessRegistrationNumber 중 하나만 사용해야 합니다.</p>\n"
+            "x-portone-description": "실명 조회를 위해 추가로 보낼 수 있습니다. birthdate과 businessRegistrationNumber 중 하나만 사용해야 합니다."
           }
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 조회된 예금주 명이 반환됩니다.</p>\n",
+            "description": "성공 응답으로 조회된 예금주 명이 반환됩니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -5191,10 +5191,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 조회된 예금주 명이 반환됩니다.</p>\n"
+            "x-portone-description": "성공 응답으로 조회된 예금주 명이 반환됩니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n<li><code>PlatformNotSupportedBankError</code>: 지원하지 않는 은행인 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우\n* `PlatformNotSupportedBankError`: 지원하지 않는 은행인 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5204,7 +5204,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5214,7 +5214,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5224,7 +5224,7 @@
             }
           },
           "503": {
-            "description": "<ul>\n<li><code>PlatformExternalApiTemporarilyFailedError</code>: 외부 api의 일시적인 오류</li>\n<li><code>PlatformExternalApiFailedError</code>: 외부 api 오류</li>\n</ul>\n",
+            "description": "* `PlatformExternalApiTemporarilyFailedError`: 외부 api의 일시적인 오류\n* `PlatformExternalApiFailedError`: 외부 api 오류",
             "content": {
               "application/json": {
                 "schema": {
@@ -5244,7 +5244,7 @@
         ],
         "x-portone-category": "platform.account",
         "x-portone-title": "예금주 조회",
-        "x-portone-description": "<p>계좌의 예금주를 조회합니다.</p>\n",
+        "x-portone-description": "계좌의 예금주를 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPlatformAccountHolderError"
         }
@@ -5253,14 +5253,14 @@
     "/platform/holidays/{year}": {},
     "/identity-verifications/{identityVerificationId}": {
       "get": {
-        "summary": "<p>본인인증 단건 조회</p>\n",
-        "description": "<p>본인인증 단건 조회</p>\n<p>주어진 아이디에 대응되는 본인인증 내역을 조회합니다.</p>\n",
+        "summary": "본인인증 단건 조회",
+        "description": "본인인증 단건 조회\n\n주어진 아이디에 대응되는 본인인증 내역을 조회합니다.",
         "operationId": "getIdentityVerification",
         "parameters": [
           {
             "name": "identityVerificationId",
             "in": "path",
-            "description": "<p>조회할 본인인증 아이디</p>\n",
+            "description": "조회할 본인인증 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -5271,19 +5271,19 @@
           {
             "name": "storeId",
             "in": "query",
-            "description": "<p>상점 아이디</p>\n<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n",
+            "description": "상점 아이디\n\n접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.",
             "required": false,
             "schema": {
               "type": "string"
             },
             "example": "your-store-id",
             "x-portone-title": "상점 아이디",
-            "x-portone-description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "x-portone-description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다."
           }
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 본인 인증 객체를 반환합니다.</p>\n",
+            "description": "성공 응답으로 본인 인증 객체를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -5309,6 +5309,7 @@
                     "gender": "FEMALE",
                     "isForeigner": false,
                     "ci": "ci-value",
+                    "ci2": "ci2-value",
                     "di": "di-value"
                   },
                   "customData": "your-custom-data-string",
@@ -5321,10 +5322,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 본인 인증 객체를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 본인 인증 객체를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5334,7 +5335,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5344,7 +5345,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5354,7 +5355,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>IdentityVerificationNotFoundError</code>: 요청된 본인인증 건이 존재하지 않는 경우</li>\n</ul>\n",
+            "description": "* `IdentityVerificationNotFoundError`: 요청된 본인인증 건이 존재하지 않는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5374,7 +5375,7 @@
         ],
         "x-portone-category": "identityVerification",
         "x-portone-title": "본인인증 단건 조회",
-        "x-portone-description": "<p>주어진 아이디에 대응되는 본인인증 내역을 조회합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 본인인증 내역을 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetIdentityVerificationError"
         }
@@ -5382,14 +5383,14 @@
     },
     "/identity-verifications/{identityVerificationId}/send": {
       "post": {
-        "summary": "<p>본인인증 요청 전송</p>\n",
-        "description": "<p>본인인증 요청 전송</p>\n<p>SMS 또는 APP 방식을 이용하여 본인인증 요청을 전송합니다.</p>\n",
+        "summary": "본인인증 요청 전송",
+        "description": "본인인증 요청 전송\n\nSMS 또는 APP 방식을 이용하여 본인인증 요청을 전송합니다.",
         "operationId": "sendIdentityVerification",
         "parameters": [
           {
             "name": "identityVerificationId",
             "in": "path",
-            "description": "<p>본인인증 아이디</p>\n",
+            "description": "본인인증 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -5409,7 +5410,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답",
             "content": {
               "application/json": {
                 "schema": {
@@ -5420,7 +5421,7 @@
             "x-portone-title": "성공 응답"
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5430,7 +5431,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5440,7 +5441,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5450,7 +5451,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>IdentityVerificationNotFoundError</code>: 요청된 본인인증 건이 존재하지 않는 경우</li>\n<li><code>ChannelNotFoundError</code>: 요청된 채널이 존재하지 않는 경우</li>\n</ul>\n",
+            "description": "* `IdentityVerificationNotFoundError`: 요청된 본인인증 건이 존재하지 않는 경우\n* `ChannelNotFoundError`: 요청된 채널이 존재하지 않는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5460,7 +5461,7 @@
             }
           },
           "409": {
-            "description": "<ul>\n<li><code>IdentityVerificationAlreadyVerifiedError</code>: 본인인증 건이 이미 인증 완료된 상태인 경우</li>\n<li><code>IdentityVerificationAlreadySentError</code>: 본인인증 건이 이미 API로 요청된 상태인 경우</li>\n</ul>\n",
+            "description": "* `IdentityVerificationAlreadyVerifiedError`: 본인인증 건이 이미 인증 완료된 상태인 경우\n* `IdentityVerificationAlreadySentError`: 본인인증 건이 이미 API로 요청된 상태인 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5470,7 +5471,7 @@
             }
           },
           "502": {
-            "description": "<ul>\n<li><code>PgProviderError</code>: PG사에서 오류를 전달한 경우</li>\n</ul>\n",
+            "description": "* `PgProviderError`: PG사에서 오류를 전달한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5490,7 +5491,7 @@
         ],
         "x-portone-category": "identityVerification",
         "x-portone-title": "본인인증 요청 전송",
-        "x-portone-description": "<p>SMS 또는 APP 방식을 이용하여 본인인증 요청을 전송합니다.</p>\n",
+        "x-portone-description": "SMS 또는 APP 방식을 이용하여 본인인증 요청을 전송합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/SendIdentityVerificationError"
         }
@@ -5498,14 +5499,14 @@
     },
     "/identity-verifications/{identityVerificationId}/confirm": {
       "post": {
-        "summary": "<p>본인인증 확인</p>\n",
-        "description": "<p>본인인증 확인</p>\n<p>요청된 본인인증에 대한 확인을 진행합니다.</p>\n",
+        "summary": "본인인증 확인",
+        "description": "본인인증 확인\n\n요청된 본인인증에 대한 확인을 진행합니다.",
         "operationId": "confirmIdentityVerification",
         "parameters": [
           {
             "name": "identityVerificationId",
             "in": "path",
-            "description": "<p>본인인증 아이디</p>\n",
+            "description": "본인인증 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -5525,7 +5526,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답",
             "content": {
               "application/json": {
                 "schema": {
@@ -5536,7 +5537,7 @@
             "x-portone-title": "성공 응답"
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5546,7 +5547,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5556,7 +5557,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5566,7 +5567,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>IdentityVerificationNotFoundError</code>: 요청된 본인인증 건이 존재하지 않는 경우</li>\n<li><code>IdentityVerificationNotSentError</code>: 본인인증 건이 API로 요청된 상태가 아닌 경우</li>\n</ul>\n",
+            "description": "* `IdentityVerificationNotFoundError`: 요청된 본인인증 건이 존재하지 않는 경우\n* `IdentityVerificationNotSentError`: 본인인증 건이 API로 요청된 상태가 아닌 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5576,7 +5577,7 @@
             }
           },
           "409": {
-            "description": "<ul>\n<li><code>IdentityVerificationAlreadyVerifiedError</code>: 본인인증 건이 이미 인증 완료된 상태인 경우</li>\n</ul>\n",
+            "description": "* `IdentityVerificationAlreadyVerifiedError`: 본인인증 건이 이미 인증 완료된 상태인 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5586,7 +5587,7 @@
             }
           },
           "502": {
-            "description": "<ul>\n<li><code>PgProviderError</code>: PG사에서 오류를 전달한 경우</li>\n</ul>\n",
+            "description": "* `PgProviderError`: PG사에서 오류를 전달한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5606,7 +5607,7 @@
         ],
         "x-portone-category": "identityVerification",
         "x-portone-title": "본인인증 확인",
-        "x-portone-description": "<p>요청된 본인인증에 대한 확인을 진행합니다.</p>\n",
+        "x-portone-description": "요청된 본인인증에 대한 확인을 진행합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/ConfirmIdentityVerificationError"
         }
@@ -5614,14 +5615,14 @@
     },
     "/identity-verifications/{identityVerificationId}/resend": {
       "post": {
-        "summary": "<p>SMS 본인인증 요청 재전송</p>\n",
-        "description": "<p>SMS 본인인증 요청 재전송</p>\n<p>SMS 본인인증 요청을 재전송합니다.</p>\n",
+        "summary": "SMS 본인인증 요청 재전송",
+        "description": "SMS 본인인증 요청 재전송\n\nSMS 본인인증 요청을 재전송합니다.",
         "operationId": "resendIdentityVerification",
         "parameters": [
           {
             "name": "identityVerificationId",
             "in": "path",
-            "description": "<p>본인인증 아이디</p>\n",
+            "description": "본인인증 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -5631,18 +5632,18 @@
           {
             "name": "storeId",
             "in": "query",
-            "description": "<p>상점 아이디</p>\n<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n",
+            "description": "상점 아이디\n\n접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.",
             "required": false,
             "schema": {
               "type": "string"
             },
             "x-portone-title": "상점 아이디",
-            "x-portone-description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "x-portone-description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다."
           }
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답",
             "content": {
               "application/json": {
                 "schema": {
@@ -5653,7 +5654,7 @@
             "x-portone-title": "성공 응답"
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5663,7 +5664,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5673,7 +5674,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5683,7 +5684,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>IdentityVerificationNotFoundError</code>: 요청된 본인인증 건이 존재하지 않는 경우</li>\n<li><code>IdentityVerificationNotSentError</code>: 본인인증 건이 API로 요청된 상태가 아닌 경우</li>\n</ul>\n",
+            "description": "* `IdentityVerificationNotFoundError`: 요청된 본인인증 건이 존재하지 않는 경우\n* `IdentityVerificationNotSentError`: 본인인증 건이 API로 요청된 상태가 아닌 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5693,7 +5694,7 @@
             }
           },
           "409": {
-            "description": "<ul>\n<li><code>IdentityVerificationAlreadyVerifiedError</code>: 본인인증 건이 이미 인증 완료된 상태인 경우</li>\n</ul>\n",
+            "description": "* `IdentityVerificationAlreadyVerifiedError`: 본인인증 건이 이미 인증 완료된 상태인 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5703,7 +5704,7 @@
             }
           },
           "502": {
-            "description": "<ul>\n<li><code>PgProviderError</code>: PG사에서 오류를 전달한 경우</li>\n</ul>\n",
+            "description": "* `PgProviderError`: PG사에서 오류를 전달한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5723,7 +5724,7 @@
         ],
         "x-portone-category": "identityVerification",
         "x-portone-title": "SMS 본인인증 요청 재전송",
-        "x-portone-description": "<p>SMS 본인인증 요청을 재전송합니다.</p>\n",
+        "x-portone-description": "SMS 본인인증 요청을 재전송합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/ResendIdentityVerificationError"
         }
@@ -5731,14 +5732,14 @@
     },
     "/payments/{paymentId}/pre-register": {
       "post": {
-        "summary": "<p>결제 정보 사전 등록</p>\n",
-        "description": "<p>결제 정보 사전 등록</p>\n<p>결제 정보를 사전 등록합니다.</p>\n",
+        "summary": "결제 정보 사전 등록",
+        "description": "결제 정보 사전 등록\n\n결제 정보를 사전 등록합니다.",
         "operationId": "preRegisterPayment",
         "parameters": [
           {
             "name": "paymentId",
             "in": "path",
-            "description": "<p>결제 건 아이디</p>\n",
+            "description": "결제 건 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -5758,7 +5759,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답",
             "content": {
               "application/json": {
                 "schema": {
@@ -5769,7 +5770,7 @@
             "x-portone-title": "성공 응답"
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5779,7 +5780,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5789,7 +5790,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5799,7 +5800,7 @@
             }
           },
           "409": {
-            "description": "<ul>\n<li><code>AlreadyPaidError</code>: 결제가 이미 완료된 경우</li>\n</ul>\n",
+            "description": "* `AlreadyPaidError`: 결제가 이미 완료된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5819,7 +5820,7 @@
         ],
         "x-portone-category": "payment",
         "x-portone-title": "결제 정보 사전 등록",
-        "x-portone-description": "<p>결제 정보를 사전 등록합니다.</p>\n",
+        "x-portone-description": "결제 정보를 사전 등록합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/PreRegisterPaymentError"
         }
@@ -5827,14 +5828,14 @@
     },
     "/billing-keys/{billingKey}": {
       "get": {
-        "summary": "<p>빌링키 단건 조회</p>\n",
-        "description": "<p>빌링키 단건 조회</p>\n<p>주어진 빌링키에 대응되는 빌링키 정보를 조회합니다.</p>\n",
+        "summary": "빌링키 단건 조회",
+        "description": "빌링키 단건 조회\n\n주어진 빌링키에 대응되는 빌링키 정보를 조회합니다.",
         "operationId": "getBillingKeyInfo",
         "parameters": [
           {
             "name": "billingKey",
             "in": "path",
-            "description": "<p>조회할 빌링키</p>\n",
+            "description": "조회할 빌링키",
             "required": true,
             "schema": {
               "type": "string"
@@ -5844,18 +5845,18 @@
           {
             "name": "storeId",
             "in": "query",
-            "description": "<p>상점 아이디</p>\n<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n",
+            "description": "상점 아이디\n\n접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.",
             "required": false,
             "schema": {
               "type": "string"
             },
             "x-portone-title": "상점 아이디",
-            "x-portone-description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "x-portone-description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다."
           }
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 빌링키 정보를 반환합니다.</p>\n",
+            "description": "성공 응답으로 빌링키 정보를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -5863,10 +5864,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 빌링키 정보를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 빌링키 정보를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5876,7 +5877,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5886,7 +5887,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5896,7 +5897,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>BillingKeyNotFoundError</code>: 빌링키가 존재하지 않는 경우</li>\n</ul>\n",
+            "description": "* `BillingKeyNotFoundError`: 빌링키가 존재하지 않는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5916,20 +5917,20 @@
         ],
         "x-portone-category": "billingKey",
         "x-portone-title": "빌링키 단건 조회",
-        "x-portone-description": "<p>주어진 빌링키에 대응되는 빌링키 정보를 조회합니다.</p>\n",
+        "x-portone-description": "주어진 빌링키에 대응되는 빌링키 정보를 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetBillingKeyInfoError"
         }
       },
       "delete": {
-        "summary": "<p>빌링키 삭제</p>\n",
-        "description": "<p>빌링키 삭제</p>\n<p>빌링키를 삭제합니다.</p>\n",
+        "summary": "빌링키 삭제",
+        "description": "빌링키 삭제\n\n빌링키를 삭제합니다.",
         "operationId": "deleteBillingKey",
         "parameters": [
           {
             "name": "billingKey",
             "in": "path",
-            "description": "<p>삭제할 빌링키</p>\n",
+            "description": "삭제할 빌링키",
             "required": true,
             "schema": {
               "type": "string"
@@ -5939,18 +5940,18 @@
           {
             "name": "storeId",
             "in": "query",
-            "description": "<p>상점 아이디</p>\n<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n",
+            "description": "상점 아이디\n\n접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.",
             "required": false,
             "schema": {
               "type": "string"
             },
             "x-portone-title": "상점 아이디",
-            "x-portone-description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "x-portone-description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다."
           }
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답",
             "content": {
               "application/json": {
                 "schema": {
@@ -5961,7 +5962,7 @@
             "x-portone-title": "성공 응답"
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5971,7 +5972,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5981,7 +5982,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -5991,7 +5992,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>BillingKeyNotIssuedError</code></li>\n<li><code>BillingKeyNotFoundError</code>: 빌링키가 존재하지 않는 경우</li>\n</ul>\n",
+            "description": "* `BillingKeyNotIssuedError`\n* `BillingKeyNotFoundError`: 빌링키가 존재하지 않는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6001,7 +6002,7 @@
             }
           },
           "409": {
-            "description": "<ul>\n<li><code>BillingKeyAlreadyDeletedError</code>: 빌링키가 이미 삭제된 경우</li>\n<li><code>PaymentScheduleAlreadyExistsError</code>: 결제 예약건이 이미 존재하는 경우</li>\n</ul>\n",
+            "description": "* `BillingKeyAlreadyDeletedError`: 빌링키가 이미 삭제된 경우\n* `PaymentScheduleAlreadyExistsError`: 결제 예약건이 이미 존재하는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6011,7 +6012,7 @@
             }
           },
           "502": {
-            "description": "<ul>\n<li><code>PgProviderError</code>: PG사에서 오류를 전달한 경우</li>\n<li><code>ChannelSpecificError</code>: 여러 채널을 지정한 요청에서, 채널 각각에서 오류가 발생한 경우</li>\n</ul>\n",
+            "description": "* `PgProviderError`: PG사에서 오류를 전달한 경우\n* `ChannelSpecificError`: 여러 채널을 지정한 요청에서, 채널 각각에서 오류가 발생한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6031,7 +6032,7 @@
         ],
         "x-portone-category": "billingKey",
         "x-portone-title": "빌링키 삭제",
-        "x-portone-description": "<p>빌링키를 삭제합니다.</p>\n",
+        "x-portone-description": "빌링키를 삭제합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/DeleteBillingKeyError"
         }
@@ -6039,8 +6040,8 @@
     },
     "/billing-keys": {
       "get": {
-        "summary": "<p>빌링키 다건 조회</p>\n",
-        "description": "<p>빌링키 다건 조회</p>\n<p>주어진 조건에 맞는 빌링키들을 페이지 기반으로 조회합니다.</p>\n",
+        "summary": "빌링키 다건 조회",
+        "description": "빌링키 다건 조회\n\n주어진 조건에 맞는 빌링키들을 페이지 기반으로 조회합니다.",
         "operationId": "getBillingKeyInfos",
         "parameters": [
           {
@@ -6072,7 +6073,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 조회된 빌링키 리스트와 페이지 정보가 반환됩니다.</p>\n",
+            "description": "성공 응답으로 조회된 빌링키 리스트와 페이지 정보가 반환됩니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -6083,7 +6084,7 @@
             "x-portone-title": "성공 응답으로 조회된 빌링키 리스트와 페이지 정보가 반환됩니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6093,7 +6094,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6103,7 +6104,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6123,14 +6124,14 @@
         ],
         "x-portone-category": "billingKey",
         "x-portone-title": "빌링키 다건 조회",
-        "x-portone-description": "<p>주어진 조건에 맞는 빌링키들을 페이지 기반으로 조회합니다.</p>\n",
+        "x-portone-description": "주어진 조건에 맞는 빌링키들을 페이지 기반으로 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetBillingKeyInfosError"
         }
       },
       "post": {
-        "summary": "<p>빌링키 발급</p>\n",
-        "description": "<p>빌링키 발급</p>\n<p>빌링키 발급을 요청합니다.</p>\n",
+        "summary": "빌링키 발급",
+        "description": "빌링키 발급\n\n빌링키 발급을 요청합니다.",
         "operationId": "issueBillingKey",
         "requestBody": {
           "content": {
@@ -6144,7 +6145,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답",
             "content": {
               "application/json": {
                 "schema": {
@@ -6155,7 +6156,7 @@
             "x-portone-title": "성공 응답"
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6165,7 +6166,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6175,7 +6176,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6185,7 +6186,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>ChannelNotFoundError</code>: 요청된 채널이 존재하지 않는 경우</li>\n</ul>\n",
+            "description": "* `ChannelNotFoundError`: 요청된 채널이 존재하지 않는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6195,7 +6196,7 @@
             }
           },
           "502": {
-            "description": "<ul>\n<li><code>PgProviderError</code>: PG사에서 오류를 전달한 경우</li>\n<li><code>ChannelSpecificError</code>: 여러 채널을 지정한 요청에서, 채널 각각에서 오류가 발생한 경우</li>\n</ul>\n",
+            "description": "* `PgProviderError`: PG사에서 오류를 전달한 경우\n* `ChannelSpecificError`: 여러 채널을 지정한 요청에서, 채널 각각에서 오류가 발생한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6215,7 +6216,7 @@
         ],
         "x-portone-category": "billingKey",
         "x-portone-title": "빌링키 발급",
-        "x-portone-description": "<p>빌링키 발급을 요청합니다.</p>\n",
+        "x-portone-description": "빌링키 발급을 요청합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/IssueBillingKeyError"
         }
@@ -6223,14 +6224,14 @@
     },
     "/payments/{paymentId}/cash-receipt": {
       "get": {
-        "summary": "<p>현금 영수증 단건 조회</p>\n",
-        "description": "<p>현금 영수증 단건 조회</p>\n<p>주어진 결제 아이디에 대응되는 현금 영수증 내역을 조회합니다.</p>\n",
+        "summary": "현금 영수증 단건 조회",
+        "description": "현금 영수증 단건 조회\n\n주어진 결제 아이디에 대응되는 현금 영수증 내역을 조회합니다.",
         "operationId": "getCashReceiptByPaymentId",
         "parameters": [
           {
             "name": "paymentId",
             "in": "path",
-            "description": "<p>결제 건 아이디</p>\n",
+            "description": "결제 건 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -6240,18 +6241,18 @@
           {
             "name": "storeId",
             "in": "query",
-            "description": "<p>상점 아이디</p>\n<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n",
+            "description": "상점 아이디\n\n접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.",
             "required": false,
             "schema": {
               "type": "string"
             },
             "x-portone-title": "상점 아이디",
-            "x-portone-description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "x-portone-description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다."
           }
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 현금 영수증 객체를 반환합니다.</p>\n",
+            "description": "성공 응답으로 현금 영수증 객체를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -6259,10 +6260,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 현금 영수증 객체를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 현금 영수증 객체를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6272,7 +6273,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6282,7 +6283,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6292,7 +6293,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>CashReceiptNotFoundError</code>: 현금영수증이 존재하지 않는 경우</li>\n</ul>\n",
+            "description": "* `CashReceiptNotFoundError`: 현금영수증이 존재하지 않는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6312,7 +6313,7 @@
         ],
         "x-portone-category": "cashReceipt",
         "x-portone-title": "현금 영수증 단건 조회",
-        "x-portone-description": "<p>주어진 결제 아이디에 대응되는 현금 영수증 내역을 조회합니다.</p>\n",
+        "x-portone-description": "주어진 결제 아이디에 대응되는 현금 영수증 내역을 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetCashReceiptError"
         }
@@ -6320,14 +6321,14 @@
     },
     "/payments/{paymentId}": {
       "get": {
-        "summary": "<p>결제 단건 조회</p>\n",
-        "description": "<p>결제 단건 조회</p>\n<p>주어진 아이디에 대응되는 결제 건을 조회합니다.</p>\n",
+        "summary": "결제 단건 조회",
+        "description": "결제 단건 조회\n\n주어진 아이디에 대응되는 결제 건을 조회합니다.",
         "operationId": "getPayment",
         "parameters": [
           {
             "name": "paymentId",
             "in": "path",
-            "description": "<p>조회할 결제 아이디</p>\n",
+            "description": "조회할 결제 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -6337,7 +6338,7 @@
           {
             "name": "storeId",
             "in": "query",
-            "description": "<p>상점 아이디</p>\n",
+            "description": "상점 아이디",
             "required": false,
             "schema": {
               "type": "string"
@@ -6347,7 +6348,7 @@
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 결제 건 객체를 반환합니다.</p>\n",
+            "description": "성공 응답으로 결제 건 객체를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -6358,7 +6359,7 @@
             "x-portone-title": "성공 응답으로 결제 건 객체를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6368,7 +6369,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6378,7 +6379,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6388,7 +6389,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PaymentNotFoundError</code>: 결제 건이 존재하지 않는 경우</li>\n</ul>\n",
+            "description": "* `PaymentNotFoundError`: 결제 건이 존재하지 않는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6408,7 +6409,7 @@
         ],
         "x-portone-category": "payment",
         "x-portone-title": "결제 단건 조회",
-        "x-portone-description": "<p>주어진 아이디에 대응되는 결제 건을 조회합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 결제 건을 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPaymentError"
         }
@@ -6416,8 +6417,8 @@
     },
     "/payments": {
       "get": {
-        "summary": "<p>결제 다건 조회(페이지 기반)</p>\n",
-        "description": "<p>결제 다건 조회(페이지 기반)</p>\n<p>주어진 조건에 맞는 결제 건들을 페이지 기반으로 조회합니다.</p>\n",
+        "summary": "결제 다건 조회(페이지 기반)",
+        "description": "결제 다건 조회(페이지 기반)\n\n주어진 조건에 맞는 결제 건들을 페이지 기반으로 조회합니다.",
         "operationId": "getPayments",
         "parameters": [
           {
@@ -6449,7 +6450,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 조회된 결제 건 리스트와 페이지 정보가 반환됩니다.</p>\n",
+            "description": "성공 응답으로 조회된 결제 건 리스트와 페이지 정보가 반환됩니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -6460,7 +6461,7 @@
             "x-portone-title": "성공 응답으로 조회된 결제 건 리스트와 페이지 정보가 반환됩니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6470,7 +6471,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6480,7 +6481,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6500,7 +6501,7 @@
         ],
         "x-portone-category": "payment",
         "x-portone-title": "결제 다건 조회(페이지 기반)",
-        "x-portone-description": "<p>주어진 조건에 맞는 결제 건들을 페이지 기반으로 조회합니다.</p>\n",
+        "x-portone-description": "주어진 조건에 맞는 결제 건들을 페이지 기반으로 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPaymentsError"
         }
@@ -6508,8 +6509,8 @@
     },
     "/payments-by-cursor": {
       "get": {
-        "summary": "<p>결제 대용량 다건 조회(커서 기반)</p>\n",
-        "description": "<p>결제 대용량 다건 조회(커서 기반)</p>\n<p>기간 내 모든 결제 건을 커서 기반으로 조회합니다. 결제 건의 생성일시를 기준으로 주어진 기간 내 존재하는 모든 결제 건이 조회됩니다.</p>\n",
+        "summary": "결제 대용량 다건 조회(커서 기반)",
+        "description": "결제 대용량 다건 조회(커서 기반)\n\n기간 내 모든 결제 건을 커서 기반으로 조회합니다. 결제 건의 생성일시를 기준으로 주어진 기간 내 존재하는 모든 결제 건이 조회됩니다.",
         "operationId": "getAllPaymentsByCursor",
         "parameters": [
           {
@@ -6541,7 +6542,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 조회된 결제 건 리스트와 커서 정보가 반환됩니다.</p>\n",
+            "description": "성공 응답으로 조회된 결제 건 리스트와 커서 정보가 반환됩니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -6552,7 +6553,7 @@
             "x-portone-title": "성공 응답으로 조회된 결제 건 리스트와 커서 정보가 반환됩니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6562,7 +6563,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6572,7 +6573,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6592,7 +6593,7 @@
         ],
         "x-portone-category": "payment",
         "x-portone-title": "결제 대용량 다건 조회(커서 기반)",
-        "x-portone-description": "<p>기간 내 모든 결제 건을 커서 기반으로 조회합니다. 결제 건의 생성일시를 기준으로 주어진 기간 내 존재하는 모든 결제 건이 조회됩니다.</p>\n",
+        "x-portone-description": "기간 내 모든 결제 건을 커서 기반으로 조회합니다. 결제 건의 생성일시를 기준으로 주어진 기간 내 존재하는 모든 결제 건이 조회됩니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetAllPaymentsError"
         },
@@ -6601,14 +6602,14 @@
     },
     "/payment-schedules/{paymentScheduleId}": {
       "get": {
-        "summary": "<p>결제 예약 단건 조회</p>\n",
-        "description": "<p>결제 예약 단건 조회</p>\n<p>주어진 아이디에 대응되는 결제 예약 건을 조회합니다.</p>\n",
+        "summary": "결제 예약 단건 조회",
+        "description": "결제 예약 단건 조회\n\n주어진 아이디에 대응되는 결제 예약 건을 조회합니다.",
         "operationId": "getPaymentSchedule",
         "parameters": [
           {
             "name": "paymentScheduleId",
             "in": "path",
-            "description": "<p>조회할 결제 예약 건 아이디</p>\n",
+            "description": "조회할 결제 예약 건 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -6618,18 +6619,18 @@
           {
             "name": "storeId",
             "in": "query",
-            "description": "<p>상점 아이디</p>\n<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n",
+            "description": "상점 아이디\n\n접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.",
             "required": false,
             "schema": {
               "type": "string"
             },
             "x-portone-title": "상점 아이디",
-            "x-portone-description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "x-portone-description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다."
           }
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 결제 예약 건 객체를 반환합니다.</p>\n",
+            "description": "성공 응답으로 결제 예약 건 객체를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -6640,7 +6641,7 @@
             "x-portone-title": "성공 응답으로 결제 예약 건 객체를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6650,7 +6651,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6660,7 +6661,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6670,7 +6671,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PaymentScheduleNotFoundError</code>: 결제 예약건이 존재하지 않는 경우</li>\n</ul>\n",
+            "description": "* `PaymentScheduleNotFoundError`: 결제 예약건이 존재하지 않는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6690,7 +6691,7 @@
         ],
         "x-portone-category": "paymentSchedule",
         "x-portone-title": "결제 예약 단건 조회",
-        "x-portone-description": "<p>주어진 아이디에 대응되는 결제 예약 건을 조회합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 결제 예약 건을 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPaymentScheduleError"
         }
@@ -6698,8 +6699,8 @@
     },
     "/payment-schedules": {
       "get": {
-        "summary": "<p>결제 예약 다건 조회</p>\n",
-        "description": "<p>결제 예약 다건 조회</p>\n<p>주어진 조건에 맞는 결제 예약 건들을 조회합니다.\n<code>filter.from</code>, <code>filter.until</code> 파라미터의 기본값이 결제 시점 기준 지난 90일에 속하는 건을 조회하도록 되어 있으니, 미래 예약 상태의 건을 조회하기 위해서는 해당 파라미터를 직접 설정해 주셔야 합니다.</p>\n",
+        "summary": "결제 예약 다건 조회",
+        "description": "결제 예약 다건 조회\n\n주어진 조건에 맞는 결제 예약 건들을 조회합니다.\n`filter.from`, `filter.until` 파라미터의 기본값이 결제 시점 기준 지난 90일에 속하는 건을 조회하도록 되어 있으니, 미래 예약 상태의 건을 조회하기 위해서는 해당 파라미터를 직접 설정해 주셔야 합니다.",
         "operationId": "getPaymentSchedules",
         "parameters": [
           {
@@ -6731,7 +6732,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 조회된 예약 결제 건 리스트가 반환됩니다.</p>\n",
+            "description": "성공 응답으로 조회된 예약 결제 건 리스트가 반환됩니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -6739,10 +6740,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 조회된 예약 결제 건 리스트가 반환됩니다.</p>\n"
+            "x-portone-description": "성공 응답으로 조회된 예약 결제 건 리스트가 반환됩니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6752,7 +6753,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6762,7 +6763,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6782,14 +6783,14 @@
         ],
         "x-portone-category": "paymentSchedule",
         "x-portone-title": "결제 예약 다건 조회",
-        "x-portone-description": "<p>주어진 조건에 맞는 결제 예약 건들을 조회합니다.\n<code>filter.from</code>, <code>filter.until</code> 파라미터의 기본값이 결제 시점 기준 지난 90일에 속하는 건을 조회하도록 되어 있으니, 미래 예약 상태의 건을 조회하기 위해서는 해당 파라미터를 직접 설정해 주셔야 합니다.</p>\n",
+        "x-portone-description": "주어진 조건에 맞는 결제 예약 건들을 조회합니다.\n`filter.from`, `filter.until` 파라미터의 기본값이 결제 시점 기준 지난 90일에 속하는 건을 조회하도록 되어 있으니, 미래 예약 상태의 건을 조회하기 위해서는 해당 파라미터를 직접 설정해 주셔야 합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPaymentSchedulesError"
         }
       },
       "delete": {
-        "summary": "<p>결제 예약 취소</p>\n",
-        "description": "<p>결제 예약 취소</p>\n<p>결제 예약 건을 취소합니다.</p>\n",
+        "summary": "결제 예약 취소",
+        "description": "결제 예약 취소\n\n결제 예약 건을 취소합니다.",
         "operationId": "revokePaymentSchedules",
         "parameters": [
           {
@@ -6821,7 +6822,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답",
             "content": {
               "application/json": {
                 "schema": {
@@ -6832,7 +6833,7 @@
             "x-portone-title": "성공 응답"
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6842,7 +6843,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6852,7 +6853,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6862,7 +6863,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PaymentScheduleNotFoundError</code>: 결제 예약건이 존재하지 않는 경우</li>\n<li><code>BillingKeyNotFoundError</code>: 빌링키가 존재하지 않는 경우</li>\n</ul>\n",
+            "description": "* `PaymentScheduleNotFoundError`: 결제 예약건이 존재하지 않는 경우\n* `BillingKeyNotFoundError`: 빌링키가 존재하지 않는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6872,7 +6873,7 @@
             }
           },
           "409": {
-            "description": "<ul>\n<li><code>PaymentScheduleAlreadyProcessedError</code>: 결제 예약건이 이미 처리된 경우</li>\n<li><code>PaymentScheduleAlreadyRevokedError</code>: 결제 예약건이 이미 취소된 경우</li>\n<li><code>BillingKeyAlreadyDeletedError</code>: 빌링키가 이미 삭제된 경우</li>\n</ul>\n",
+            "description": "* `PaymentScheduleAlreadyProcessedError`: 결제 예약건이 이미 처리된 경우\n* `PaymentScheduleAlreadyRevokedError`: 결제 예약건이 이미 취소된 경우\n* `BillingKeyAlreadyDeletedError`: 빌링키가 이미 삭제된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6892,7 +6893,7 @@
         ],
         "x-portone-category": "paymentSchedule",
         "x-portone-title": "결제 예약 취소",
-        "x-portone-description": "<p>결제 예약 건을 취소합니다.</p>\n",
+        "x-portone-description": "결제 예약 건을 취소합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/RevokePaymentSchedulesError"
         }
@@ -6900,14 +6901,14 @@
     },
     "/payments/{paymentId}/schedule": {
       "post": {
-        "summary": "<p>결제 예약</p>\n",
-        "description": "<p>결제 예약</p>\n<p>결제를 예약합니다.</p>\n",
+        "summary": "결제 예약",
+        "description": "결제 예약\n\n결제를 예약합니다.",
         "operationId": "createPaymentSchedule",
         "parameters": [
           {
             "name": "paymentId",
             "in": "path",
-            "description": "<p>결제 건 아이디</p>\n",
+            "description": "결제 건 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -6927,7 +6928,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답",
             "content": {
               "application/json": {
                 "schema": {
@@ -6938,7 +6939,7 @@
             "x-portone-title": "성공 응답"
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6948,7 +6949,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6958,7 +6959,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6968,7 +6969,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>BillingKeyNotFoundError</code>: 빌링키가 존재하지 않는 경우</li>\n</ul>\n",
+            "description": "* `BillingKeyNotFoundError`: 빌링키가 존재하지 않는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6978,7 +6979,7 @@
             }
           },
           "409": {
-            "description": "<ul>\n<li><code>AlreadyPaidOrWaitingError</code>: 결제가 이미 완료되었거나 대기중인 경우</li>\n<li><code>SumOfPartsExceedsTotalAmountError</code>: 면세 금액 등 하위 항목들의 합이 전체 결제 금액을 초과한 경우</li>\n<li><code>BillingKeyAlreadyDeletedError</code>: 빌링키가 이미 삭제된 경우</li>\n<li><code>PaymentScheduleAlreadyExistsError</code>: 결제 예약건이 이미 존재하는 경우</li>\n</ul>\n",
+            "description": "* `AlreadyPaidOrWaitingError`: 결제가 이미 완료되었거나 대기중인 경우\n* `SumOfPartsExceedsTotalAmountError`: 면세 금액 등 하위 항목들의 합이 전체 결제 금액을 초과한 경우\n* `BillingKeyAlreadyDeletedError`: 빌링키가 이미 삭제된 경우\n* `PaymentScheduleAlreadyExistsError`: 결제 예약건이 이미 존재하는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -6998,7 +6999,7 @@
         ],
         "x-portone-category": "paymentSchedule",
         "x-portone-title": "결제 예약",
-        "x-portone-description": "<p>결제를 예약합니다.</p>\n",
+        "x-portone-description": "결제를 예약합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/CreatePaymentScheduleError"
         }
@@ -7006,14 +7007,14 @@
     },
     "/payments/{paymentId}/cancel": {
       "post": {
-        "summary": "<p>결제 취소</p>\n",
-        "description": "<p>결제 취소</p>\n<p>결제 취소를 요청합니다.</p>\n",
+        "summary": "결제 취소",
+        "description": "결제 취소\n\n결제 취소를 요청합니다.",
         "operationId": "cancelPayment",
         "parameters": [
           {
             "name": "paymentId",
             "in": "path",
-            "description": "<p>결제 건 아이디</p>\n",
+            "description": "결제 건 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -7033,7 +7034,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답",
             "content": {
               "application/json": {
                 "schema": {
@@ -7044,7 +7045,7 @@
             "x-portone-title": "성공 응답"
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7054,7 +7055,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7064,7 +7065,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7074,7 +7075,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PaymentNotFoundError</code>: 결제 건이 존재하지 않는 경우</li>\n</ul>\n",
+            "description": "* `PaymentNotFoundError`: 결제 건이 존재하지 않는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7084,7 +7085,7 @@
             }
           },
           "409": {
-            "description": "<ul>\n<li><code>PaymentNotPaidError</code>: 결제가 완료되지 않은 경우</li>\n<li><code>PaymentAlreadyCancelledError</code>: 결제가 이미 취소된 경우</li>\n<li><code>CancellableAmountConsistencyBrokenError</code>: 취소 가능 잔액 검증에 실패한 경우</li>\n<li><code>CancelAmountExceedsCancellableAmountError</code>: 결제 취소 금액이 취소 가능 금액을 초과한 경우</li>\n<li><code>SumOfPartsExceedsCancelAmountError</code>: 면세 금액 등 하위 항목들의 합이 전체 취소 금액을 초과한 경우</li>\n<li><code>CancelTaxFreeAmountExceedsCancellableTaxFreeAmountError</code>: 취소 면세 금액이 취소 가능한 면세 금액을 초과한 경우</li>\n<li><code>CancelTaxAmountExceedsCancellableTaxAmountError</code>: 취소 과세 금액이 취소 가능한 과세 금액을 초과한 경우</li>\n<li><code>RemainedAmountLessThanPromotionMinPaymentAmountError</code>: 부분 취소 시, 취소하게 될 경우 남은 금액이 프로모션의 최소 결제 금액보다 작아지는 경우</li>\n</ul>\n",
+            "description": "* `PaymentNotPaidError`: 결제가 완료되지 않은 경우\n* `PaymentAlreadyCancelledError`: 결제가 이미 취소된 경우\n* `CancellableAmountConsistencyBrokenError`: 취소 가능 잔액 검증에 실패한 경우\n* `CancelAmountExceedsCancellableAmountError`: 결제 취소 금액이 취소 가능 금액을 초과한 경우\n* `SumOfPartsExceedsCancelAmountError`: 면세 금액 등 하위 항목들의 합이 전체 취소 금액을 초과한 경우\n* `CancelTaxFreeAmountExceedsCancellableTaxFreeAmountError`: 취소 면세 금액이 취소 가능한 면세 금액을 초과한 경우\n* `CancelTaxAmountExceedsCancellableTaxAmountError`: 취소 과세 금액이 취소 가능한 과세 금액을 초과한 경우\n* `RemainedAmountLessThanPromotionMinPaymentAmountError`: 부분 취소 시, 취소하게 될 경우 남은 금액이 프로모션의 최소 결제 금액보다 작아지는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7094,7 +7095,7 @@
             }
           },
           "502": {
-            "description": "<ul>\n<li><code>PgProviderError</code>: PG사에서 오류를 전달한 경우</li>\n</ul>\n",
+            "description": "* `PgProviderError`: PG사에서 오류를 전달한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7114,7 +7115,7 @@
         ],
         "x-portone-category": "payment",
         "x-portone-title": "결제 취소",
-        "x-portone-description": "<p>결제 취소를 요청합니다.</p>\n",
+        "x-portone-description": "결제 취소를 요청합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/CancelPaymentError"
         }
@@ -7122,14 +7123,14 @@
     },
     "/payments/{paymentId}/billing-key": {
       "post": {
-        "summary": "<p>빌링키 결제</p>\n",
-        "description": "<p>빌링키 결제</p>\n<p>빌링키로 결제를 진행합니다.</p>\n",
+        "summary": "빌링키 결제",
+        "description": "빌링키 결제\n\n빌링키로 결제를 진행합니다.",
         "operationId": "PayWithBillingKey",
         "parameters": [
           {
             "name": "paymentId",
             "in": "path",
-            "description": "<p>결제 건 아이디</p>\n",
+            "description": "결제 건 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -7149,7 +7150,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답",
             "content": {
               "application/json": {
                 "schema": {
@@ -7160,7 +7161,7 @@
             "x-portone-title": "성공 응답"
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n<li><code>PromotionPayMethodDoesNotMatchError</code>: 결제수단이 프로모션에 지정된 것과 일치하지 않는 경우</li>\n<li><code>DiscountAmountExceedsTotalAmountError</code>: 프로모션 할인 금액이 결제 시도 금액 이상인 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우\n* `PromotionPayMethodDoesNotMatchError`: 결제수단이 프로모션에 지정된 것과 일치하지 않는 경우\n* `DiscountAmountExceedsTotalAmountError`: 프로모션 할인 금액이 결제 시도 금액 이상인 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7170,7 +7171,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7180,7 +7181,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7190,7 +7191,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>BillingKeyNotFoundError</code>: 빌링키가 존재하지 않는 경우</li>\n<li><code>ChannelNotFoundError</code>: 요청된 채널이 존재하지 않는 경우</li>\n</ul>\n",
+            "description": "* `BillingKeyNotFoundError`: 빌링키가 존재하지 않는 경우\n* `ChannelNotFoundError`: 요청된 채널이 존재하지 않는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7200,7 +7201,7 @@
             }
           },
           "409": {
-            "description": "<ul>\n<li><code>AlreadyPaidError</code>: 결제가 이미 완료된 경우</li>\n<li><code>SumOfPartsExceedsTotalAmountError</code>: 면세 금액 등 하위 항목들의 합이 전체 결제 금액을 초과한 경우</li>\n<li><code>BillingKeyAlreadyDeletedError</code>: 빌링키가 이미 삭제된 경우</li>\n</ul>\n",
+            "description": "* `AlreadyPaidError`: 결제가 이미 완료된 경우\n* `SumOfPartsExceedsTotalAmountError`: 면세 금액 등 하위 항목들의 합이 전체 결제 금액을 초과한 경우\n* `BillingKeyAlreadyDeletedError`: 빌링키가 이미 삭제된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7210,7 +7211,7 @@
             }
           },
           "502": {
-            "description": "<ul>\n<li><code>PgProviderError</code>: PG사에서 오류를 전달한 경우</li>\n</ul>\n",
+            "description": "* `PgProviderError`: PG사에서 오류를 전달한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7230,7 +7231,7 @@
         ],
         "x-portone-category": "payment",
         "x-portone-title": "빌링키 결제",
-        "x-portone-description": "<p>빌링키로 결제를 진행합니다.</p>\n",
+        "x-portone-description": "빌링키로 결제를 진행합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/PayWithBillingKeyError"
         }
@@ -7238,14 +7239,14 @@
     },
     "/payments/{paymentId}/instant": {
       "post": {
-        "summary": "<p>수기 결제</p>\n",
-        "description": "<p>수기 결제</p>\n<p>수기 결제를 진행합니다.</p>\n",
+        "summary": "수기 결제",
+        "description": "수기 결제\n\n수기 결제를 진행합니다.",
         "operationId": "PayInstantly",
         "parameters": [
           {
             "name": "paymentId",
             "in": "path",
-            "description": "<p>결제 건 아이디</p>\n",
+            "description": "결제 건 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -7265,7 +7266,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답",
             "content": {
               "application/json": {
                 "schema": {
@@ -7276,7 +7277,7 @@
             "x-portone-title": "성공 응답"
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n<li><code>PromotionPayMethodDoesNotMatchError</code>: 결제수단이 프로모션에 지정된 것과 일치하지 않는 경우</li>\n<li><code>DiscountAmountExceedsTotalAmountError</code>: 프로모션 할인 금액이 결제 시도 금액 이상인 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우\n* `PromotionPayMethodDoesNotMatchError`: 결제수단이 프로모션에 지정된 것과 일치하지 않는 경우\n* `DiscountAmountExceedsTotalAmountError`: 프로모션 할인 금액이 결제 시도 금액 이상인 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7286,7 +7287,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7296,7 +7297,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7306,7 +7307,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>ChannelNotFoundError</code>: 요청된 채널이 존재하지 않는 경우</li>\n</ul>\n",
+            "description": "* `ChannelNotFoundError`: 요청된 채널이 존재하지 않는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7316,7 +7317,7 @@
             }
           },
           "409": {
-            "description": "<ul>\n<li><code>AlreadyPaidError</code>: 결제가 이미 완료된 경우</li>\n<li><code>SumOfPartsExceedsTotalAmountError</code>: 면세 금액 등 하위 항목들의 합이 전체 결제 금액을 초과한 경우</li>\n</ul>\n",
+            "description": "* `AlreadyPaidError`: 결제가 이미 완료된 경우\n* `SumOfPartsExceedsTotalAmountError`: 면세 금액 등 하위 항목들의 합이 전체 결제 금액을 초과한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7326,7 +7327,7 @@
             }
           },
           "502": {
-            "description": "<ul>\n<li><code>PgProviderError</code>: PG사에서 오류를 전달한 경우</li>\n</ul>\n",
+            "description": "* `PgProviderError`: PG사에서 오류를 전달한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7346,7 +7347,7 @@
         ],
         "x-portone-category": "payment",
         "x-portone-title": "수기 결제",
-        "x-portone-description": "<p>수기 결제를 진행합니다.</p>\n",
+        "x-portone-description": "수기 결제를 진행합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/PayInstantlyError"
         }
@@ -7354,8 +7355,8 @@
     },
     "/cash-receipts": {
       "post": {
-        "summary": "<p>현금 영수증 수동 발급</p>\n",
-        "description": "<p>현금 영수증 수동 발급</p>\n<p>현금 영수증 발급을 요청합니다.</p>\n",
+        "summary": "현금 영수증 수동 발급",
+        "description": "현금 영수증 수동 발급\n\n현금 영수증 발급을 요청합니다.",
         "operationId": "issueCashReceipt",
         "requestBody": {
           "content": {
@@ -7369,7 +7370,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답",
             "content": {
               "application/json": {
                 "schema": {
@@ -7380,7 +7381,7 @@
             "x-portone-title": "성공 응답"
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7390,7 +7391,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7400,7 +7401,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7410,7 +7411,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>ChannelNotFoundError</code>: 요청된 채널이 존재하지 않는 경우</li>\n</ul>\n",
+            "description": "* `ChannelNotFoundError`: 요청된 채널이 존재하지 않는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7420,7 +7421,7 @@
             }
           },
           "409": {
-            "description": "<ul>\n<li><code>CashReceiptAlreadyIssuedError</code>: 현금영수증이 이미 발급된 경우</li>\n</ul>\n",
+            "description": "* `CashReceiptAlreadyIssuedError`: 현금영수증이 이미 발급된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7430,7 +7431,7 @@
             }
           },
           "502": {
-            "description": "<ul>\n<li><code>PgProviderError</code>: PG사에서 오류를 전달한 경우</li>\n</ul>\n",
+            "description": "* `PgProviderError`: PG사에서 오류를 전달한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7450,7 +7451,7 @@
         ],
         "x-portone-category": "cashReceipt",
         "x-portone-title": "현금 영수증 수동 발급",
-        "x-portone-description": "<p>현금 영수증 발급을 요청합니다.</p>\n",
+        "x-portone-description": "현금 영수증 발급을 요청합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/IssueCashReceiptError"
         }
@@ -7458,14 +7459,14 @@
     },
     "/payments/{paymentId}/cash-receipt/cancel": {
       "post": {
-        "summary": "<p>현금 영수증 취소</p>\n",
-        "description": "<p>현금 영수증 취소</p>\n<p>현금 영수증 취소를 요청합니다.</p>\n",
+        "summary": "현금 영수증 취소",
+        "description": "현금 영수증 취소\n\n현금 영수증 취소를 요청합니다.",
         "operationId": "cancelCashReceiptByPaymentId",
         "parameters": [
           {
             "name": "paymentId",
             "in": "path",
-            "description": "<p>결제 건 아이디</p>\n",
+            "description": "결제 건 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -7475,18 +7476,18 @@
           {
             "name": "storeId",
             "in": "query",
-            "description": "<p>상점 아이디</p>\n<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n",
+            "description": "상점 아이디\n\n접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.",
             "required": false,
             "schema": {
               "type": "string"
             },
             "x-portone-title": "상점 아이디",
-            "x-portone-description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "x-portone-description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다."
           }
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답",
             "content": {
               "application/json": {
                 "schema": {
@@ -7497,7 +7498,7 @@
             "x-portone-title": "성공 응답"
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7507,7 +7508,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7517,7 +7518,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7527,7 +7528,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>CashReceiptNotIssuedError</code>: 현금영수증이 발급되지 않은 경우</li>\n<li><code>CashReceiptNotFoundError</code>: 현금영수증이 존재하지 않는 경우</li>\n</ul>\n",
+            "description": "* `CashReceiptNotIssuedError`: 현금영수증이 발급되지 않은 경우\n* `CashReceiptNotFoundError`: 현금영수증이 존재하지 않는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7537,7 +7538,7 @@
             }
           },
           "502": {
-            "description": "<ul>\n<li><code>PgProviderError</code>: PG사에서 오류를 전달한 경우</li>\n</ul>\n",
+            "description": "* `PgProviderError`: PG사에서 오류를 전달한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7557,7 +7558,7 @@
         ],
         "x-portone-category": "cashReceipt",
         "x-portone-title": "현금 영수증 취소",
-        "x-portone-description": "<p>현금 영수증 취소를 요청합니다.</p>\n",
+        "x-portone-description": "현금 영수증 취소를 요청합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/CancelCashReceiptError"
         }
@@ -7565,14 +7566,14 @@
     },
     "/payments/{paymentId}/virtual-account/close": {
       "post": {
-        "summary": "<p>가상계좌 말소</p>\n",
-        "description": "<p>가상계좌 말소</p>\n<p>발급된 가상계좌를 말소합니다.</p>\n",
+        "summary": "가상계좌 말소",
+        "description": "가상계좌 말소\n\n발급된 가상계좌를 말소합니다.",
         "operationId": "closeVirtualAccount",
         "parameters": [
           {
             "name": "paymentId",
             "in": "path",
-            "description": "<p>결제 건 아이디</p>\n",
+            "description": "결제 건 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -7582,18 +7583,18 @@
           {
             "name": "storeId",
             "in": "query",
-            "description": "<p>상점 아이디</p>\n<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n",
+            "description": "상점 아이디\n\n접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.",
             "required": false,
             "schema": {
               "type": "string"
             },
             "x-portone-title": "상점 아이디",
-            "x-portone-description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "x-portone-description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다."
           }
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답",
             "content": {
               "application/json": {
                 "schema": {
@@ -7604,7 +7605,7 @@
             "x-portone-title": "성공 응답"
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7614,7 +7615,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7624,7 +7625,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7634,7 +7635,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PaymentNotFoundError</code>: 결제 건이 존재하지 않는 경우</li>\n</ul>\n",
+            "description": "* `PaymentNotFoundError`: 결제 건이 존재하지 않는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7644,7 +7645,7 @@
             }
           },
           "409": {
-            "description": "<ul>\n<li><code>PaymentNotWaitingForDepositError</code>: 결제 건이 입금 대기 상태가 아닌 경우</li>\n</ul>\n",
+            "description": "* `PaymentNotWaitingForDepositError`: 결제 건이 입금 대기 상태가 아닌 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7654,7 +7655,7 @@
             }
           },
           "502": {
-            "description": "<ul>\n<li><code>PgProviderError</code>: PG사에서 오류를 전달한 경우</li>\n</ul>\n",
+            "description": "* `PgProviderError`: PG사에서 오류를 전달한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7674,7 +7675,7 @@
         ],
         "x-portone-category": "payment",
         "x-portone-title": "가상계좌 말소",
-        "x-portone-description": "<p>발급된 가상계좌를 말소합니다.</p>\n",
+        "x-portone-description": "발급된 가상계좌를 말소합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/CloseVirtualAccountError"
         }
@@ -7682,14 +7683,14 @@
     },
     "/payments/{paymentId}/escrow/logistics": {
       "post": {
-        "summary": "<p>에스크로 배송 정보 등록</p>\n",
-        "description": "<p>에스크로 배송 정보 등록</p>\n<p>에스크로 배송 정보를 등록합니다.</p>\n",
+        "summary": "에스크로 배송 정보 등록",
+        "description": "에스크로 배송 정보 등록\n\n에스크로 배송 정보를 등록합니다.",
         "operationId": "applyEscrowLogistics",
         "parameters": [
           {
             "name": "paymentId",
             "in": "path",
-            "description": "<p>결제 건 아이디</p>\n",
+            "description": "결제 건 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -7709,7 +7710,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답",
             "content": {
               "application/json": {
                 "schema": {
@@ -7720,7 +7721,7 @@
             "x-portone-title": "성공 응답"
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7730,7 +7731,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7740,7 +7741,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7750,7 +7751,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PaymentNotFoundError</code>: 결제 건이 존재하지 않는 경우</li>\n</ul>\n",
+            "description": "* `PaymentNotFoundError`: 결제 건이 존재하지 않는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7760,7 +7761,7 @@
             }
           },
           "409": {
-            "description": "<ul>\n<li><code>PaymentNotPaidError</code>: 결제가 완료되지 않은 경우</li>\n</ul>\n",
+            "description": "* `PaymentNotPaidError`: 결제가 완료되지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7770,7 +7771,7 @@
             }
           },
           "502": {
-            "description": "<ul>\n<li><code>PgProviderError</code>: PG사에서 오류를 전달한 경우</li>\n</ul>\n",
+            "description": "* `PgProviderError`: PG사에서 오류를 전달한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7790,20 +7791,20 @@
         ],
         "x-portone-category": "payment",
         "x-portone-title": "에스크로 배송 정보 등록",
-        "x-portone-description": "<p>에스크로 배송 정보를 등록합니다.</p>\n",
+        "x-portone-description": "에스크로 배송 정보를 등록합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/ApplyEscrowLogisticsError"
         }
       },
       "patch": {
-        "summary": "<p>에스크로 배송 정보 수정</p>\n",
-        "description": "<p>에스크로 배송 정보 수정</p>\n<p>에스크로 배송 정보를 수정합니다.</p>\n",
+        "summary": "에스크로 배송 정보 수정",
+        "description": "에스크로 배송 정보 수정\n\n에스크로 배송 정보를 수정합니다.",
         "operationId": "modifyEscrowLogistics",
         "parameters": [
           {
             "name": "paymentId",
             "in": "path",
-            "description": "<p>결제 건 아이디</p>\n",
+            "description": "결제 건 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -7823,7 +7824,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답",
             "content": {
               "application/json": {
                 "schema": {
@@ -7834,7 +7835,7 @@
             "x-portone-title": "성공 응답"
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7844,7 +7845,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7854,7 +7855,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7864,7 +7865,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PaymentNotFoundError</code>: 결제 건이 존재하지 않는 경우</li>\n</ul>\n",
+            "description": "* `PaymentNotFoundError`: 결제 건이 존재하지 않는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7874,7 +7875,7 @@
             }
           },
           "409": {
-            "description": "<ul>\n<li><code>PaymentNotPaidError</code>: 결제가 완료되지 않은 경우</li>\n</ul>\n",
+            "description": "* `PaymentNotPaidError`: 결제가 완료되지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7884,7 +7885,7 @@
             }
           },
           "502": {
-            "description": "<ul>\n<li><code>PgProviderError</code>: PG사에서 오류를 전달한 경우</li>\n</ul>\n",
+            "description": "* `PgProviderError`: PG사에서 오류를 전달한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7904,7 +7905,7 @@
         ],
         "x-portone-category": "payment",
         "x-portone-title": "에스크로 배송 정보 수정",
-        "x-portone-description": "<p>에스크로 배송 정보를 수정합니다.</p>\n",
+        "x-portone-description": "에스크로 배송 정보를 수정합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/ModifyEscrowLogisticsError"
         }
@@ -7912,14 +7913,14 @@
     },
     "/payments/{paymentId}/escrow/complete": {
       "post": {
-        "summary": "<p>에스크로 구매 확정</p>\n",
-        "description": "<p>에스크로 구매 확정</p>\n<p>에스크로 결제를 구매 확정 처리합니다</p>\n",
+        "summary": "에스크로 구매 확정",
+        "description": "에스크로 구매 확정\n\n에스크로 결제를 구매 확정 처리합니다",
         "operationId": "confirmEscrow",
         "parameters": [
           {
             "name": "paymentId",
             "in": "path",
-            "description": "<p>결제 건 아이디</p>\n",
+            "description": "결제 건 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -7939,7 +7940,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답",
             "content": {
               "application/json": {
                 "schema": {
@@ -7950,7 +7951,7 @@
             "x-portone-title": "성공 응답"
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7960,7 +7961,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7970,7 +7971,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7980,7 +7981,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PaymentNotFoundError</code>: 결제 건이 존재하지 않는 경우</li>\n</ul>\n",
+            "description": "* `PaymentNotFoundError`: 결제 건이 존재하지 않는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -7990,7 +7991,7 @@
             }
           },
           "409": {
-            "description": "<ul>\n<li><code>PaymentNotPaidError</code>: 결제가 완료되지 않은 경우</li>\n</ul>\n",
+            "description": "* `PaymentNotPaidError`: 결제가 완료되지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -8000,7 +8001,7 @@
             }
           },
           "502": {
-            "description": "<ul>\n<li><code>PgProviderError</code>: PG사에서 오류를 전달한 경우</li>\n</ul>\n",
+            "description": "* `PgProviderError`: PG사에서 오류를 전달한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -8020,7 +8021,7 @@
         ],
         "x-portone-category": "payment",
         "x-portone-title": "에스크로 구매 확정",
-        "x-portone-description": "<p>에스크로 결제를 구매 확정 처리합니다</p>\n",
+        "x-portone-description": "에스크로 결제를 구매 확정 처리합니다",
         "x-portone-error": {
           "$ref": "#/components/schemas/ConfirmEscrowError"
         }
@@ -8028,14 +8029,14 @@
     },
     "/payments/{paymentId}/resend-webhook": {
       "post": {
-        "summary": "<p>웹훅 재발송</p>\n",
-        "description": "<p>웹훅 재발송</p>\n<p>웹훅을 재발송합니다.</p>\n",
+        "summary": "웹훅 재발송",
+        "description": "웹훅 재발송\n\n웹훅을 재발송합니다.",
         "operationId": "resendWebhook",
         "parameters": [
           {
             "name": "paymentId",
             "in": "path",
-            "description": "<p>결제 건 아이디</p>\n",
+            "description": "결제 건 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -8055,7 +8056,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답",
             "content": {
               "application/json": {
                 "schema": {
@@ -8066,7 +8067,7 @@
             "x-portone-title": "성공 응답"
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -8076,7 +8077,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -8086,7 +8087,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -8096,7 +8097,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PaymentNotFoundError</code>: 결제 건이 존재하지 않는 경우</li>\n<li><code>WebhookNotFoundError</code>: 웹훅 내역이 존재하지 않는 경우</li>\n</ul>\n",
+            "description": "* `PaymentNotFoundError`: 결제 건이 존재하지 않는 경우\n* `WebhookNotFoundError`: 웹훅 내역이 존재하지 않는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -8116,7 +8117,7 @@
         ],
         "x-portone-category": "payment",
         "x-portone-title": "웹훅 재발송",
-        "x-portone-description": "<p>웹훅을 재발송합니다.</p>\n",
+        "x-portone-description": "웹훅을 재발송합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/ResendWebhookError"
         }
@@ -8125,7 +8126,7 @@
     "/channels": {},
     "/analytics/charts/payment": {
       "get": {
-        "description": "<p>고객사의 결제 현황을 조회합니다.</p>\n",
+        "description": "고객사의 결제 현황을 조회합니다.",
         "operationId": "getAnalyticsPaymentChart",
         "requestBody": {
           "content": {
@@ -8139,7 +8140,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 결제 현황을 반환합니다.</p>\n",
+            "description": "성공 응답으로 결제 현황을 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -8147,10 +8148,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 결제 현황을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 결제 현황을 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -8160,7 +8161,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -8170,7 +8171,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -8189,7 +8190,7 @@
           }
         ],
         "x-portone-category": "analytics",
-        "x-portone-description": "<p>고객사의 결제 현황을 조회합니다.</p>\n",
+        "x-portone-description": "고객사의 결제 현황을 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetAnalyticsPaymentChartError"
         },
@@ -8198,7 +8199,7 @@
     },
     "/analytics/charts/payment-insight": {
       "get": {
-        "description": "<p>고객사의 결제 현황 인사이트를 조회합니다.</p>\n",
+        "description": "고객사의 결제 현황 인사이트를 조회합니다.",
         "operationId": "getAnalyticsPaymentChartInsight",
         "requestBody": {
           "content": {
@@ -8212,7 +8213,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 결제 현황 인사이트를 반환합니다.</p>\n",
+            "description": "성공 응답으로 결제 현황 인사이트를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -8220,10 +8221,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 결제 현황 인사이트를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 결제 현황 인사이트를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -8233,7 +8234,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -8243,7 +8244,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -8262,7 +8263,7 @@
           }
         ],
         "x-portone-category": "analytics",
-        "x-portone-description": "<p>고객사의 결제 현황 인사이트를 조회합니다.</p>\n",
+        "x-portone-description": "고객사의 결제 현황 인사이트를 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetAnalyticsPaymentChartInsightError"
         },
@@ -8271,7 +8272,7 @@
     },
     "/analytics/charts/average-amount": {
       "get": {
-        "description": "<p>고객사의 평균 거래액 현황을 조회합니다.</p>\n",
+        "description": "고객사의 평균 거래액 현황을 조회합니다.",
         "operationId": "getAverageAmountChart",
         "requestBody": {
           "content": {
@@ -8285,7 +8286,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 평균 거래액 현황을 반환합니다.</p>\n",
+            "description": "성공 응답으로 평균 거래액 현황을 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -8293,10 +8294,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 평균 거래액 현황을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 평균 거래액 현황을 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -8306,7 +8307,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -8316,7 +8317,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -8335,7 +8336,7 @@
           }
         ],
         "x-portone-category": "analytics",
-        "x-portone-description": "<p>고객사의 평균 거래액 현황을 조회합니다.</p>\n",
+        "x-portone-description": "고객사의 평균 거래액 현황을 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetAverageAmountChartError"
         },
@@ -8344,7 +8345,7 @@
     },
     "/analytics/charts/payment-method": {
       "get": {
-        "description": "<p>고객사의 결제수단 현황을 조회합니다.</p>\n",
+        "description": "고객사의 결제수단 현황을 조회합니다.",
         "operationId": "getPaymentMethodChart",
         "requestBody": {
           "content": {
@@ -8358,7 +8359,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 결제수단 현황을 반환합니다.</p>\n",
+            "description": "성공 응답으로 결제수단 현황을 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -8366,10 +8367,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 결제수단 현황을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 결제수단 현황을 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -8379,7 +8380,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -8389,7 +8390,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -8408,7 +8409,7 @@
           }
         ],
         "x-portone-category": "analytics",
-        "x-portone-description": "<p>고객사의 결제수단 현황을 조회합니다.</p>\n",
+        "x-portone-description": "고객사의 결제수단 현황을 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPaymentMethodChartError"
         },
@@ -8417,7 +8418,7 @@
     },
     "/analytics/charts/payment-method-trend": {
       "get": {
-        "description": "<p>고객사의 결제수단 트렌드를 조회합니다.</p>\n",
+        "description": "고객사의 결제수단 트렌드를 조회합니다.",
         "operationId": "getPaymentMethodTrendChart",
         "requestBody": {
           "content": {
@@ -8431,7 +8432,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 결제수단 트렌드를 반환합니다.</p>\n",
+            "description": "성공 응답으로 결제수단 트렌드를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -8439,10 +8440,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 결제수단 트렌드를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 결제수단 트렌드를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -8452,7 +8453,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -8462,7 +8463,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -8481,7 +8482,7 @@
           }
         ],
         "x-portone-category": "analytics",
-        "x-portone-description": "<p>고객사의 결제수단 트렌드를 조회합니다.</p>\n",
+        "x-portone-description": "고객사의 결제수단 트렌드를 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPaymentMethodTrendChartError"
         },
@@ -8490,7 +8491,7 @@
     },
     "/analytics/charts/card": {
       "get": {
-        "description": "<p>고객사의 카드결제 현황을 조회합니다.</p>\n",
+        "description": "고객사의 카드결제 현황을 조회합니다.",
         "operationId": "getAnalyticsCardChart",
         "requestBody": {
           "content": {
@@ -8504,7 +8505,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 카드결제 현황을 반환합니다.</p>\n",
+            "description": "성공 응답으로 카드결제 현황을 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -8512,10 +8513,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 카드결제 현황을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 카드결제 현황을 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -8525,7 +8526,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -8535,7 +8536,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -8554,7 +8555,7 @@
           }
         ],
         "x-portone-category": "analytics",
-        "x-portone-description": "<p>고객사의 카드결제 현황을 조회합니다.</p>\n",
+        "x-portone-description": "고객사의 카드결제 현황을 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetAnalyticsCardChartError"
         },
@@ -8563,7 +8564,7 @@
     },
     "/analytics/charts/card-company": {
       "get": {
-        "description": "<p>고객사의 카드사별 결제 현황을 조회합니다.</p>\n",
+        "description": "고객사의 카드사별 결제 현황을 조회합니다.",
         "operationId": "getAnalyticsCardCompanyChart",
         "requestBody": {
           "content": {
@@ -8577,7 +8578,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 카드사별 결제 현황을 반환합니다.</p>\n",
+            "description": "성공 응답으로 카드사별 결제 현황을 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -8585,10 +8586,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 카드사별 결제 현황을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 카드사별 결제 현황을 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -8598,7 +8599,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -8608,7 +8609,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -8627,7 +8628,7 @@
           }
         ],
         "x-portone-category": "analytics",
-        "x-portone-description": "<p>고객사의 카드사별 결제 현황을 조회합니다.</p>\n",
+        "x-portone-description": "고객사의 카드사별 결제 현황을 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetAnalyticsCardCompanyChartError"
         },
@@ -8636,7 +8637,7 @@
     },
     "/analytics/charts/easy-pay": {
       "get": {
-        "description": "<p>고객사의 간편결제 현황을 조회합니다.</p>\n",
+        "description": "고객사의 간편결제 현황을 조회합니다.",
         "operationId": "getAnalyticsEasyPayChart",
         "requestBody": {
           "content": {
@@ -8650,7 +8651,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 간편결제 현황을 반환합니다.</p>\n",
+            "description": "성공 응답으로 간편결제 현황을 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -8658,10 +8659,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 간편결제 현황을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 간편결제 현황을 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -8671,7 +8672,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -8681,7 +8682,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -8700,7 +8701,7 @@
           }
         ],
         "x-portone-category": "analytics",
-        "x-portone-description": "<p>고객사의 간편결제 현황을 조회합니다.</p>\n",
+        "x-portone-description": "고객사의 간편결제 현황을 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetAnalyticsEasyPayChartError"
         },
@@ -8709,7 +8710,7 @@
     },
     "/analytics/charts/easy-pay-provider": {
       "get": {
-        "description": "<p>고객사의 간편결제사별 결제 현황을 조회합니다.</p>\n",
+        "description": "고객사의 간편결제사별 결제 현황을 조회합니다.",
         "operationId": "getAnalyticsEasyPayProviderChart",
         "requestBody": {
           "content": {
@@ -8723,7 +8724,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 간편결제사별 결제 현황을 반환합니다.</p>\n",
+            "description": "성공 응답으로 간편결제사별 결제 현황을 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -8731,10 +8732,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 간편결제사별 결제 현황을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 간편결제사별 결제 현황을 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -8744,7 +8745,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -8754,7 +8755,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -8773,7 +8774,7 @@
           }
         ],
         "x-portone-category": "analytics",
-        "x-portone-description": "<p>고객사의 간편결제사별 결제 현황을 조회합니다.</p>\n",
+        "x-portone-description": "고객사의 간편결제사별 결제 현황을 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetAnalyticsEasyPayProviderChartError"
         },
@@ -8782,7 +8783,7 @@
     },
     "/analytics/charts/pg-company": {
       "get": {
-        "description": "<p>고객사의 결제대행사 현황을 조회합니다.</p>\n",
+        "description": "고객사의 결제대행사 현황을 조회합니다.",
         "operationId": "getPgCompanyChart",
         "requestBody": {
           "content": {
@@ -8796,7 +8797,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 결제대행사 현황을 반환합니다.</p>\n",
+            "description": "성공 응답으로 결제대행사 현황을 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -8804,10 +8805,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 결제대행사 현황을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 결제대행사 현황을 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -8817,7 +8818,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -8827,7 +8828,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -8846,7 +8847,7 @@
           }
         ],
         "x-portone-category": "analytics",
-        "x-portone-description": "<p>고객사의 결제대행사 현황을 조회합니다.</p>\n",
+        "x-portone-description": "고객사의 결제대행사 현황을 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPgCompanyChartError"
         },
@@ -8855,7 +8856,7 @@
     },
     "/analytics/charts/pg-company-trend": {
       "get": {
-        "description": "<p>고객사의 결제대행사별 거래 추이를 조회합니다.</p>\n",
+        "description": "고객사의 결제대행사별 거래 추이를 조회합니다.",
         "operationId": "getPgCompanyTrendChart",
         "requestBody": {
           "content": {
@@ -8869,7 +8870,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 결제대행사별 거래 추이를 반환합니다.</p>\n",
+            "description": "성공 응답으로 결제대행사별 거래 추이를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -8877,10 +8878,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 결제대행사별 거래 추이를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 결제대행사별 거래 추이를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -8890,7 +8891,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -8900,7 +8901,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -8919,7 +8920,7 @@
           }
         ],
         "x-portone-category": "analytics",
-        "x-portone-description": "<p>고객사의 결제대행사별 거래 추이를 조회합니다.</p>\n",
+        "x-portone-description": "고객사의 결제대행사별 거래 추이를 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPgCompanyTrendChartError"
         },
@@ -8928,11 +8929,11 @@
     },
     "/analytics/overseas-payment-usage": {
       "get": {
-        "description": "<p>고객사의 해외 결제 사용 여부를 조회합니다.</p>\n",
+        "description": "고객사의 해외 결제 사용 여부를 조회합니다.",
         "operationId": "getAnalyticsOverseasPaymentUsage",
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 해외 결제 사용 여부을 반환합니다.</p>\n",
+            "description": "성공 응답으로 해외 결제 사용 여부을 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -8940,10 +8941,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 해외 결제 사용 여부을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 해외 결제 사용 여부을 반환합니다."
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -8953,7 +8954,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -8972,7 +8973,7 @@
           }
         ],
         "x-portone-category": "analytics",
-        "x-portone-description": "<p>고객사의 해외 결제 사용 여부를 조회합니다.</p>\n",
+        "x-portone-description": "고객사의 해외 결제 사용 여부를 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetAnalyticsOverseasPaymentUsageError"
         },
@@ -8981,7 +8982,7 @@
     },
     "/analytics/cancellation-rate": {
       "get": {
-        "description": "<p>고객사의 환불율을 조회합니다.</p>\n",
+        "description": "고객사의 환불율을 조회합니다.",
         "operationId": "getAnalyticsCancellationRate",
         "requestBody": {
           "content": {
@@ -8995,7 +8996,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 환불율을 반환합니다.</p>\n",
+            "description": "성공 응답으로 환불율을 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -9003,10 +9004,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 환불율을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 환불율을 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9016,7 +9017,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9026,7 +9027,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9045,7 +9046,7 @@
           }
         ],
         "x-portone-category": "analytics",
-        "x-portone-description": "<p>고객사의 환불율을 조회합니다.</p>\n",
+        "x-portone-description": "고객사의 환불율을 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetAnalyticsCancellationRateError"
         },
@@ -9054,7 +9055,7 @@
     },
     "/analytics/charts/payment-status": {
       "get": {
-        "description": "<p>고객사의 결제상태 이력 집계를 조회합니다.</p>\n",
+        "description": "고객사의 결제상태 이력 집계를 조회합니다.",
         "operationId": "getPaymentStatusChart",
         "requestBody": {
           "content": {
@@ -9068,7 +9069,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 결제상태 이력 집계 결과를 반환합니다.</p>\n",
+            "description": "성공 응답으로 결제상태 이력 집계 결과를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -9076,10 +9077,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 결제상태 이력 집계 결과를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 결제상태 이력 집계 결과를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9089,7 +9090,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9099,7 +9100,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9118,7 +9119,7 @@
           }
         ],
         "x-portone-category": "analytics",
-        "x-portone-description": "<p>고객사의 결제상태 이력 집계를 조회합니다.</p>\n",
+        "x-portone-description": "고객사의 결제상태 이력 집계를 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPaymentStatusChartError"
         },
@@ -9127,7 +9128,7 @@
     },
     "/analytics/charts/payment-status/by-method": {
       "get": {
-        "description": "<p>고객사의 결제수단별 결제전환율을 조회합니다.</p>\n",
+        "description": "고객사의 결제수단별 결제전환율을 조회합니다.",
         "operationId": "getPaymentStatusByPaymentMethodChart",
         "requestBody": {
           "content": {
@@ -9141,7 +9142,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 결제수단별 결제전환율 조회 결과를 반환합니다.</p>\n",
+            "description": "성공 응답으로 결제수단별 결제전환율 조회 결과를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -9149,10 +9150,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 결제수단별 결제전환율 조회 결과를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 결제수단별 결제전환율 조회 결과를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9162,7 +9163,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9172,7 +9173,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9191,7 +9192,7 @@
           }
         ],
         "x-portone-category": "analytics",
-        "x-portone-description": "<p>고객사의 결제수단별 결제전환율을 조회합니다.</p>\n",
+        "x-portone-description": "고객사의 결제수단별 결제전환율을 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPaymentStatusByPaymentMethodChartError"
         },
@@ -9200,7 +9201,7 @@
     },
     "/analytics/charts/payment-status/by-pg-company": {
       "get": {
-        "description": "<p>고객사의 PG사별 결제전환율을 조회합니다.</p>\n",
+        "description": "고객사의 PG사별 결제전환율을 조회합니다.",
         "operationId": "getPaymentStatusByPgCompanyChart",
         "requestBody": {
           "content": {
@@ -9214,7 +9215,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 PG사별 결제전환율 조회 결과를 반환합니다.</p>\n",
+            "description": "성공 응답으로 PG사별 결제전환율 조회 결과를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -9222,10 +9223,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 PG사별 결제전환율 조회 결과를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 PG사별 결제전환율 조회 결과를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9235,7 +9236,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9245,7 +9246,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9264,7 +9265,7 @@
           }
         ],
         "x-portone-category": "analytics",
-        "x-portone-description": "<p>고객사의 PG사별 결제전환율을 조회합니다.</p>\n",
+        "x-portone-description": "고객사의 PG사별 결제전환율을 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPaymentStatusByPgCompanyChartError"
         },
@@ -9273,7 +9274,7 @@
     },
     "/analytics/charts/payment-status/by-payment-client": {
       "get": {
-        "description": "<p>고객사의 결제환경별 결제전환율을 조회합니다.</p>\n",
+        "description": "고객사의 결제환경별 결제전환율을 조회합니다.",
         "operationId": "getPaymentStatusByPaymentClientChart",
         "requestBody": {
           "content": {
@@ -9287,7 +9288,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 결제환경별 결제전환율 조회 결과를 반환합니다.</p>\n",
+            "description": "성공 응답으로 결제환경별 결제전환율 조회 결과를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -9295,10 +9296,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 결제환경별 결제전환율 조회 결과를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 결제환경별 결제전환율 조회 결과를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9308,7 +9309,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9318,7 +9319,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9337,7 +9338,7 @@
           }
         ],
         "x-portone-category": "analytics",
-        "x-portone-description": "<p>고객사의 결제환경별 결제전환율을 조회합니다.</p>\n",
+        "x-portone-description": "고객사의 결제환경별 결제전환율을 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPaymentStatusByPaymentClientChartError"
         },
@@ -9346,14 +9347,14 @@
     },
     "/b2b-preview/member-companies/{brn}": {
       "get": {
-        "summary": "<p>연동 사업자 조회</p>\n",
-        "description": "<p>연동 사업자 조회</p>\n<p>포트원 B2B 서비스에 연동된 사업자를 조회합니다.</p>\n",
+        "summary": "연동 사업자 조회",
+        "description": "연동 사업자 조회\n\n포트원 B2B 서비스에 연동된 사업자를 조회합니다.",
         "operationId": "getB2bMemberCompany",
         "parameters": [
           {
             "name": "brn",
             "in": "path",
-            "description": "<p>사업자등록번호</p>\n",
+            "description": "사업자등록번호",
             "required": true,
             "schema": {
               "type": "string"
@@ -9363,18 +9364,18 @@
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\n\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다."
           }
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 사업자 객체를 반환합니다.</p>\n",
+            "description": "성공 응답으로 사업자 객체를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -9382,10 +9383,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 사업자 객체를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 사업자 객체를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9395,7 +9396,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9405,7 +9406,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>B2bNotEnabledError</code>: B2B 기능이 활성화되지 않은 경우</li>\n</ul>\n",
+            "description": "* `B2bNotEnabledError`: B2B 기능이 활성화되지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9415,7 +9416,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>B2bMemberCompanyNotFoundError</code>: 연동 사업자가 존재하지 않는 경우</li>\n</ul>\n",
+            "description": "* `B2bMemberCompanyNotFoundError`: 연동 사업자가 존재하지 않는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9425,7 +9426,7 @@
             }
           },
           "502": {
-            "description": "<ul>\n<li><code>B2bExternalServiceError</code>: 외부 서비스에서 에러가 발생한 경우</li>\n</ul>\n",
+            "description": "* `B2bExternalServiceError`: 외부 서비스에서 에러가 발생한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9445,32 +9446,32 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "연동 사업자 조회",
-        "x-portone-description": "<p>포트원 B2B 서비스에 연동된 사업자를 조회합니다.</p>\n",
+        "x-portone-description": "포트원 B2B 서비스에 연동된 사업자를 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetB2bMemberCompanyError"
         },
         "x-portone-unstable": true
       },
       "patch": {
-        "summary": "<p>연동 사업자 정보 수정</p>\n",
-        "description": "<p>연동 사업자 정보 수정</p>\n<p>연동 사업자 정보를 수정합니다.</p>\n",
+        "summary": "연동 사업자 정보 수정",
+        "description": "연동 사업자 정보 수정\n\n연동 사업자 정보를 수정합니다.",
         "operationId": "updateB2bMemberCompany",
         "parameters": [
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\n\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다."
           },
           {
             "name": "brn",
             "in": "path",
-            "description": "<p>사업자등록번호</p>\n",
+            "description": "사업자등록번호",
             "required": true,
             "schema": {
               "type": "string"
@@ -9490,7 +9491,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답",
             "content": {
               "application/json": {
                 "schema": {
@@ -9501,7 +9502,7 @@
             "x-portone-title": "성공 응답"
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9511,7 +9512,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9521,7 +9522,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>B2bNotEnabledError</code>: B2B 기능이 활성화되지 않은 경우</li>\n</ul>\n",
+            "description": "* `B2bNotEnabledError`: B2B 기능이 활성화되지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9531,7 +9532,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>B2bMemberCompanyNotFoundError</code>: 연동 사업자가 존재하지 않는 경우</li>\n</ul>\n",
+            "description": "* `B2bMemberCompanyNotFoundError`: 연동 사업자가 존재하지 않는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9551,7 +9552,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "연동 사업자 정보 수정",
-        "x-portone-description": "<p>연동 사업자 정보를 수정합니다.</p>\n",
+        "x-portone-description": "연동 사업자 정보를 수정합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/UpdateB2bMemberCompanyError"
         },
@@ -9560,20 +9561,20 @@
     },
     "/b2b-preview/member-companies": {
       "post": {
-        "summary": "<p>사업자 연동</p>\n",
-        "description": "<p>사업자 연동</p>\n<p>포트원 B2B 서비스에 사업자를 연동합니다.</p>\n",
+        "summary": "사업자 연동",
+        "description": "사업자 연동\n\n포트원 B2B 서비스에 사업자를 연동합니다.",
         "operationId": "registerB2bMemberCompany",
         "parameters": [
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\n\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다."
           }
         ],
         "requestBody": {
@@ -9588,7 +9589,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답",
             "content": {
               "application/json": {
                 "schema": {
@@ -9599,7 +9600,7 @@
             "x-portone-title": "성공 응답"
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9609,7 +9610,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9619,7 +9620,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>B2bNotEnabledError</code>: B2B 기능이 활성화되지 않은 경우</li>\n</ul>\n",
+            "description": "* `B2bNotEnabledError`: B2B 기능이 활성화되지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9629,7 +9630,7 @@
             }
           },
           "409": {
-            "description": "<ul>\n<li><code>B2bIdAlreadyExistsError</code>: ID가 이미 사용중인 경우</li>\n<li><code>B2bCompanyAlreadyRegisteredError</code>: 사업자가 이미 연동되어 있는 경우</li>\n</ul>\n",
+            "description": "* `B2bIdAlreadyExistsError`: ID가 이미 사용중인 경우\n* `B2bCompanyAlreadyRegisteredError`: 사업자가 이미 연동되어 있는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9639,7 +9640,7 @@
             }
           },
           "502": {
-            "description": "<ul>\n<li><code>B2bExternalServiceError</code>: 외부 서비스에서 에러가 발생한 경우</li>\n</ul>\n",
+            "description": "* `B2bExternalServiceError`: 외부 서비스에서 에러가 발생한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9659,7 +9660,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "사업자 연동",
-        "x-portone-description": "<p>포트원 B2B 서비스에 사업자를 연동합니다.</p>\n",
+        "x-portone-description": "포트원 B2B 서비스에 사업자를 연동합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/RegisterB2bMemberCompanyError"
         },
@@ -9668,14 +9669,14 @@
     },
     "/b2b-preview/member-companies/{brn}/contacts/{contactId}": {
       "get": {
-        "summary": "<p>담당자 조회</p>\n",
-        "description": "<p>담당자 조회</p>\n<p>연동 사업자에 등록된 담당자를 조회합니다.</p>\n",
+        "summary": "담당자 조회",
+        "description": "담당자 조회\n\n연동 사업자에 등록된 담당자를 조회합니다.",
         "operationId": "getB2bMemberCompanyContact",
         "parameters": [
           {
             "name": "brn",
             "in": "path",
-            "description": "<p>사업자등록번호</p>\n",
+            "description": "사업자등록번호",
             "required": true,
             "schema": {
               "type": "string"
@@ -9685,7 +9686,7 @@
           {
             "name": "contactId",
             "in": "path",
-            "description": "<p>담당자 ID</p>\n",
+            "description": "담당자 ID",
             "required": true,
             "schema": {
               "type": "string"
@@ -9695,18 +9696,18 @@
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\n\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다."
           }
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 담당자 객체를 반환합니다.</p>\n",
+            "description": "성공 응답으로 담당자 객체를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -9714,10 +9715,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 담당자 객체를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 담당자 객체를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9727,7 +9728,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9737,7 +9738,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>B2bNotEnabledError</code>: B2B 기능이 활성화되지 않은 경우</li>\n</ul>\n",
+            "description": "* `B2bNotEnabledError`: B2B 기능이 활성화되지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9747,7 +9748,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>B2bMemberCompanyNotFoundError</code>: 연동 사업자가 존재하지 않는 경우</li>\n<li><code>B2bContactNotFoundError</code>: 담당자가 존재하지 않는 경우</li>\n</ul>\n",
+            "description": "* `B2bMemberCompanyNotFoundError`: 연동 사업자가 존재하지 않는 경우\n* `B2bContactNotFoundError`: 담당자가 존재하지 않는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9757,7 +9758,7 @@
             }
           },
           "502": {
-            "description": "<ul>\n<li><code>B2bExternalServiceError</code>: 외부 서비스에서 에러가 발생한 경우</li>\n</ul>\n",
+            "description": "* `B2bExternalServiceError`: 외부 서비스에서 에러가 발생한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9777,32 +9778,32 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "담당자 조회",
-        "x-portone-description": "<p>연동 사업자에 등록된 담당자를 조회합니다.</p>\n",
+        "x-portone-description": "연동 사업자에 등록된 담당자를 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetB2bMemberCompanyContactError"
         },
         "x-portone-unstable": true
       },
       "patch": {
-        "summary": "<p>담당자 정보 수정</p>\n",
-        "description": "<p>담당자 정보 수정</p>\n<p>담당자 정보를 수정합니다.</p>\n",
+        "summary": "담당자 정보 수정",
+        "description": "담당자 정보 수정\n\n담당자 정보를 수정합니다.",
         "operationId": "updateB2bMemberCompanyContact",
         "parameters": [
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\n\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다."
           },
           {
             "name": "brn",
             "in": "path",
-            "description": "<p>사업자등록번호</p>\n",
+            "description": "사업자등록번호",
             "required": true,
             "schema": {
               "type": "string"
@@ -9812,7 +9813,7 @@
           {
             "name": "contactId",
             "in": "path",
-            "description": "<p>담당자 ID</p>\n",
+            "description": "담당자 ID",
             "required": true,
             "schema": {
               "type": "string"
@@ -9832,7 +9833,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답",
             "content": {
               "application/json": {
                 "schema": {
@@ -9843,7 +9844,7 @@
             "x-portone-title": "성공 응답"
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9853,7 +9854,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9863,7 +9864,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>B2bNotEnabledError</code>: B2B 기능이 활성화되지 않은 경우</li>\n</ul>\n",
+            "description": "* `B2bNotEnabledError`: B2B 기능이 활성화되지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9873,7 +9874,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>B2bContactNotFoundError</code>: 담당자가 존재하지 않는 경우</li>\n<li><code>B2bMemberCompanyNotFoundError</code>: 연동 사업자가 존재하지 않는 경우</li>\n</ul>\n",
+            "description": "* `B2bContactNotFoundError`: 담당자가 존재하지 않는 경우\n* `B2bMemberCompanyNotFoundError`: 연동 사업자가 존재하지 않는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9883,7 +9884,7 @@
             }
           },
           "502": {
-            "description": "<ul>\n<li><code>B2bExternalServiceError</code>: 외부 서비스에서 에러가 발생한 경우</li>\n</ul>\n",
+            "description": "* `B2bExternalServiceError`: 외부 서비스에서 에러가 발생한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9903,7 +9904,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "담당자 정보 수정",
-        "x-portone-description": "<p>담당자 정보를 수정합니다.</p>\n",
+        "x-portone-description": "담당자 정보를 수정합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/UpdateB2bMemberCompanyContactError"
         },
@@ -9912,14 +9913,14 @@
     },
     "/b2b-preview/member-companies/{brn}/certificate/registration-url": {
       "get": {
-        "summary": "<p>사업자 인증서 등록 URL 조회</p>\n",
-        "description": "<p>사업자 인증서 등록 URL 조회</p>\n<p>연동 사업자의 인증서를 등록하기 위한 URL을 조회합니다.</p>\n",
+        "summary": "사업자 인증서 등록 URL 조회",
+        "description": "사업자 인증서 등록 URL 조회\n\n연동 사업자의 인증서를 등록하기 위한 URL을 조회합니다.",
         "operationId": "getB2bCertificateRegistrationUrl",
         "parameters": [
           {
             "name": "brn",
             "in": "path",
-            "description": "<p>사업자등록번호</p>\n",
+            "description": "사업자등록번호",
             "required": true,
             "schema": {
               "type": "string"
@@ -9929,18 +9930,18 @@
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\n\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다."
           }
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 URL을 반환합니다.</p>\n",
+            "description": "성공 응답으로 URL을 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -9948,10 +9949,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 URL을 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 URL을 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9961,7 +9962,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9971,7 +9972,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>B2bNotEnabledError</code>: B2B 기능이 활성화되지 않은 경우</li>\n</ul>\n",
+            "description": "* `B2bNotEnabledError`: B2B 기능이 활성화되지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9981,7 +9982,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>B2bMemberCompanyNotFoundError</code>: 연동 사업자가 존재하지 않는 경우</li>\n</ul>\n",
+            "description": "* `B2bMemberCompanyNotFoundError`: 연동 사업자가 존재하지 않는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -9991,7 +9992,7 @@
             }
           },
           "502": {
-            "description": "<ul>\n<li><code>B2bExternalServiceError</code>: 외부 서비스에서 에러가 발생한 경우</li>\n</ul>\n",
+            "description": "* `B2bExternalServiceError`: 외부 서비스에서 에러가 발생한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10011,7 +10012,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "사업자 인증서 등록 URL 조회",
-        "x-portone-description": "<p>연동 사업자의 인증서를 등록하기 위한 URL을 조회합니다.</p>\n",
+        "x-portone-description": "연동 사업자의 인증서를 등록하기 위한 URL을 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetB2bCertificateRegistrationUrlError"
         },
@@ -10020,14 +10021,14 @@
     },
     "/b2b-preview/member-companies/{brn}/certificate": {
       "get": {
-        "summary": "<p>인증서 조회</p>\n",
-        "description": "<p>인증서 조회</p>\n<p>연동 사업자의 인증서를 조회합니다.</p>\n",
+        "summary": "인증서 조회",
+        "description": "인증서 조회\n\n연동 사업자의 인증서를 조회합니다.",
         "operationId": "getB2bCertificate",
         "parameters": [
           {
             "name": "brn",
             "in": "path",
-            "description": "<p>사업자등록번호</p>\n",
+            "description": "사업자등록번호",
             "required": true,
             "schema": {
               "type": "string"
@@ -10037,18 +10038,18 @@
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\n\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다."
           }
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 인증서 객체를 반환합니다.</p>\n",
+            "description": "성공 응답으로 인증서 객체를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -10056,10 +10057,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 인증서 객체를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 인증서 객체를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10069,7 +10070,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10079,7 +10080,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>B2bNotEnabledError</code>: B2B 기능이 활성화되지 않은 경우</li>\n</ul>\n",
+            "description": "* `B2bNotEnabledError`: B2B 기능이 활성화되지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10089,7 +10090,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>B2bMemberCompanyNotFoundError</code>: 연동 사업자가 존재하지 않는 경우</li>\n<li><code>B2bCertificateUnregisteredError</code>: 인증서가 등록되어 있지 않은 경우</li>\n</ul>\n",
+            "description": "* `B2bMemberCompanyNotFoundError`: 연동 사업자가 존재하지 않는 경우\n* `B2bCertificateUnregisteredError`: 인증서가 등록되어 있지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10099,7 +10100,7 @@
             }
           },
           "502": {
-            "description": "<ul>\n<li><code>B2bExternalServiceError</code>: 외부 서비스에서 에러가 발생한 경우</li>\n</ul>\n",
+            "description": "* `B2bExternalServiceError`: 외부 서비스에서 에러가 발생한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10119,7 +10120,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "인증서 조회",
-        "x-portone-description": "<p>연동 사업자의 인증서를 조회합니다.</p>\n",
+        "x-portone-description": "연동 사업자의 인증서를 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetB2bCertificateError"
         },
@@ -10128,14 +10129,14 @@
     },
     "/b2b-preview/member-companies/contacts/id-existence": {
       "get": {
-        "summary": "<p>담당자 ID 존재 여부 확인</p>\n",
-        "description": "<p>담당자 ID 존재 여부 확인</p>\n<p>담당자 ID가 이미 사용중인지 확인합니다.</p>\n",
+        "summary": "담당자 ID 존재 여부 확인",
+        "description": "담당자 ID 존재 여부 확인\n\n담당자 ID가 이미 사용중인지 확인합니다.",
         "operationId": "getB2bContactIdExistence",
         "parameters": [
           {
             "name": "contactId",
             "in": "query",
-            "description": "<p>담당자 ID</p>\n",
+            "description": "담당자 ID",
             "required": true,
             "schema": {
               "type": "string"
@@ -10145,18 +10146,18 @@
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\n\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다."
           }
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답입니다.</p>\n",
+            "description": "성공 응답입니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -10164,10 +10165,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답입니다.</p>\n"
+            "x-portone-description": "성공 응답입니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10177,7 +10178,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10187,7 +10188,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>B2bNotEnabledError</code>: B2B 기능이 활성화되지 않은 경우</li>\n</ul>\n",
+            "description": "* `B2bNotEnabledError`: B2B 기능이 활성화되지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10197,7 +10198,7 @@
             }
           },
           "502": {
-            "description": "<ul>\n<li><code>B2bExternalServiceError</code>: 외부 서비스에서 에러가 발생한 경우</li>\n</ul>\n",
+            "description": "* `B2bExternalServiceError`: 외부 서비스에서 에러가 발생한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10217,7 +10218,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "담당자 ID 존재 여부 확인",
-        "x-portone-description": "<p>담당자 ID가 이미 사용중인지 확인합니다.</p>\n",
+        "x-portone-description": "담당자 ID가 이미 사용중인지 확인합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/getB2bContactIdExistenceError"
         },
@@ -10226,14 +10227,14 @@
     },
     "/b2b-preview/bank-accounts/{bank}/{accountNumber}/holder": {
       "get": {
-        "summary": "<p>예금주 조회</p>\n",
-        "description": "<p>예금주 조회</p>\n<p>원하는 계좌의 예금주를 조회합니다.</p>\n",
+        "summary": "예금주 조회",
+        "description": "예금주 조회\n\n원하는 계좌의 예금주를 조회합니다.",
         "operationId": "getB2bBankAccountHolder",
         "parameters": [
           {
             "name": "bank",
             "in": "path",
-            "description": "<p>은행</p>\n",
+            "description": "은행",
             "required": true,
             "schema": {
               "$ref": "#/components/schemas/Bank"
@@ -10243,7 +10244,7 @@
           {
             "name": "accountNumber",
             "in": "path",
-            "description": "<p>'-'를 제외한 계좌 번호</p>\n",
+            "description": "'-'를 제외한 계좌 번호",
             "required": true,
             "schema": {
               "type": "string"
@@ -10253,18 +10254,18 @@
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\n\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다."
           }
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답",
             "content": {
               "application/json": {
                 "schema": {
@@ -10272,10 +10273,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답</p>\n"
+            "x-portone-description": "성공 응답"
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10285,7 +10286,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10295,7 +10296,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>B2bNotEnabledError</code>: B2B 기능이 활성화되지 않은 경우</li>\n</ul>\n",
+            "description": "* `B2bNotEnabledError`: B2B 기능이 활성화되지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10305,7 +10306,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>B2bBankAccountNotFoundError</code>: 계좌가 존재하지 않는 경우</li>\n<li><code>B2bForeignExchangeAccountError</code>: 계좌 정보 조회가 불가능한 외화 계좌인 경우</li>\n<li><code>B2bSuspendedAccountError</code>: 정지 계좌인 경우</li>\n</ul>\n",
+            "description": "* `B2bBankAccountNotFoundError`: 계좌가 존재하지 않는 경우\n* `B2bForeignExchangeAccountError`: 계좌 정보 조회가 불가능한 외화 계좌인 경우\n* `B2bSuspendedAccountError`: 정지 계좌인 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10315,7 +10316,7 @@
             }
           },
           "502": {
-            "description": "<ul>\n<li><code>B2bExternalServiceError</code>: 외부 서비스에서 에러가 발생한 경우</li>\n</ul>\n",
+            "description": "* `B2bExternalServiceError`: 외부 서비스에서 에러가 발생한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10325,7 +10326,7 @@
             }
           },
           "503": {
-            "description": "<ul>\n<li><code>B2bRegularMaintenanceTimeError</code>: 금융기관 시스템이 정기 점검 중인 경우</li>\n<li><code>B2bFinancialSystemFailureError</code>: 금융기관 장애</li>\n<li><code>B2bFinancialSystemUnderMaintenanceError</code>: 금융기관 시스템이 점검 중인 경우</li>\n<li><code>B2bFinancialSystemCommunicationError</code>: 금융기관과의 통신에 실패한 경우</li>\n</ul>\n",
+            "description": "* `B2bRegularMaintenanceTimeError`: 금융기관 시스템이 정기 점검 중인 경우\n* `B2bFinancialSystemFailureError`: 금융기관 장애\n* `B2bFinancialSystemUnderMaintenanceError`: 금융기관 시스템이 점검 중인 경우\n* `B2bFinancialSystemCommunicationError`: 금융기관과의 통신에 실패한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10345,7 +10346,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "예금주 조회",
-        "x-portone-description": "<p>원하는 계좌의 예금주를 조회합니다.</p>\n",
+        "x-portone-description": "원하는 계좌의 예금주를 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetB2bAccountHolderError"
         },
@@ -10354,14 +10355,14 @@
     },
     "/b2b-preview/company/{brn}/state": {
       "get": {
-        "summary": "<p>사업자 상태 조회</p>\n",
-        "description": "<p>사업자 상태 조회</p>\n<p>원하는 사업자의 상태를 조회합니다. 포트원 B2B 서비스에 연동 및 등록되지 않은 사업자도 조회 가능합니다.</p>\n",
+        "summary": "사업자 상태 조회",
+        "description": "사업자 상태 조회\n\n원하는 사업자의 상태를 조회합니다. 포트원 B2B 서비스에 연동 및 등록되지 않은 사업자도 조회 가능합니다.",
         "operationId": "getB2bCompanyState",
         "parameters": [
           {
             "name": "brn",
             "in": "path",
-            "description": "<p>사업자등록번호</p>\n",
+            "description": "사업자등록번호",
             "required": true,
             "schema": {
               "type": "string"
@@ -10371,18 +10372,18 @@
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\n\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다."
           }
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 사업자 상태 객체를 반환합니다.</p>\n",
+            "description": "성공 응답으로 사업자 상태 객체를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -10390,10 +10391,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 사업자 상태 객체를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 사업자 상태 객체를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10403,7 +10404,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10413,7 +10414,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>B2bNotEnabledError</code>: B2B 기능이 활성화되지 않은 경우</li>\n</ul>\n",
+            "description": "* `B2bNotEnabledError`: B2B 기능이 활성화되지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10423,7 +10424,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>B2bCompanyNotFoundError</code>: 사업자가 존재하지 않는 경우</li>\n</ul>\n",
+            "description": "* `B2bCompanyNotFoundError`: 사업자가 존재하지 않는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10433,7 +10434,7 @@
             }
           },
           "502": {
-            "description": "<ul>\n<li><code>B2bExternalServiceError</code>: 외부 서비스에서 에러가 발생한 경우</li>\n</ul>\n",
+            "description": "* `B2bExternalServiceError`: 외부 서비스에서 에러가 발생한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10443,7 +10444,7 @@
             }
           },
           "503": {
-            "description": "<ul>\n<li><code>B2bHometaxUnderMaintenanceError</code>: 홈택스가 점검중이거나 순단이 발생한 경우</li>\n</ul>\n",
+            "description": "* `B2bHometaxUnderMaintenanceError`: 홈택스가 점검중이거나 순단이 발생한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10463,7 +10464,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "사업자 상태 조회",
-        "x-portone-description": "<p>원하는 사업자의 상태를 조회합니다. 포트원 B2B 서비스에 연동 및 등록되지 않은 사업자도 조회 가능합니다.</p>\n",
+        "x-portone-description": "원하는 사업자의 상태를 조회합니다. 포트원 B2B 서비스에 연동 및 등록되지 않은 사업자도 조회 가능합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetB2bCompanyStateError"
         },
@@ -10472,20 +10473,20 @@
     },
     "/b2b-preview/tax-invoices/request-reverse-issuance": {
       "post": {
-        "summary": "<p>세금계산서 역발행 요청</p>\n",
-        "description": "<p>세금계산서 역발행 요청</p>\n<p>공급자에게 세금계산서 역발행을 요청합니다.</p>\n",
+        "summary": "세금계산서 역발행 요청",
+        "description": "세금계산서 역발행 요청\n\n공급자에게 세금계산서 역발행을 요청합니다.",
         "operationId": "requestB2bTaxInvoiceReverseIssuance",
         "parameters": [
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\n\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다."
           }
         ],
         "requestBody": {
@@ -10500,7 +10501,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 세금계산서를 반환합니다.</p>\n",
+            "description": "성공 응답으로 세금계산서를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -10508,10 +10509,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 세금계산서를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 세금계산서를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10521,7 +10522,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10531,7 +10532,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>B2bNotEnabledError</code>: B2B 기능이 활성화되지 않은 경우</li>\n</ul>\n",
+            "description": "* `B2bNotEnabledError`: B2B 기능이 활성화되지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10541,7 +10542,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>B2bSupplierNotFoundError</code>: 공급자가 존재하지 않은 경우</li>\n<li><code>B2bRecipientNotFoundError</code>: 공급받는자가 존재하지 않은 경우</li>\n</ul>\n",
+            "description": "* `B2bSupplierNotFoundError`: 공급자가 존재하지 않은 경우\n* `B2bRecipientNotFoundError`: 공급받는자가 존재하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10551,7 +10552,7 @@
             }
           },
           "502": {
-            "description": "<ul>\n<li><code>B2bExternalServiceError</code>: 외부 서비스에서 에러가 발생한 경우</li>\n</ul>\n",
+            "description": "* `B2bExternalServiceError`: 외부 서비스에서 에러가 발생한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10571,7 +10572,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "세금계산서 역발행 요청",
-        "x-portone-description": "<p>공급자에게 세금계산서 역발행을 요청합니다.</p>\n",
+        "x-portone-description": "공급자에게 세금계산서 역발행을 요청합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/RequestB2bTaxInvoiceReverseIssuanceError"
         },
@@ -10580,14 +10581,14 @@
     },
     "/b2b-preview/tax-invoices/{documentKey}": {
       "get": {
-        "summary": "<p>세금 계산서 조회</p>\n",
-        "description": "<p>세금 계산서 조회</p>\n<p>등록된 세금 계산서를 공급자 혹은 공급받는자 문서번호로 조회합니다.</p>\n",
+        "summary": "세금 계산서 조회",
+        "description": "세금 계산서 조회\n\n등록된 세금 계산서를 공급자 혹은 공급받는자 문서번호로 조회합니다.",
         "operationId": "getB2bTaxInvoice",
         "parameters": [
           {
             "name": "documentKey",
             "in": "path",
-            "description": "<p>세금계산서 문서 번호</p>\n",
+            "description": "세금계산서 문서 번호",
             "required": true,
             "schema": {
               "type": "string"
@@ -10597,7 +10598,7 @@
           {
             "name": "brn",
             "in": "query",
-            "description": "<p>사업자등록번호</p>\n",
+            "description": "사업자등록번호",
             "required": true,
             "schema": {
               "type": "string"
@@ -10607,29 +10608,29 @@
           {
             "name": "documentKeyType",
             "in": "query",
-            "description": "<p>문서 번호 유형</p>\n<p>path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.</p>\n",
+            "description": "문서 번호 유형\n\npath 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.",
             "required": false,
             "schema": {
               "$ref": "#/components/schemas/B2bTaxInvoiceDocumentKeyType"
             },
             "x-portone-title": "문서 번호 유형",
-            "x-portone-description": "<p>path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.</p>\n"
+            "x-portone-description": "path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다."
           },
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\n\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다."
           }
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 세금계산서를 반환합니다.</p>\n",
+            "description": "성공 응답으로 세금계산서를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -10637,10 +10638,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 세금계산서를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 세금계산서를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10650,7 +10651,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10660,7 +10661,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>B2bNotEnabledError</code>: B2B 기능이 활성화되지 않은 경우</li>\n</ul>\n",
+            "description": "* `B2bNotEnabledError`: B2B 기능이 활성화되지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10670,7 +10671,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>B2bTaxInvoiceNotFoundError</code>: 세금계산서가 존재하지 않은 경우</li>\n</ul>\n",
+            "description": "* `B2bTaxInvoiceNotFoundError`: 세금계산서가 존재하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10680,7 +10681,7 @@
             }
           },
           "502": {
-            "description": "<ul>\n<li><code>B2bExternalServiceError</code>: 외부 서비스에서 에러가 발생한 경우</li>\n</ul>\n",
+            "description": "* `B2bExternalServiceError`: 외부 서비스에서 에러가 발생한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10700,21 +10701,21 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "세금 계산서 조회",
-        "x-portone-description": "<p>등록된 세금 계산서를 공급자 혹은 공급받는자 문서번호로 조회합니다.</p>\n",
+        "x-portone-description": "등록된 세금 계산서를 공급자 혹은 공급받는자 문서번호로 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetB2bTaxInvoiceError"
         },
         "x-portone-unstable": true
       },
       "delete": {
-        "summary": "<p>세금계산서 삭제</p>\n",
-        "description": "<p>세금계산서 삭제</p>\n<p>세금계산서를 삭제합니다.</p>\n",
+        "summary": "세금계산서 삭제",
+        "description": "세금계산서 삭제\n\n세금계산서를 삭제합니다.",
         "operationId": "deleteB2bTaxInvoice",
         "parameters": [
           {
             "name": "documentKey",
             "in": "path",
-            "description": "<p>세금계산서 문서 번호</p>\n",
+            "description": "세금계산서 문서 번호",
             "required": true,
             "schema": {
               "type": "string"
@@ -10724,7 +10725,7 @@
           {
             "name": "brn",
             "in": "query",
-            "description": "<p>사업자등록번호</p>\n",
+            "description": "사업자등록번호",
             "required": true,
             "schema": {
               "type": "string"
@@ -10734,24 +10735,24 @@
           {
             "name": "documentKeyType",
             "in": "query",
-            "description": "<p>문서 번호 유형</p>\n<p>path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.</p>\n",
+            "description": "문서 번호 유형\n\npath 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.",
             "required": false,
             "schema": {
               "$ref": "#/components/schemas/B2bTaxInvoiceDocumentKeyType"
             },
             "x-portone-title": "문서 번호 유형",
-            "x-portone-description": "<p>path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.</p>\n"
+            "x-portone-description": "path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다."
           },
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\n\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다."
           }
         ],
         "responses": {
@@ -10759,7 +10760,7 @@
             "description": ""
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n<li><code>B2bTaxInvoiceNonDeletableStatusError</code>: 세금계산서가 삭제 가능한 상태가 아닌 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우\n* `B2bTaxInvoiceNonDeletableStatusError`: 세금계산서가 삭제 가능한 상태가 아닌 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10769,7 +10770,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10779,7 +10780,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>B2bNotEnabledError</code>: B2B 기능이 활성화되지 않은 경우</li>\n</ul>\n",
+            "description": "* `B2bNotEnabledError`: B2B 기능이 활성화되지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10789,7 +10790,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>B2bTaxInvoiceNotFoundError</code>: 세금계산서가 존재하지 않은 경우</li>\n</ul>\n",
+            "description": "* `B2bTaxInvoiceNotFoundError`: 세금계산서가 존재하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10799,7 +10800,7 @@
             }
           },
           "502": {
-            "description": "<ul>\n<li><code>B2bExternalServiceError</code>: 외부 서비스에서 에러가 발생한 경우</li>\n</ul>\n",
+            "description": "* `B2bExternalServiceError`: 외부 서비스에서 에러가 발생한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10819,7 +10820,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "세금계산서 삭제",
-        "x-portone-description": "<p>세금계산서를 삭제합니다.</p>\n",
+        "x-portone-description": "세금계산서를 삭제합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/DeleteB2bTaxInvoiceError"
         },
@@ -10828,20 +10829,20 @@
     },
     "/b2b-preview/tax-invoices/issue": {
       "post": {
-        "summary": "<p>세금계산서 발행</p>\n",
-        "description": "<p>세금계산서 발행</p>\n<p>역발행의 경우 역발행요청(REQUESTED) 상태, 정발행의 경우 임시저장(REGISTERED) 상태의 세금계산서를 발행합니다.</p>\n",
+        "summary": "세금계산서 발행",
+        "description": "세금계산서 발행\n\n역발행의 경우 역발행요청(REQUESTED) 상태, 정발행의 경우 임시저장(REGISTERED) 상태의 세금계산서를 발행합니다.",
         "operationId": "issueB2bTaxInvoice",
         "parameters": [
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\n\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다."
           }
         ],
         "requestBody": {
@@ -10856,7 +10857,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 세금계산서를 반환합니다.</p>\n",
+            "description": "성공 응답으로 세금계산서를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -10864,10 +10865,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 세금계산서를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 세금계산서를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n<li><code>B2bTaxInvoiceNotRequestedStatusError</code>: 세금계산서가 역발행 대기 상태가 아닌 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우\n* `B2bTaxInvoiceNotRequestedStatusError`: 세금계산서가 역발행 대기 상태가 아닌 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10877,7 +10878,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10887,7 +10888,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>B2bNotEnabledError</code>: B2B 기능이 활성화되지 않은 경우</li>\n</ul>\n",
+            "description": "* `B2bNotEnabledError`: B2B 기능이 활성화되지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10897,7 +10898,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>B2bTaxInvoiceNotFoundError</code>: 세금계산서가 존재하지 않은 경우</li>\n</ul>\n",
+            "description": "* `B2bTaxInvoiceNotFoundError`: 세금계산서가 존재하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10907,7 +10908,7 @@
             }
           },
           "502": {
-            "description": "<ul>\n<li><code>B2bExternalServiceError</code>: 외부 서비스에서 에러가 발생한 경우</li>\n</ul>\n",
+            "description": "* `B2bExternalServiceError`: 외부 서비스에서 에러가 발생한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10927,7 +10928,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "세금계산서 발행",
-        "x-portone-description": "<p>역발행의 경우 역발행요청(REQUESTED) 상태, 정발행의 경우 임시저장(REGISTERED) 상태의 세금계산서를 발행합니다.</p>\n",
+        "x-portone-description": "역발행의 경우 역발행요청(REQUESTED) 상태, 정발행의 경우 임시저장(REGISTERED) 상태의 세금계산서를 발행합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/IssueB2bTaxInvoiceError"
         },
@@ -10936,20 +10937,20 @@
     },
     "/b2b-preview/tax-invoices/cancel-request": {
       "post": {
-        "summary": "<p>세금계산서 역발행 요청 취소</p>\n",
-        "description": "<p>세금계산서 역발행 요청 취소</p>\n<p>공급받는자가 공급자에게 세금계산서 역발행 요청한 것을 취소합니다.</p>\n",
+        "summary": "세금계산서 역발행 요청 취소",
+        "description": "세금계산서 역발행 요청 취소\n\n공급받는자가 공급자에게 세금계산서 역발행 요청한 것을 취소합니다.",
         "operationId": "cancelB2bTaxInvoiceRequest",
         "parameters": [
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\n\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다."
           }
         ],
         "requestBody": {
@@ -10964,7 +10965,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 세금계산서를 반환합니다.</p>\n",
+            "description": "성공 응답으로 세금계산서를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -10972,10 +10973,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 세금계산서를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 세금계산서를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n<li><code>B2bTaxInvoiceNotRequestedStatusError</code>: 세금계산서가 역발행 대기 상태가 아닌 경우</li>\n<li><code>B2bTaxInvoiceNoRecipientDocumentKeyError</code>: 세금계산서에 공급받는자 문서 번호가 기입되지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우\n* `B2bTaxInvoiceNotRequestedStatusError`: 세금계산서가 역발행 대기 상태가 아닌 경우\n* `B2bTaxInvoiceNoRecipientDocumentKeyError`: 세금계산서에 공급받는자 문서 번호가 기입되지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10985,7 +10986,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -10995,7 +10996,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>B2bNotEnabledError</code>: B2B 기능이 활성화되지 않은 경우</li>\n</ul>\n",
+            "description": "* `B2bNotEnabledError`: B2B 기능이 활성화되지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -11005,7 +11006,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>B2bTaxInvoiceNotFoundError</code>: 세금계산서가 존재하지 않은 경우</li>\n</ul>\n",
+            "description": "* `B2bTaxInvoiceNotFoundError`: 세금계산서가 존재하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -11015,7 +11016,7 @@
             }
           },
           "502": {
-            "description": "<ul>\n<li><code>B2bExternalServiceError</code>: 외부 서비스에서 에러가 발생한 경우</li>\n</ul>\n",
+            "description": "* `B2bExternalServiceError`: 외부 서비스에서 에러가 발생한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -11035,7 +11036,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "세금계산서 역발행 요청 취소",
-        "x-portone-description": "<p>공급받는자가 공급자에게 세금계산서 역발행 요청한 것을 취소합니다.</p>\n",
+        "x-portone-description": "공급받는자가 공급자에게 세금계산서 역발행 요청한 것을 취소합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/CancelB2bTaxInvoiceRequestError"
         },
@@ -11044,20 +11045,20 @@
     },
     "/b2b-preview/tax-invoices/cancel-issuance": {
       "post": {
-        "summary": "<p>세금계산서 역발행 취소</p>\n",
-        "description": "<p>세금계산서 역발행 취소</p>\n<p>공급자가 발행 완료한 세금계산서를 국세청 전송 전 취소합니다.</p>\n",
+        "summary": "세금계산서 역발행 취소",
+        "description": "세금계산서 역발행 취소\n\n공급자가 발행 완료한 세금계산서를 국세청 전송 전 취소합니다.",
         "operationId": "cancelB2bTaxInvoiceIssuance",
         "parameters": [
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\n\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다."
           }
         ],
         "requestBody": {
@@ -11072,7 +11073,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 세금계산서를 반환합니다.</p>\n",
+            "description": "성공 응답으로 세금계산서를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -11080,10 +11081,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 세금계산서를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 세금계산서를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n<li><code>B2bTaxInvoiceNotIssuedStatusError</code>: 세금계산서가 발행된(ISSUED) 상태가 아닌 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우\n* `B2bTaxInvoiceNotIssuedStatusError`: 세금계산서가 발행된(ISSUED) 상태가 아닌 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -11093,7 +11094,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -11103,7 +11104,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>B2bNotEnabledError</code>: B2B 기능이 활성화되지 않은 경우</li>\n</ul>\n",
+            "description": "* `B2bNotEnabledError`: B2B 기능이 활성화되지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -11113,7 +11114,7 @@
             }
           },
           "502": {
-            "description": "<ul>\n<li><code>B2bExternalServiceError</code>: 외부 서비스에서 에러가 발생한 경우</li>\n</ul>\n",
+            "description": "* `B2bExternalServiceError`: 외부 서비스에서 에러가 발생한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -11133,7 +11134,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "세금계산서 역발행 취소",
-        "x-portone-description": "<p>공급자가 발행 완료한 세금계산서를 국세청 전송 전 취소합니다.</p>\n",
+        "x-portone-description": "공급자가 발행 완료한 세금계산서를 국세청 전송 전 취소합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/CancelB2bTaxInvoiceIssuanceError"
         },
@@ -11142,20 +11143,20 @@
     },
     "/b2b-preview/tax-invoices/refuse-request": {
       "post": {
-        "summary": "<p>세금계산서 역발행 요청 거부</p>\n",
-        "description": "<p>세금계산서 역발행 요청 거부</p>\n<p>공급자가 공급받는자로부터 요청받은 세금계산서 역발행 건을 거부합니다.</p>\n",
+        "summary": "세금계산서 역발행 요청 거부",
+        "description": "세금계산서 역발행 요청 거부\n\n공급자가 공급받는자로부터 요청받은 세금계산서 역발행 건을 거부합니다.",
         "operationId": "refuseB2bTaxInvoiceRequest",
         "parameters": [
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\n\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다."
           }
         ],
         "requestBody": {
@@ -11170,7 +11171,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 세금계산서를 반환합니다.</p>\n",
+            "description": "성공 응답으로 세금계산서를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -11178,10 +11179,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 세금계산서를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 세금계산서를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n<li><code>B2bTaxInvoiceNotRequestedStatusError</code>: 세금계산서가 역발행 대기 상태가 아닌 경우</li>\n<li><code>B2bTaxInvoiceNoSupplierDocumentKeyError</code>: 세금계산서에 공급자 문서 번호가 기입되지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우\n* `B2bTaxInvoiceNotRequestedStatusError`: 세금계산서가 역발행 대기 상태가 아닌 경우\n* `B2bTaxInvoiceNoSupplierDocumentKeyError`: 세금계산서에 공급자 문서 번호가 기입되지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -11191,7 +11192,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -11201,7 +11202,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>B2bNotEnabledError</code>: B2B 기능이 활성화되지 않은 경우</li>\n</ul>\n",
+            "description": "* `B2bNotEnabledError`: B2B 기능이 활성화되지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -11211,7 +11212,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>B2bTaxInvoiceNotFoundError</code>: 세금계산서가 존재하지 않은 경우</li>\n</ul>\n",
+            "description": "* `B2bTaxInvoiceNotFoundError`: 세금계산서가 존재하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -11221,7 +11222,7 @@
             }
           },
           "502": {
-            "description": "<ul>\n<li><code>B2bExternalServiceError</code>: 외부 서비스에서 에러가 발생한 경우</li>\n</ul>\n",
+            "description": "* `B2bExternalServiceError`: 외부 서비스에서 에러가 발생한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -11241,7 +11242,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "세금계산서 역발행 요청 거부",
-        "x-portone-description": "<p>공급자가 공급받는자로부터 요청받은 세금계산서 역발행 건을 거부합니다.</p>\n",
+        "x-portone-description": "공급자가 공급받는자로부터 요청받은 세금계산서 역발행 건을 거부합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/RefuseB2bTaxInvoiceRequestError"
         },
@@ -11250,14 +11251,14 @@
     },
     "/b2b-preview/tax-invoices": {
       "get": {
-        "summary": "<p>세금 계산서 다건조회</p>\n",
-        "description": "<p>세금 계산서 다건조회</p>\n<p>조회 기간 내 등록된 세금 계산서를 다건 조회합니다.</p>\n",
+        "summary": "세금 계산서 다건조회",
+        "description": "세금 계산서 다건조회\n\n조회 기간 내 등록된 세금 계산서를 다건 조회합니다.",
         "operationId": "getB2bTaxInvoices",
         "parameters": [
           {
             "name": "brn",
             "in": "query",
-            "description": "<p>사업자등록번호</p>\n",
+            "description": "사업자등록번호",
             "required": true,
             "schema": {
               "type": "string"
@@ -11267,55 +11268,55 @@
           {
             "name": "pageNumber",
             "in": "query",
-            "description": "<p>페이지 번호</p>\n<p>0부터 시작하는 페이지 번호. 기본 값은 0.</p>\n",
+            "description": "페이지 번호\n\n0부터 시작하는 페이지 번호. 기본 값은 0.",
             "required": false,
             "schema": {
               "type": "integer",
               "format": "int32"
             },
             "x-portone-title": "페이지 번호",
-            "x-portone-description": "<p>0부터 시작하는 페이지 번호. 기본 값은 0.</p>\n"
+            "x-portone-description": "0부터 시작하는 페이지 번호. 기본 값은 0."
           },
           {
             "name": "pageSize",
             "in": "query",
-            "description": "<p>페이지 크기</p>\n<p>각 페이지 당 포함할 객체 수. 기본 값은 500이며 최대 1000까지 요청가능합니다.</p>\n",
+            "description": "페이지 크기\n\n각 페이지 당 포함할 객체 수. 기본 값은 500이며 최대 1000까지 요청가능합니다.",
             "required": false,
             "schema": {
               "type": "integer",
               "format": "int32"
             },
             "x-portone-title": "페이지 크기",
-            "x-portone-description": "<p>각 페이지 당 포함할 객체 수. 기본 값은 500이며 최대 1000까지 요청가능합니다.</p>\n"
+            "x-portone-description": "각 페이지 당 포함할 객체 수. 기본 값은 500이며 최대 1000까지 요청가능합니다."
           },
           {
             "name": "from",
             "in": "query",
-            "description": "<p>조회 시작일</p>\n",
+            "description": "조회 시작일",
             "required": true,
             "schema": {
-              "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+              "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
               "type": "string",
-              "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n"
+              "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다."
             },
             "x-portone-title": "조회 시작일"
           },
           {
             "name": "until",
             "in": "query",
-            "description": "<p>조회 종료일</p>\n",
+            "description": "조회 종료일",
             "required": true,
             "schema": {
-              "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+              "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
               "type": "string",
-              "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n"
+              "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다."
             },
             "x-portone-title": "조회 종료일"
           },
           {
             "name": "dateType",
             "in": "query",
-            "description": "<p>조회 기간 기준</p>\n",
+            "description": "조회 기간 기준",
             "required": true,
             "schema": {
               "$ref": "#/components/schemas/B2bSearchDateType"
@@ -11325,24 +11326,24 @@
           {
             "name": "documentKeyType",
             "in": "query",
-            "description": "<p>문서 번호 유형</p>\n<p>path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.</p>\n",
+            "description": "문서 번호 유형\n\npath 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.",
             "required": false,
             "schema": {
               "$ref": "#/components/schemas/B2bTaxInvoiceDocumentKeyType"
             },
             "x-portone-title": "문서 번호 유형",
-            "x-portone-description": "<p>path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.</p>\n"
+            "x-portone-description": "path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다."
           },
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\n\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다."
           }
         ],
         "responses": {
@@ -11357,7 +11358,7 @@
             }
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -11367,7 +11368,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -11377,7 +11378,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>B2bNotEnabledError</code>: B2B 기능이 활성화되지 않은 경우</li>\n</ul>\n",
+            "description": "* `B2bNotEnabledError`: B2B 기능이 활성화되지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -11387,7 +11388,7 @@
             }
           },
           "502": {
-            "description": "<ul>\n<li><code>B2bExternalServiceError</code>: 외부 서비스에서 에러가 발생한 경우</li>\n</ul>\n",
+            "description": "* `B2bExternalServiceError`: 외부 서비스에서 에러가 발생한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -11407,7 +11408,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "세금 계산서 다건조회",
-        "x-portone-description": "<p>조회 기간 내 등록된 세금 계산서를 다건 조회합니다.</p>\n",
+        "x-portone-description": "조회 기간 내 등록된 세금 계산서를 다건 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetB2bTaxInvoicesError"
         },
@@ -11416,14 +11417,14 @@
     },
     "/b2b-preview/tax-invoices/{documentKey}/popup-url": {
       "get": {
-        "summary": "<p>세금 계산서 팝업 URL 조회</p>\n",
-        "description": "<p>세금 계산서 팝업 URL 조회</p>\n<p>등록된 세금 계산서 팝업 URL을 공급자 혹은 공급받는자 문서번호로 조회합니다.</p>\n",
+        "summary": "세금 계산서 팝업 URL 조회",
+        "description": "세금 계산서 팝업 URL 조회\n\n등록된 세금 계산서 팝업 URL을 공급자 혹은 공급받는자 문서번호로 조회합니다.",
         "operationId": "getB2bTaxInvoicePopupUrl",
         "parameters": [
           {
             "name": "documentKey",
             "in": "path",
-            "description": "<p>세금계산서 문서 번호</p>\n",
+            "description": "세금계산서 문서 번호",
             "required": true,
             "schema": {
               "type": "string"
@@ -11433,7 +11434,7 @@
           {
             "name": "brn",
             "in": "query",
-            "description": "<p>사업자등록번호</p>\n",
+            "description": "사업자등록번호",
             "required": true,
             "schema": {
               "type": "string"
@@ -11443,35 +11444,35 @@
           {
             "name": "documentKeyType",
             "in": "query",
-            "description": "<p>문서 번호 유형</p>\n<p>path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.</p>\n",
+            "description": "문서 번호 유형\n\npath 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.",
             "required": false,
             "schema": {
               "$ref": "#/components/schemas/B2bTaxInvoiceDocumentKeyType"
             },
             "x-portone-title": "문서 번호 유형",
-            "x-portone-description": "<p>path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.</p>\n"
+            "x-portone-description": "path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다."
           },
           {
             "name": "includeMenu",
             "in": "query",
-            "description": "<p>메뉴 포함 여부</p>\n<p>팝업 URL에 메뉴 레이아웃을 포함 여부를 결정합니다. 기본 값은 true입니다.</p>\n",
+            "description": "메뉴 포함 여부\n\n팝업 URL에 메뉴 레이아웃을 포함 여부를 결정합니다. 기본 값은 true입니다.",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "메뉴 포함 여부",
-            "x-portone-description": "<p>팝업 URL에 메뉴 레이아웃을 포함 여부를 결정합니다. 기본 값은 true입니다.</p>\n"
+            "x-portone-description": "팝업 URL에 메뉴 레이아웃을 포함 여부를 결정합니다. 기본 값은 true입니다."
           },
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\n\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다."
           }
         ],
         "responses": {
@@ -11486,7 +11487,7 @@
             }
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -11496,7 +11497,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -11506,7 +11507,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>B2bNotEnabledError</code>: B2B 기능이 활성화되지 않은 경우</li>\n</ul>\n",
+            "description": "* `B2bNotEnabledError`: B2B 기능이 활성화되지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -11516,7 +11517,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>B2bTaxInvoiceNotFoundError</code>: 세금계산서가 존재하지 않은 경우</li>\n</ul>\n",
+            "description": "* `B2bTaxInvoiceNotFoundError`: 세금계산서가 존재하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -11526,7 +11527,7 @@
             }
           },
           "502": {
-            "description": "<ul>\n<li><code>B2bExternalServiceError</code>: 외부 서비스에서 에러가 발생한 경우</li>\n</ul>\n",
+            "description": "* `B2bExternalServiceError`: 외부 서비스에서 에러가 발생한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -11546,7 +11547,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "세금 계산서 팝업 URL 조회",
-        "x-portone-description": "<p>등록된 세금 계산서 팝업 URL을 공급자 혹은 공급받는자 문서번호로 조회합니다.</p>\n",
+        "x-portone-description": "등록된 세금 계산서 팝업 URL을 공급자 혹은 공급받는자 문서번호로 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetB2bTaxInvoicePopupUrlError"
         },
@@ -11555,14 +11556,14 @@
     },
     "/b2b-preview/tax-invoices/{documentKey}/print-url": {
       "get": {
-        "summary": "<p>세금 계산서 프린트 URL 조회</p>\n",
-        "description": "<p>세금 계산서 프린트 URL 조회</p>\n<p>등록된 세금 계산서 프린트 URL을 공급자 혹은 공급받는자 문서번호로 조회합니다.</p>\n",
+        "summary": "세금 계산서 프린트 URL 조회",
+        "description": "세금 계산서 프린트 URL 조회\n\n등록된 세금 계산서 프린트 URL을 공급자 혹은 공급받는자 문서번호로 조회합니다.",
         "operationId": "getB2bTaxInvoicePrintUrl",
         "parameters": [
           {
             "name": "documentKey",
             "in": "path",
-            "description": "<p>세금계산서 문서 번호</p>\n",
+            "description": "세금계산서 문서 번호",
             "required": true,
             "schema": {
               "type": "string"
@@ -11572,7 +11573,7 @@
           {
             "name": "brn",
             "in": "query",
-            "description": "<p>사업자등록번호</p>\n",
+            "description": "사업자등록번호",
             "required": true,
             "schema": {
               "type": "string"
@@ -11582,24 +11583,24 @@
           {
             "name": "documentKeyType",
             "in": "query",
-            "description": "<p>문서 번호 유형</p>\n<p>path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.</p>\n",
+            "description": "문서 번호 유형\n\npath 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.",
             "required": false,
             "schema": {
               "$ref": "#/components/schemas/B2bTaxInvoiceDocumentKeyType"
             },
             "x-portone-title": "문서 번호 유형",
-            "x-portone-description": "<p>path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.</p>\n"
+            "x-portone-description": "path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다."
           },
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\n\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다."
           }
         ],
         "responses": {
@@ -11614,7 +11615,7 @@
             }
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -11624,7 +11625,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -11634,7 +11635,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>B2bNotEnabledError</code>: B2B 기능이 활성화되지 않은 경우</li>\n</ul>\n",
+            "description": "* `B2bNotEnabledError`: B2B 기능이 활성화되지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -11644,7 +11645,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>B2bTaxInvoiceNotFoundError</code>: 세금계산서가 존재하지 않은 경우</li>\n</ul>\n",
+            "description": "* `B2bTaxInvoiceNotFoundError`: 세금계산서가 존재하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -11654,7 +11655,7 @@
             }
           },
           "502": {
-            "description": "<ul>\n<li><code>B2bExternalServiceError</code>: 외부 서비스에서 에러가 발생한 경우</li>\n</ul>\n",
+            "description": "* `B2bExternalServiceError`: 외부 서비스에서 에러가 발생한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -11674,7 +11675,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "세금 계산서 프린트 URL 조회",
-        "x-portone-description": "<p>등록된 세금 계산서 프린트 URL을 공급자 혹은 공급받는자 문서번호로 조회합니다.</p>\n",
+        "x-portone-description": "등록된 세금 계산서 프린트 URL을 공급자 혹은 공급받는자 문서번호로 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetB2bTaxInvoicePrintUrlError"
         },
@@ -11683,14 +11684,14 @@
     },
     "/b2b-preview/tax-invoices/{documentKey}/pdf-download-url": {
       "get": {
-        "summary": "<p>세금 계산서 PDF 다운로드 URL 조회</p>\n",
-        "description": "<p>세금 계산서 PDF 다운로드 URL 조회</p>\n<p>등록된 세금 계산서 PDF 다운로드 URL을 공급자 혹은 공급받는자 문서번호로 조회합니다.</p>\n",
+        "summary": "세금 계산서 PDF 다운로드 URL 조회",
+        "description": "세금 계산서 PDF 다운로드 URL 조회\n\n등록된 세금 계산서 PDF 다운로드 URL을 공급자 혹은 공급받는자 문서번호로 조회합니다.",
         "operationId": "getB2bTaxInvoicePdfDownloadUrl",
         "parameters": [
           {
             "name": "documentKey",
             "in": "path",
-            "description": "<p>세금계산서 문서 번호</p>\n",
+            "description": "세금계산서 문서 번호",
             "required": true,
             "schema": {
               "type": "string"
@@ -11700,7 +11701,7 @@
           {
             "name": "brn",
             "in": "query",
-            "description": "<p>사업자등록번호</p>\n",
+            "description": "사업자등록번호",
             "required": true,
             "schema": {
               "type": "string"
@@ -11710,24 +11711,24 @@
           {
             "name": "documentKeyType",
             "in": "query",
-            "description": "<p>문서 번호 유형</p>\n<p>path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.</p>\n",
+            "description": "문서 번호 유형\n\npath 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.",
             "required": false,
             "schema": {
               "$ref": "#/components/schemas/B2bTaxInvoiceDocumentKeyType"
             },
             "x-portone-title": "문서 번호 유형",
-            "x-portone-description": "<p>path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.</p>\n"
+            "x-portone-description": "path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다."
           },
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\n\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다."
           }
         ],
         "responses": {
@@ -11742,7 +11743,7 @@
             }
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -11752,7 +11753,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -11762,7 +11763,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>B2bNotEnabledError</code>: B2B 기능이 활성화되지 않은 경우</li>\n</ul>\n",
+            "description": "* `B2bNotEnabledError`: B2B 기능이 활성화되지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -11772,7 +11773,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>B2bTaxInvoiceNotFoundError</code>: 세금계산서가 존재하지 않은 경우</li>\n</ul>\n",
+            "description": "* `B2bTaxInvoiceNotFoundError`: 세금계산서가 존재하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -11782,7 +11783,7 @@
             }
           },
           "502": {
-            "description": "<ul>\n<li><code>B2bExternalServiceError</code>: 외부 서비스에서 에러가 발생한 경우</li>\n</ul>\n",
+            "description": "* `B2bExternalServiceError`: 외부 서비스에서 에러가 발생한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -11802,7 +11803,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "세금 계산서 PDF 다운로드 URL 조회",
-        "x-portone-description": "<p>등록된 세금 계산서 PDF 다운로드 URL을 공급자 혹은 공급받는자 문서번호로 조회합니다.</p>\n",
+        "x-portone-description": "등록된 세금 계산서 PDF 다운로드 URL을 공급자 혹은 공급받는자 문서번호로 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetB2bTaxInvoicePdfDownloadUrlError"
         },
@@ -11811,20 +11812,20 @@
     },
     "/b2b-preview/tax-invoices/register": {
       "post": {
-        "summary": "<p>세금계산서 임시 저장</p>\n",
-        "description": "<p>세금계산서 임시 저장</p>\n<p>세금계산서 임시 저장을 요청합니다.</p>\n",
+        "summary": "세금계산서 임시 저장",
+        "description": "세금계산서 임시 저장\n\n세금계산서 임시 저장을 요청합니다.",
         "operationId": "requestB2bTaxInvoiceRegister",
         "parameters": [
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\n\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다."
           }
         ],
         "requestBody": {
@@ -11839,7 +11840,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 세금계산서를 반환합니다.</p>\n",
+            "description": "성공 응답으로 세금계산서를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -11847,10 +11848,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 세금계산서를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 세금계산서를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -11860,7 +11861,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -11870,7 +11871,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>B2bNotEnabledError</code>: B2B 기능이 활성화되지 않은 경우</li>\n</ul>\n",
+            "description": "* `B2bNotEnabledError`: B2B 기능이 활성화되지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -11880,7 +11881,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>B2bSupplierNotFoundError</code>: 공급자가 존재하지 않은 경우</li>\n<li><code>B2bRecipientNotFoundError</code>: 공급받는자가 존재하지 않은 경우</li>\n</ul>\n",
+            "description": "* `B2bSupplierNotFoundError`: 공급자가 존재하지 않은 경우\n* `B2bRecipientNotFoundError`: 공급받는자가 존재하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -11890,7 +11891,7 @@
             }
           },
           "502": {
-            "description": "<ul>\n<li><code>B2bExternalServiceError</code>: 외부 서비스에서 에러가 발생한 경우</li>\n</ul>\n",
+            "description": "* `B2bExternalServiceError`: 외부 서비스에서 에러가 발생한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -11910,7 +11911,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "세금계산서 임시 저장",
-        "x-portone-description": "<p>세금계산서 임시 저장을 요청합니다.</p>\n",
+        "x-portone-description": "세금계산서 임시 저장을 요청합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/RequestB2bTaxInvoiceRegisterError"
         },
@@ -11919,20 +11920,20 @@
     },
     "/b2b-preview/tax-invoices/request": {
       "post": {
-        "summary": "<p>세금계산서 역발행 요청</p>\n",
-        "description": "<p>세금계산서 역발행 요청</p>\n<p>임시저장(REGISTERED) 상태의 역발행 세금계산서를 공급자에게 발행 요청합니다.</p>\n",
+        "summary": "세금계산서 역발행 요청",
+        "description": "세금계산서 역발행 요청\n\n임시저장(REGISTERED) 상태의 역발행 세금계산서를 공급자에게 발행 요청합니다.",
         "operationId": "requestB2bTaxInvoice",
         "parameters": [
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\n\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다."
           }
         ],
         "requestBody": {
@@ -11947,7 +11948,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 세금계산서를 반환합니다.</p>\n",
+            "description": "성공 응답으로 세금계산서를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -11955,10 +11956,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 세금계산서를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 세금계산서를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n<li><code>B2bTaxInvoiceNotRegisteredStatusError</code>: 세금계산서가 임시저장 상태가 아닌 경우</li>\n<li><code>B2bTaxInvoiceNoRecipientDocumentKeyError</code>: 세금계산서에 공급받는자 문서 번호가 기입되지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우\n* `B2bTaxInvoiceNotRegisteredStatusError`: 세금계산서가 임시저장 상태가 아닌 경우\n* `B2bTaxInvoiceNoRecipientDocumentKeyError`: 세금계산서에 공급받는자 문서 번호가 기입되지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -11968,7 +11969,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -11978,7 +11979,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>B2bNotEnabledError</code>: B2B 기능이 활성화되지 않은 경우</li>\n</ul>\n",
+            "description": "* `B2bNotEnabledError`: B2B 기능이 활성화되지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -11988,7 +11989,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>B2bTaxInvoiceNotFoundError</code>: 세금계산서가 존재하지 않은 경우</li>\n</ul>\n",
+            "description": "* `B2bTaxInvoiceNotFoundError`: 세금계산서가 존재하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -11998,7 +11999,7 @@
             }
           },
           "502": {
-            "description": "<ul>\n<li><code>B2bExternalServiceError</code>: 외부 서비스에서 에러가 발생한 경우</li>\n</ul>\n",
+            "description": "* `B2bExternalServiceError`: 외부 서비스에서 에러가 발생한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -12018,7 +12019,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "세금계산서 역발행 요청",
-        "x-portone-description": "<p>임시저장(REGISTERED) 상태의 역발행 세금계산서를 공급자에게 발행 요청합니다.</p>\n",
+        "x-portone-description": "임시저장(REGISTERED) 상태의 역발행 세금계산서를 공급자에게 발행 요청합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/requestB2bTaxInvoiceError"
         },
@@ -12027,20 +12028,20 @@
     },
     "/b2b-preview/tax-invoices/file-upload-link": {
       "post": {
-        "summary": "<p>세금계산서 파일 업로드 링크 생성</p>\n",
-        "description": "<p>세금계산서 파일 업로드 링크 생성</p>\n<p>세금계산서의 첨부파일를 업로드할 링크를 생성합니다.</p>\n",
+        "summary": "세금계산서 파일 업로드 링크 생성",
+        "description": "세금계산서 파일 업로드 링크 생성\n\n세금계산서의 첨부파일를 업로드할 링크를 생성합니다.",
         "operationId": "createB2bTaxInvoiceFileUploadLink",
         "parameters": [
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\n\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다."
           }
         ],
         "requestBody": {
@@ -12065,7 +12066,7 @@
             }
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -12075,7 +12076,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -12085,7 +12086,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>B2bNotEnabledError</code>: B2B 기능이 활성화되지 않은 경우</li>\n</ul>\n",
+            "description": "* `B2bNotEnabledError`: B2B 기능이 활성화되지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -12105,7 +12106,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "세금계산서 파일 업로드 링크 생성",
-        "x-portone-description": "<p>세금계산서의 첨부파일를 업로드할 링크를 생성합니다.</p>\n",
+        "x-portone-description": "세금계산서의 첨부파일를 업로드할 링크를 생성합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/CreateB2bTaxInvoiceFileUploadLinkCreateError"
         },
@@ -12114,20 +12115,20 @@
     },
     "/b2b-preview/tax-invoices/attach-file": {
       "post": {
-        "summary": "<p>세금계산서 파일 첨부</p>\n",
-        "description": "<p>세금계산서 파일 첨부</p>\n<p>세금계산서에 파일을 첨부합니다.</p>\n",
+        "summary": "세금계산서 파일 첨부",
+        "description": "세금계산서 파일 첨부\n\n세금계산서에 파일을 첨부합니다.",
         "operationId": "attachB2bTaxInvoiceFile",
         "parameters": [
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\n\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다."
           }
         ],
         "requestBody": {
@@ -12145,7 +12146,7 @@
             "description": ""
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n<li><code>B2bTaxInvoiceNotRegisteredStatusError</code>: 세금계산서가 임시저장 상태가 아닌 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우\n* `B2bTaxInvoiceNotRegisteredStatusError`: 세금계산서가 임시저장 상태가 아닌 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -12155,7 +12156,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -12165,7 +12166,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>B2bNotEnabledError</code>: B2B 기능이 활성화되지 않은 경우</li>\n</ul>\n",
+            "description": "* `B2bNotEnabledError`: B2B 기능이 활성화되지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -12175,7 +12176,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>B2bTaxInvoiceNotFoundError</code>: 세금계산서가 존재하지 않은 경우</li>\n<li><code>B2bFileNotFoundError</code>: 업로드한 파일을 찾을 수 없는 경우</li>\n</ul>\n",
+            "description": "* `B2bTaxInvoiceNotFoundError`: 세금계산서가 존재하지 않은 경우\n* `B2bFileNotFoundError`: 업로드한 파일을 찾을 수 없는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -12185,7 +12186,7 @@
             }
           },
           "502": {
-            "description": "<ul>\n<li><code>B2bExternalServiceError</code>: 외부 서비스에서 에러가 발생한 경우</li>\n</ul>\n",
+            "description": "* `B2bExternalServiceError`: 외부 서비스에서 에러가 발생한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -12205,7 +12206,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "세금계산서 파일 첨부",
-        "x-portone-description": "<p>세금계산서에 파일을 첨부합니다.</p>\n",
+        "x-portone-description": "세금계산서에 파일을 첨부합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/AttachB2bTaxInvoiceFileError"
         },
@@ -12214,14 +12215,14 @@
     },
     "/b2b-preview/tax-invoices/{documentKey}/attachments": {
       "get": {
-        "summary": "<p>세금계산서 첨부파일 목록 조회</p>\n",
-        "description": "<p>세금계산서 첨부파일 목록 조회</p>\n<p>세금계산서에 첨부된 파일 목록을 조회합니다.</p>\n",
+        "summary": "세금계산서 첨부파일 목록 조회",
+        "description": "세금계산서 첨부파일 목록 조회\n\n세금계산서에 첨부된 파일 목록을 조회합니다.",
         "operationId": "getB2bTaxInvoiceAttachments",
         "parameters": [
           {
             "name": "documentKey",
             "in": "path",
-            "description": "<p>세금계산서 문서 번호</p>\n",
+            "description": "세금계산서 문서 번호",
             "required": true,
             "schema": {
               "type": "string"
@@ -12231,7 +12232,7 @@
           {
             "name": "brn",
             "in": "query",
-            "description": "<p>사업자등록번호</p>\n",
+            "description": "사업자등록번호",
             "required": true,
             "schema": {
               "type": "string"
@@ -12241,24 +12242,24 @@
           {
             "name": "documentKeyType",
             "in": "query",
-            "description": "<p>문서 번호 유형</p>\n<p>path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.</p>\n",
+            "description": "문서 번호 유형\n\npath 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.",
             "required": false,
             "schema": {
               "$ref": "#/components/schemas/B2bTaxInvoiceDocumentKeyType"
             },
             "x-portone-title": "문서 번호 유형",
-            "x-portone-description": "<p>path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.</p>\n"
+            "x-portone-description": "path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다."
           },
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\n\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다."
           }
         ],
         "responses": {
@@ -12273,7 +12274,7 @@
             }
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -12283,7 +12284,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -12293,7 +12294,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>B2bNotEnabledError</code>: B2B 기능이 활성화되지 않은 경우</li>\n</ul>\n",
+            "description": "* `B2bNotEnabledError`: B2B 기능이 활성화되지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -12303,7 +12304,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>B2bTaxInvoiceNotFoundError</code>: 세금계산서가 존재하지 않은 경우</li>\n</ul>\n",
+            "description": "* `B2bTaxInvoiceNotFoundError`: 세금계산서가 존재하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -12313,7 +12314,7 @@
             }
           },
           "502": {
-            "description": "<ul>\n<li><code>B2bExternalServiceError</code>: 외부 서비스에서 에러가 발생한 경우</li>\n</ul>\n",
+            "description": "* `B2bExternalServiceError`: 외부 서비스에서 에러가 발생한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -12333,7 +12334,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "세금계산서 첨부파일 목록 조회",
-        "x-portone-description": "<p>세금계산서에 첨부된 파일 목록을 조회합니다.</p>\n",
+        "x-portone-description": "세금계산서에 첨부된 파일 목록을 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetB2bTaxInvoiceAttachmentsError"
         },
@@ -12342,14 +12343,14 @@
     },
     "/b2b-preview/tax-invoices/{documentKey}/attachments/{attachmentId}": {
       "delete": {
-        "summary": "<p>세금계산서 첨부파일 삭제</p>\n",
-        "description": "<p>세금계산서 첨부파일 삭제</p>\n<p>세금계산서 첨부파일을 삭제합니다.</p>\n",
+        "summary": "세금계산서 첨부파일 삭제",
+        "description": "세금계산서 첨부파일 삭제\n\n세금계산서 첨부파일을 삭제합니다.",
         "operationId": "deleteB2bTaxInvoiceAttachment",
         "parameters": [
           {
             "name": "documentKey",
             "in": "path",
-            "description": "<p>세금계산서 문서 번호</p>\n",
+            "description": "세금계산서 문서 번호",
             "required": true,
             "schema": {
               "type": "string"
@@ -12359,7 +12360,7 @@
           {
             "name": "attachmentId",
             "in": "path",
-            "description": "<p>첨부파일 아이디</p>\n",
+            "description": "첨부파일 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -12369,7 +12370,7 @@
           {
             "name": "brn",
             "in": "query",
-            "description": "<p>사업자등록번호</p>\n",
+            "description": "사업자등록번호",
             "required": true,
             "schema": {
               "type": "string"
@@ -12379,24 +12380,24 @@
           {
             "name": "documentKeyType",
             "in": "query",
-            "description": "<p>문서 번호 유형</p>\n<p>path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.</p>\n",
+            "description": "문서 번호 유형\n\npath 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.",
             "required": false,
             "schema": {
               "$ref": "#/components/schemas/B2bTaxInvoiceDocumentKeyType"
             },
             "x-portone-title": "문서 번호 유형",
-            "x-portone-description": "<p>path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.</p>\n"
+            "x-portone-description": "path 파라미터로 전달된 문서번호 유형. 기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다."
           },
           {
             "name": "test",
             "in": "query",
-            "description": "<p>테스트 모드 여부</p>\n<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n",
+            "description": "테스트 모드 여부\n\ntrue 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.",
             "required": false,
             "schema": {
               "type": "boolean"
             },
             "x-portone-title": "테스트 모드 여부",
-            "x-portone-description": "<p>true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다.</p>\n"
+            "x-portone-description": "true 이면 테스트 모드로 실행되며, false 이거나 주어지지 않은 경우 테스트 모드를 사용하지 않습니다."
           }
         ],
         "responses": {
@@ -12404,7 +12405,7 @@
             "description": ""
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n<li><code>B2bTaxInvoiceNotRegisteredStatusError</code>: 세금계산서가 임시저장 상태가 아닌 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우\n* `B2bTaxInvoiceNotRegisteredStatusError`: 세금계산서가 임시저장 상태가 아닌 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -12414,7 +12415,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -12424,7 +12425,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>B2bNotEnabledError</code>: B2B 기능이 활성화되지 않은 경우</li>\n</ul>\n",
+            "description": "* `B2bNotEnabledError`: B2B 기능이 활성화되지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -12434,7 +12435,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>B2bTaxInvoiceNotFoundError</code>: 세금계산서가 존재하지 않은 경우</li>\n<li><code>B2bTaxInvoiceAttachmentNotFoundError</code>: 세금계산서의 첨부파일을 찾을 수 없는 경우</li>\n</ul>\n",
+            "description": "* `B2bTaxInvoiceNotFoundError`: 세금계산서가 존재하지 않은 경우\n* `B2bTaxInvoiceAttachmentNotFoundError`: 세금계산서의 첨부파일을 찾을 수 없는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -12444,7 +12445,7 @@
             }
           },
           "502": {
-            "description": "<ul>\n<li><code>B2bExternalServiceError</code>: 외부 서비스에서 에러가 발생한 경우</li>\n</ul>\n",
+            "description": "* `B2bExternalServiceError`: 외부 서비스에서 에러가 발생한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -12464,7 +12465,7 @@
         ],
         "x-portone-category": "b2b",
         "x-portone-title": "세금계산서 첨부파일 삭제",
-        "x-portone-description": "<p>세금계산서 첨부파일을 삭제합니다.</p>\n",
+        "x-portone-description": "세금계산서 첨부파일을 삭제합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/DeleteB2bTaxInvoiceAttachmentError"
         },
@@ -12473,14 +12474,14 @@
     },
     "/kakaopay/payment/order": {
       "get": {
-        "summary": "<p>카카오페이 주문 조회 API</p>\n",
-        "description": "<p>카카오페이 주문 조회 API</p>\n<p>주어진 아이디에 대응되는 카카오페이 주문 건을 조회합니다.\n해당 API 사용이 필요한 경우 포트원 기술지원팀으로 문의 주시길 바랍니다.</p>\n",
+        "summary": "카카오페이 주문 조회 API",
+        "description": "카카오페이 주문 조회 API\n\n주어진 아이디에 대응되는 카카오페이 주문 건을 조회합니다.\n해당 API 사용이 필요한 경우 포트원 기술지원팀으로 문의 주시길 바랍니다.",
         "operationId": "GetKakaopayPaymentOrder",
         "parameters": [
           {
             "name": "pgTxId",
             "in": "query",
-            "description": "<p>카카오페이 주문 번호 (tid)</p>\n",
+            "description": "카카오페이 주문 번호 (tid)",
             "required": true,
             "schema": {
               "type": "string"
@@ -12490,7 +12491,7 @@
           {
             "name": "channelKey",
             "in": "query",
-            "description": "<p>채널 키</p>\n",
+            "description": "채널 키",
             "required": true,
             "schema": {
               "type": "string"
@@ -12500,7 +12501,7 @@
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 카카오페이 주문 조회 응답 객체를 반환합니다.</p>\n",
+            "description": "성공 응답으로 카카오페이 주문 조회 응답 객체를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -12511,7 +12512,7 @@
             "x-portone-title": "성공 응답으로 카카오페이 주문 조회 응답 객체를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -12521,7 +12522,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -12541,7 +12542,7 @@
         ],
         "x-portone-category": "pgSpecific",
         "x-portone-title": "카카오페이 주문 조회 API",
-        "x-portone-description": "<p>주어진 아이디에 대응되는 카카오페이 주문 건을 조회합니다.\n해당 API 사용이 필요한 경우 포트원 기술지원팀으로 문의 주시길 바랍니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 카카오페이 주문 건을 조회합니다.\n해당 API 사용이 필요한 경우 포트원 기술지원팀으로 문의 주시길 바랍니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetKakaopayPaymentOrderError"
         }
@@ -12549,14 +12550,14 @@
     },
     "/payments/{paymentId}/register-store-receipt": {
       "post": {
-        "summary": "<p>영수증 내 하위 상점 거래 등록</p>\n",
-        "description": "<p>영수증 내 하위 상점 거래 등록</p>\n<p>결제 내역 매출전표에 하위 상점의 거래를 등록합니다.\n지원되는 PG사:\nKG이니시스(이용 전 콘솔 -&gt; 결제연동 탭에서 INIApi Key 등록 필요)</p>\n",
+        "summary": "영수증 내 하위 상점 거래 등록",
+        "description": "영수증 내 하위 상점 거래 등록\n\n결제 내역 매출전표에 하위 상점의 거래를 등록합니다.\n지원되는 PG사:\nKG이니시스(이용 전 콘솔 -> 결제연동 탭에서 INIApi Key 등록 필요)",
         "operationId": "registerStoreReceipt",
         "parameters": [
           {
             "name": "paymentId",
             "in": "path",
-            "description": "<p>등록할 하위 상점 결제 건 아이디</p>\n",
+            "description": "등록할 하위 상점 결제 건 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -12576,7 +12577,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답</p>\n",
+            "description": "성공 응답",
             "content": {
               "application/json": {
                 "schema": {
@@ -12587,7 +12588,7 @@
             "x-portone-title": "성공 응답"
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -12597,7 +12598,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -12607,7 +12608,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -12617,7 +12618,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PaymentNotFoundError</code>: 결제 건이 존재하지 않는 경우</li>\n</ul>\n",
+            "description": "* `PaymentNotFoundError`: 결제 건이 존재하지 않는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -12627,7 +12628,7 @@
             }
           },
           "409": {
-            "description": "<ul>\n<li><code>PaymentNotPaidError</code>: 결제가 완료되지 않은 경우</li>\n</ul>\n",
+            "description": "* `PaymentNotPaidError`: 결제가 완료되지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -12637,7 +12638,7 @@
             }
           },
           "502": {
-            "description": "<ul>\n<li><code>PgProviderError</code>: PG사에서 오류를 전달한 경우</li>\n</ul>\n",
+            "description": "* `PgProviderError`: PG사에서 오류를 전달한 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -12657,7 +12658,7 @@
         ],
         "x-portone-category": "payment",
         "x-portone-title": "영수증 내 하위 상점 거래 등록",
-        "x-portone-description": "<p>결제 내역 매출전표에 하위 상점의 거래를 등록합니다.\n지원되는 PG사:\nKG이니시스(이용 전 콘솔 -&gt; 결제연동 탭에서 INIApi Key 등록 필요)</p>\n",
+        "x-portone-description": "결제 내역 매출전표에 하위 상점의 거래를 등록합니다.\n지원되는 PG사:\nKG이니시스(이용 전 콘솔 -> 결제연동 탭에서 INIApi Key 등록 필요)",
         "x-portone-error": {
           "$ref": "#/components/schemas/RegisterStoreReceiptError"
         }
@@ -12674,14 +12675,14 @@
     "/payment-reconciliations/transactions/summaries": {},
     "/promotions/{promotionId}": {
       "get": {
-        "summary": "<p>프로모션 단건 조회</p>\n",
-        "description": "<p>프로모션 단건 조회</p>\n<p>주어진 아이디에 대응되는 프로모션을 조회합니다.</p>\n",
+        "summary": "프로모션 단건 조회",
+        "description": "프로모션 단건 조회\n\n주어진 아이디에 대응되는 프로모션을 조회합니다.",
         "operationId": "getPromotion",
         "parameters": [
           {
             "name": "promotionId",
             "in": "path",
-            "description": "<p>조회할 프로모션 아이디</p>\n",
+            "description": "조회할 프로모션 아이디",
             "required": true,
             "schema": {
               "type": "string"
@@ -12691,7 +12692,7 @@
         ],
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 프로모션 객체를 반환합니다.</p>\n",
+            "description": "성공 응답으로 프로모션 객체를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -12702,7 +12703,7 @@
             "x-portone-title": "성공 응답으로 프로모션 객체를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -12712,7 +12713,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -12722,7 +12723,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -12732,7 +12733,7 @@
             }
           },
           "404": {
-            "description": "<ul>\n<li><code>PromotionNotFoundError</code>: 프로모션이 존재하지 않는 경우</li>\n</ul>\n",
+            "description": "* `PromotionNotFoundError`: 프로모션이 존재하지 않는 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -12752,7 +12753,7 @@
         ],
         "x-portone-category": "promotion",
         "x-portone-title": "프로모션 단건 조회",
-        "x-portone-description": "<p>주어진 아이디에 대응되는 프로모션을 조회합니다.</p>\n",
+        "x-portone-description": "주어진 아이디에 대응되는 프로모션을 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPromotionError"
         }
@@ -12762,8 +12763,8 @@
     "/excel/promotions": {},
     "/platform/account-transfers": {
       "get": {
-        "summary": "<p>이체 내역 다건 조회</p>\n",
-        "description": "<p>이체 내역 다건 조회</p>\n<p>여러 이체 내역을 조회합니다.</p>\n",
+        "summary": "이체 내역 다건 조회",
+        "description": "이체 내역 다건 조회\n\n여러 이체 내역을 조회합니다.",
         "operationId": "getPlatformAccountTransfers",
         "parameters": [
           {
@@ -12795,7 +12796,7 @@
         },
         "responses": {
           "200": {
-            "description": "<p>성공 응답으로 조회된 이체 내역과 페이지 정보를 반환합니다.</p>\n",
+            "description": "성공 응답으로 조회된 이체 내역과 페이지 정보를 반환합니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -12803,10 +12804,10 @@
                 }
               }
             },
-            "x-portone-description": "<p>성공 응답으로 조회된 이체 내역과 페이지 정보를 반환합니다.</p>\n"
+            "x-portone-description": "성공 응답으로 조회된 이체 내역과 페이지 정보를 반환합니다."
           },
           "400": {
-            "description": "<ul>\n<li><code>InvalidRequestError</code>: 요청된 입력 정보가 유효하지 않은 경우</li>\n</ul>\n",
+            "description": "* `InvalidRequestError`: 요청된 입력 정보가 유효하지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -12816,7 +12817,7 @@
             }
           },
           "401": {
-            "description": "<ul>\n<li><code>UnauthorizedError</code>: 인증 정보가 올바르지 않은 경우</li>\n</ul>\n",
+            "description": "* `UnauthorizedError`: 인증 정보가 올바르지 않은 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -12826,7 +12827,7 @@
             }
           },
           "403": {
-            "description": "<ul>\n<li><code>PlatformNotEnabledError</code>: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</li>\n<li><code>ForbiddenError</code>: 요청이 거절된 경우</li>\n</ul>\n",
+            "description": "* `PlatformNotEnabledError`: 플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우\n* `ForbiddenError`: 요청이 거절된 경우",
             "content": {
               "application/json": {
                 "schema": {
@@ -12846,7 +12847,7 @@
         ],
         "x-portone-category": "platform.accountTransfer",
         "x-portone-title": "이체 내역 다건 조회",
-        "x-portone-description": "<p>여러 이체 내역을 조회합니다.</p>\n",
+        "x-portone-description": "여러 이체 내역을 조회합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/GetPlatformAccountTransfersError"
         },
@@ -12858,7 +12859,7 @@
     "schemas": {
       "Address": {
         "title": "분리 형식 주소",
-        "description": "<p>분리 형식 주소</p>\n<p>oneLine(한 줄 형식 주소) 필드는 항상 존재합니다.</p>\n",
+        "description": "분리 형식 주소\n\noneLine(한 줄 형식 주소) 필드는 항상 존재합니다.",
         "oneOf": [
           {
             "$ref": "#/components/schemas/OneLineAddress"
@@ -12875,7 +12876,7 @@
           }
         },
         "x-portone-title": "분리 형식 주소",
-        "x-portone-description": "<p>oneLine(한 줄 형식 주소) 필드는 항상 존재합니다.</p>\n",
+        "x-portone-description": "oneLine(한 줄 형식 주소) 필드는 항상 존재합니다.",
         "x-portone-discriminator": {
           "ONE_LINE": {
             "title": "한 줄 형식"
@@ -12887,7 +12888,7 @@
       },
       "AlreadyPaidError": {
         "title": "결제가 이미 완료된 경우",
-        "description": "<p>결제가 이미 완료된 경우</p>\n",
+        "description": "결제가 이미 완료된 경우",
         "type": "object",
         "required": [
           "type"
@@ -12905,7 +12906,7 @@
       },
       "AlreadyPaidOrWaitingError": {
         "title": "결제가 이미 완료되었거나 대기중인 경우",
-        "description": "<p>결제가 이미 완료되었거나 대기중인 경우</p>\n",
+        "description": "결제가 이미 완료되었거나 대기중인 경우",
         "type": "object",
         "required": [
           "type"
@@ -12951,7 +12952,7 @@
       },
       "AnalyticsAverageAmountChart": {
         "title": "고객사의 평균 거래액 현황 조회 응답",
-        "description": "<p>고객사의 평균 거래액 현황 조회 응답</p>\n",
+        "description": "고객사의 평균 거래액 현황 조회 응답",
         "type": "object",
         "required": [
           "stats",
@@ -12972,7 +12973,7 @@
       },
       "AnalyticsAverageAmountChartStat": {
         "title": "AnalyticsAverageAmountChartStat",
-        "description": "<p>특정 시점의 건별 평균 거래액, 고객 당 평균 거래액을 나타냅니다.</p>\n",
+        "description": "특정 시점의 건별 평균 거래액, 고객 당 평균 거래액을 나타냅니다.",
         "type": "object",
         "required": [
           "timestamp",
@@ -12996,11 +12997,11 @@
             "title": "고객 당 평균 거래액"
           }
         },
-        "x-portone-description": "<p>특정 시점의 건별 평균 거래액, 고객 당 평균 거래액을 나타냅니다.</p>\n"
+        "x-portone-description": "특정 시점의 건별 평균 거래액, 고객 당 평균 거래액을 나타냅니다."
       },
       "AnalyticsAverageAmountChartSummary": {
         "title": "AnalyticsAverageAmountChartSummary",
-        "description": "<p>전체 구간의 건별 평균 거래액, 고객 당 평균 거래액을 나타냅니다.</p>\n",
+        "description": "전체 구간의 건별 평균 거래액, 고객 당 평균 거래액을 나타냅니다.",
         "type": "object",
         "required": [
           "paymentAverageAmount",
@@ -13018,11 +13019,11 @@
             "title": "고객 당 평균 거래액"
           }
         },
-        "x-portone-description": "<p>전체 구간의 건별 평균 거래액, 고객 당 평균 거래액을 나타냅니다.</p>\n"
+        "x-portone-description": "전체 구간의 건별 평균 거래액, 고객 당 평균 거래액을 나타냅니다."
       },
       "AnalyticsCancellationRate": {
         "title": "고객사의 환불율 정보",
-        "description": "<p>고객사의 환불율 정보</p>\n",
+        "description": "고객사의 환불율 정보",
         "type": "object",
         "required": [
           "cancellationRate"
@@ -13037,7 +13038,7 @@
       },
       "AnalyticsCardChart": {
         "title": "고객사의 카드결제 현황 차트 정보",
-        "description": "<p>고객사의 카드결제 현황 차트 정보</p>\n",
+        "description": "고객사의 카드결제 현황 차트 정보",
         "type": "object",
         "required": [
           "stats"
@@ -13054,7 +13055,7 @@
       },
       "AnalyticsCardChartStat": {
         "title": "AnalyticsCardChartStat",
-        "description": "<p>특정 시점의 카드결제 거래 건 수와 금액을 나타냅니다.</p>\n",
+        "description": "특정 시점의 카드결제 거래 건 수와 금액을 나타냅니다.",
         "type": "object",
         "required": [
           "timestamp",
@@ -13078,11 +13079,11 @@
             "title": "거래 건수"
           }
         },
-        "x-portone-description": "<p>특정 시점의 카드결제 거래 건 수와 금액을 나타냅니다.</p>\n"
+        "x-portone-description": "특정 시점의 카드결제 거래 건 수와 금액을 나타냅니다."
       },
       "AnalyticsCardCompanyChart": {
         "title": "고객사의 카드사별 결제 현황 조회 응답",
-        "description": "<p>고객사의 카드사별 결제 현황 조회 응답</p>\n",
+        "description": "고객사의 카드사별 결제 현황 조회 응답",
         "type": "object",
         "required": [
           "stats",
@@ -13110,7 +13111,7 @@
       },
       "AnalyticsCardCompanyChartRemainderStat": {
         "title": "AnalyticsCardCompanyChartRemainderStat",
-        "description": "<p>특정 시점의 나머지 카드사들의 결제금액, 결제 건수를 나타냅니다.</p>\n",
+        "description": "특정 시점의 나머지 카드사들의 결제금액, 결제 건수를 나타냅니다.",
         "type": "object",
         "required": [
           "timestamp",
@@ -13134,11 +13135,11 @@
             "title": "결제 건수"
           }
         },
-        "x-portone-description": "<p>특정 시점의 나머지 카드사들의 결제금액, 결제 건수를 나타냅니다.</p>\n"
+        "x-portone-description": "특정 시점의 나머지 카드사들의 결제금액, 결제 건수를 나타냅니다."
       },
       "AnalyticsCardCompanyChartStat": {
         "title": "AnalyticsCardCompanyChartStat",
-        "description": "<p>특정 시점의 카드사 별 결제금액, 결제 건수를 나타냅니다.</p>\n",
+        "description": "특정 시점의 카드사 별 결제금액, 결제 건수를 나타냅니다.",
         "type": "object",
         "required": [
           "timestamp",
@@ -13167,11 +13168,11 @@
             "title": "결제 건수"
           }
         },
-        "x-portone-description": "<p>특정 시점의 카드사 별 결제금액, 결제 건수를 나타냅니다.</p>\n"
+        "x-portone-description": "특정 시점의 카드사 별 결제금액, 결제 건수를 나타냅니다."
       },
       "AnalyticsCardCompanyChartSummary": {
         "title": "AnalyticsCardCompanyChartSummary",
-        "description": "<p>결제금액, 결제 건수의 총합을 나타냅니다.</p>\n",
+        "description": "결제금액, 결제 건수의 총합을 나타냅니다.",
         "type": "object",
         "required": [
           "totalAmount",
@@ -13189,11 +13190,11 @@
             "title": "결제 건수 합"
           }
         },
-        "x-portone-description": "<p>결제금액, 결제 건수의 총합을 나타냅니다.</p>\n"
+        "x-portone-description": "결제금액, 결제 건수의 총합을 나타냅니다."
       },
       "AnalyticsEasyPayChart": {
         "title": "고객사의 간편결제 현황 차트 정보",
-        "description": "<p>고객사의 간편결제 현황 차트 정보</p>\n",
+        "description": "고객사의 간편결제 현황 차트 정보",
         "type": "object",
         "required": [
           "stats"
@@ -13210,7 +13211,7 @@
       },
       "AnalyticsEasyPayChartStat": {
         "title": "AnalyticsEasyPayChartStat",
-        "description": "<p>특정 시점의 간편결제 거래 건수와 금액을 나타냅니다.</p>\n",
+        "description": "특정 시점의 간편결제 거래 건수와 금액을 나타냅니다.",
         "type": "object",
         "required": [
           "timestamp",
@@ -13234,11 +13235,11 @@
             "title": "거래 건수"
           }
         },
-        "x-portone-description": "<p>특정 시점의 간편결제 거래 건수와 금액을 나타냅니다.</p>\n"
+        "x-portone-description": "특정 시점의 간편결제 거래 건수와 금액을 나타냅니다."
       },
       "AnalyticsEasyPayProviderChart": {
         "title": "고객사의 간편결제사별 결제 현황 차트 정보",
-        "description": "<p>고객사의 간편결제사별 결제 현황 차트 정보</p>\n",
+        "description": "고객사의 간편결제사별 결제 현황 차트 정보",
         "type": "object",
         "required": [
           "stats",
@@ -13266,7 +13267,7 @@
       },
       "AnalyticsEasyPayProviderChartRemainderStat": {
         "title": "AnalyticsEasyPayProviderChartRemainderStat",
-        "description": "<p>특정 시점의 나머지 간편결제사들의 결제금액, 결제 건수를 나타냅니다.</p>\n",
+        "description": "특정 시점의 나머지 간편결제사들의 결제금액, 결제 건수를 나타냅니다.",
         "type": "object",
         "required": [
           "timestamp",
@@ -13290,11 +13291,11 @@
             "title": "결제 건수"
           }
         },
-        "x-portone-description": "<p>특정 시점의 나머지 간편결제사들의 결제금액, 결제 건수를 나타냅니다.</p>\n"
+        "x-portone-description": "특정 시점의 나머지 간편결제사들의 결제금액, 결제 건수를 나타냅니다."
       },
       "AnalyticsEasyPayProviderChartStat": {
         "title": "AnalyticsEasyPayProviderChartStat",
-        "description": "<p>특정 시점의 간편결제사별 결제금액, 결제 건수를 나타냅니다.</p>\n",
+        "description": "특정 시점의 간편결제사별 결제금액, 결제 건수를 나타냅니다.",
         "type": "object",
         "required": [
           "timestamp",
@@ -13323,11 +13324,11 @@
             "title": "결제 건수"
           }
         },
-        "x-portone-description": "<p>특정 시점의 간편결제사별 결제금액, 결제 건수를 나타냅니다.</p>\n"
+        "x-portone-description": "특정 시점의 간편결제사별 결제금액, 결제 건수를 나타냅니다."
       },
       "AnalyticsEasyPayProviderChartSummary": {
         "title": "AnalyticsEasyPayProviderChartSummary",
-        "description": "<p>결제금액, 결제 건수의 총합을 나타냅니다.</p>\n",
+        "description": "결제금액, 결제 건수의 총합을 나타냅니다.",
         "type": "object",
         "required": [
           "totalAmount",
@@ -13345,11 +13346,11 @@
             "title": "결제 건수의 합"
           }
         },
-        "x-portone-description": "<p>결제금액, 결제 건수의 총합을 나타냅니다.</p>\n"
+        "x-portone-description": "결제금액, 결제 건수의 총합을 나타냅니다."
       },
       "AnalyticsOverseasPaymentUsage": {
         "title": "고객사의 해외 결제 사용 여부",
-        "description": "<p>고객사의 해외 결제 사용 여부</p>\n",
+        "description": "고객사의 해외 결제 사용 여부",
         "type": "object",
         "required": [
           "isUsing"
@@ -13363,7 +13364,7 @@
       },
       "AnalyticsPaymentChart": {
         "title": "고객사의 결제 현황 차트 정보",
-        "description": "<p>고객사의 결제 현황 차트 정보</p>\n",
+        "description": "고객사의 결제 현황 차트 정보",
         "type": "object",
         "required": [
           "stats"
@@ -13380,7 +13381,7 @@
       },
       "AnalyticsPaymentChartInsight": {
         "title": "고객사의 결제 현황 인사이트 정보",
-        "description": "<p>고객사의 결제 현황 인사이트 정보</p>\n",
+        "description": "고객사의 결제 현황 인사이트 정보",
         "type": "object",
         "required": [
           "highestHourInDay",
@@ -13420,7 +13421,7 @@
       },
       "AnalyticsPaymentChartStat": {
         "title": "AnalyticsPaymentChartStat",
-        "description": "<p>특정 시점의 거래 건 수와 금액을 나타냅니다.</p>\n",
+        "description": "특정 시점의 거래 건 수와 금액을 나타냅니다.",
         "type": "object",
         "required": [
           "timestamp",
@@ -13444,11 +13445,11 @@
             "title": "거래 건수"
           }
         },
-        "x-portone-description": "<p>특정 시점의 거래 건 수와 금액을 나타냅니다.</p>\n"
+        "x-portone-description": "특정 시점의 거래 건 수와 금액을 나타냅니다."
       },
       "AnalyticsPaymentMethodChart": {
         "title": "고객사의 결제수단 현황 차트 정보",
-        "description": "<p>고객사의 결제수단 현황 차트 정보</p>\n",
+        "description": "고객사의 결제수단 현황 차트 정보",
         "type": "object",
         "required": [
           "stats"
@@ -13465,7 +13466,7 @@
       },
       "AnalyticsPaymentMethodChartStat": {
         "title": "AnalyticsPaymentMethodChartStat",
-        "description": "<p>결제수단별 결제금액, 결제 건수를 나타냅니다.</p>\n",
+        "description": "결제수단별 결제금액, 결제 건수를 나타냅니다.",
         "type": "object",
         "required": [
           "amount",
@@ -13487,11 +13488,11 @@
             "title": "결제수단별 결제 건수"
           }
         },
-        "x-portone-description": "<p>결제수단별 결제금액, 결제 건수를 나타냅니다.</p>\n"
+        "x-portone-description": "결제수단별 결제금액, 결제 건수를 나타냅니다."
       },
       "AnalyticsPaymentMethodTrendChart": {
         "title": "고객사의 결제수단 트렌드 차트 정보",
-        "description": "<p>고객사의 결제수단 트렌드 차트 정보</p>\n",
+        "description": "고객사의 결제수단 트렌드 차트 정보",
         "type": "object",
         "required": [
           "stats"
@@ -13503,14 +13504,14 @@
               "$ref": "#/components/schemas/AnalyticsPaymentMethodTrendChartStat"
             },
             "title": "결제수단별 결제금액, 결제 건수 데이터",
-            "description": "<p>(timestamp, paymentMethod) 를 기준으로 오름차순 정렬되어 주어집니다.</p>\n"
+            "description": "(timestamp, paymentMethod) 를 기준으로 오름차순 정렬되어 주어집니다."
           }
         },
         "x-portone-title": "고객사의 결제수단 트렌드 차트 정보"
       },
       "AnalyticsPaymentMethodTrendChartStat": {
         "title": "AnalyticsPaymentMethodTrendChartStat",
-        "description": "<p>특정 시점의 결제수단별 결제금액, 결제 건수를 나타냅니다.</p>\n",
+        "description": "특정 시점의 결제수단별 결제금액, 결제 건수를 나타냅니다.",
         "type": "object",
         "required": [
           "timestamp",
@@ -13538,11 +13539,11 @@
             "title": "결제 건수"
           }
         },
-        "x-portone-description": "<p>특정 시점의 결제수단별 결제금액, 결제 건수를 나타냅니다.</p>\n"
+        "x-portone-description": "특정 시점의 결제수단별 결제금액, 결제 건수를 나타냅니다."
       },
       "AnalyticsPaymentStatusByPaymentClientChart": {
         "title": "고객사의 결제 환경 별 결제 상태 차트 정보",
-        "description": "<p>고객사의 결제 환경 별 결제 상태 차트 정보</p>\n",
+        "description": "고객사의 결제 환경 별 결제 상태 차트 정보",
         "type": "object",
         "required": [
           "stats"
@@ -13559,7 +13560,7 @@
       },
       "AnalyticsPaymentStatusByPaymentClientChartStat": {
         "title": "AnalyticsPaymentStatusByPaymentClientChartStat",
-        "description": "<p>고객사의 결제 환경 별 결제 상태 차트 정보</p>\n",
+        "description": "고객사의 결제 환경 별 결제 상태 차트 정보",
         "type": "object",
         "required": [
           "paymentClientType",
@@ -13587,11 +13588,11 @@
             "title": "거래 건수"
           }
         },
-        "x-portone-description": "<p>고객사의 결제 환경 별 결제 상태 차트 정보</p>\n"
+        "x-portone-description": "고객사의 결제 환경 별 결제 상태 차트 정보"
       },
       "AnalyticsPaymentStatusByPaymentMethodChart": {
         "title": "고객사의 결제 수단 별 결제 상태 차트 정보",
-        "description": "<p>고객사의 결제 수단 별 결제 상태 차트 정보</p>\n",
+        "description": "고객사의 결제 수단 별 결제 상태 차트 정보",
         "type": "object",
         "required": [
           "stats"
@@ -13608,7 +13609,7 @@
       },
       "AnalyticsPaymentStatusByPaymentMethodChartStat": {
         "title": "AnalyticsPaymentStatusByPaymentMethodChartStat",
-        "description": "<p>각 결제수단, 상태 별 건수와 금액을 나타냅니다.</p>\n",
+        "description": "각 결제수단, 상태 별 건수와 금액을 나타냅니다.",
         "type": "object",
         "required": [
           "paymentStatus",
@@ -13635,11 +13636,11 @@
             "title": "거래 건수"
           }
         },
-        "x-portone-description": "<p>각 결제수단, 상태 별 건수와 금액을 나타냅니다.</p>\n"
+        "x-portone-description": "각 결제수단, 상태 별 건수와 금액을 나타냅니다."
       },
       "AnalyticsPaymentStatusByPgCompanyChart": {
         "title": "고객사의 PG사 별 결제 상태 차트 정보",
-        "description": "<p>고객사의 PG사 별 결제 상태 차트 정보</p>\n",
+        "description": "고객사의 PG사 별 결제 상태 차트 정보",
         "type": "object",
         "required": [
           "stats"
@@ -13656,7 +13657,7 @@
       },
       "AnalyticsPaymentStatusByPgCompanyChartStat": {
         "title": "AnalyticsPaymentStatusByPgCompanyChartStat",
-        "description": "<p>각 상태의 건수와 금액, 사분위수를 나타냅니다.</p>\n",
+        "description": "각 상태의 건수와 금액, 사분위수를 나타냅니다.",
         "type": "object",
         "required": [
           "pgCompany",
@@ -13684,11 +13685,11 @@
             "title": "거래 건수"
           }
         },
-        "x-portone-description": "<p>각 상태의 건수와 금액, 사분위수를 나타냅니다.</p>\n"
+        "x-portone-description": "각 상태의 건수와 금액, 사분위수를 나타냅니다."
       },
       "AnalyticsPaymentStatusChart": {
         "title": "고객사의 결제 상태 차트 정보",
-        "description": "<p>고객사의 결제 상태 차트 정보</p>\n",
+        "description": "고객사의 결제 상태 차트 정보",
         "type": "object",
         "required": [
           "stats"
@@ -13705,7 +13706,7 @@
       },
       "AnalyticsPaymentStatusChartStat": {
         "title": "AnalyticsPaymentStatusChartStat",
-        "description": "<p>각 상태의 건수와 금액, 사분위수를 나타냅니다.</p>\n",
+        "description": "각 상태의 건수와 금액, 사분위수를 나타냅니다.",
         "type": "object",
         "required": [
           "paymentStatus",
@@ -13752,11 +13753,11 @@
             "title": "3 사분위수"
           }
         },
-        "x-portone-description": "<p>각 상태의 건수와 금액, 사분위수를 나타냅니다.</p>\n"
+        "x-portone-description": "각 상태의 건수와 금액, 사분위수를 나타냅니다."
       },
       "AnalyticsPgCompanyChart": {
         "title": "고객사의 결제대행사 현황 차트 정보",
-        "description": "<p>고객사의 결제대행사 현황 차트 정보</p>\n",
+        "description": "고객사의 결제대행사 현황 차트 정보",
         "type": "object",
         "required": [
           "stats"
@@ -13773,7 +13774,7 @@
       },
       "AnalyticsPgCompanyChartStat": {
         "title": "AnalyticsPgCompanyChartStat",
-        "description": "<p>결제대행사별 결제금액, 결제 건수를 나타냅니다.</p>\n",
+        "description": "결제대행사별 결제금액, 결제 건수를 나타냅니다.",
         "type": "object",
         "required": [
           "pgCompany",
@@ -13796,11 +13797,11 @@
             "title": "결제대행사별 결제 건수"
           }
         },
-        "x-portone-description": "<p>결제대행사별 결제금액, 결제 건수를 나타냅니다.</p>\n"
+        "x-portone-description": "결제대행사별 결제금액, 결제 건수를 나타냅니다."
       },
       "AnalyticsPgCompanyTrendChart": {
         "title": "고객사의 결제대행사별 거래 추이 차트 정보",
-        "description": "<p>고객사의 결제대행사별 거래 추이 차트 정보</p>\n",
+        "description": "고객사의 결제대행사별 거래 추이 차트 정보",
         "type": "object",
         "required": [
           "stats"
@@ -13817,7 +13818,7 @@
       },
       "AnalyticsPgCompanyTrendChartStat": {
         "title": "AnalyticsPgCompanyTrendChartStat",
-        "description": "<p>특정 시점의 결제대행사 별 결제금액, 결제 건수를 나타냅니다.</p>\n",
+        "description": "특정 시점의 결제대행사 별 결제금액, 결제 건수를 나타냅니다.",
         "type": "object",
         "required": [
           "timestamp",
@@ -13846,11 +13847,11 @@
             "title": "결제 건수"
           }
         },
-        "x-portone-description": "<p>특정 시점의 결제대행사 별 결제금액, 결제 건수를 나타냅니다.</p>\n"
+        "x-portone-description": "특정 시점의 결제대행사 별 결제금액, 결제 건수를 나타냅니다."
       },
       "AnalyticsTimeGranularity": {
         "title": "조회 시간 단위",
-        "description": "<p>조회 시간 단위</p>\n<p>하나의 단위 필드만 선택하여 입력합니다.</p>\n",
+        "description": "조회 시간 단위\n\n하나의 단위 필드만 선택하여 입력합니다.",
         "type": "object",
         "properties": {
           "minute": {
@@ -13870,11 +13871,11 @@
           }
         },
         "x-portone-title": "조회 시간 단위",
-        "x-portone-description": "<p>하나의 단위 필드만 선택하여 입력합니다.</p>\n"
+        "x-portone-description": "하나의 단위 필드만 선택하여 입력합니다."
       },
       "AnalyticsTimeGranularityDay": {
         "title": "일",
-        "description": "<p>일</p>\n",
+        "description": "일",
         "type": "object",
         "required": [
           "timezoneHourOffset"
@@ -13889,19 +13890,19 @@
       },
       "AnalyticsTimeGranularityHour": {
         "title": "시간",
-        "description": "<p>시간</p>\n",
+        "description": "시간",
         "type": "object",
         "x-portone-title": "시간"
       },
       "AnalyticsTimeGranularityMinute": {
         "title": "분",
-        "description": "<p>분</p>\n",
+        "description": "분",
         "type": "object",
         "x-portone-title": "분"
       },
       "AnalyticsTimeGranularityMonth": {
         "title": "월",
-        "description": "<p>월</p>\n",
+        "description": "월",
         "type": "object",
         "required": [
           "timezoneHourOffset"
@@ -13916,7 +13917,7 @@
       },
       "AnalyticsTimeGranularityWeek": {
         "title": "주",
-        "description": "<p>주</p>\n",
+        "description": "주",
         "type": "object",
         "required": [
           "timezoneHourOffset"
@@ -13965,7 +13966,7 @@
       },
       "ApplyEscrowLogisticsResponse": {
         "title": "에스크로 배송 정보 등록 성공 응답",
-        "description": "<p>에스크로 배송 정보 등록 성공 응답</p>\n",
+        "description": "에스크로 배송 정보 등록 성공 응답",
         "type": "object",
         "required": [
           "invoiceNumber",
@@ -13992,7 +13993,7 @@
       },
       "ApprovePlatformPartnerBody": {
         "title": "파트너 상태를 승인 완료로 변경하기 위한 입력 정보",
-        "description": "<p>파트너 상태를 승인 완료로 변경하기 위한 입력 정보</p>\n",
+        "description": "파트너 상태를 승인 완료로 변경하기 위한 입력 정보",
         "type": "object",
         "properties": {
           "memo": {
@@ -14038,7 +14039,7 @@
       },
       "ApprovePlatformPartnerResponse": {
         "title": "파트너 승인 성공 응답",
-        "description": "<p>파트너 승인 성공 응답</p>\n",
+        "description": "파트너 승인 성공 응답",
         "type": "object",
         "required": [
           "partner"
@@ -14087,7 +14088,7 @@
       },
       "ArchivePlatformAdditionalFeePolicyResponse": {
         "title": "추가 수수료 정책 보관 성공 응답",
-        "description": "<p>추가 수수료 정책 보관 성공 응답</p>\n",
+        "description": "추가 수수료 정책 보관 성공 응답",
         "type": "object",
         "required": [
           "additionalFeePolicy"
@@ -14136,7 +14137,7 @@
       },
       "ArchivePlatformContractResponse": {
         "title": "계약 보관 성공 응답",
-        "description": "<p>계약 보관 성공 응답</p>\n",
+        "description": "계약 보관 성공 응답",
         "type": "object",
         "required": [
           "contract"
@@ -14185,7 +14186,7 @@
       },
       "ArchivePlatformDiscountSharePolicyResponse": {
         "title": "할인 분담 보관 성공 응답",
-        "description": "<p>할인 분담 보관 성공 응답</p>\n",
+        "description": "할인 분담 보관 성공 응답",
         "type": "object",
         "required": [
           "discountSharePolicy"
@@ -14234,7 +14235,7 @@
       },
       "ArchivePlatformPartnerResponse": {
         "title": "파트너 보관 성공 응답",
-        "description": "<p>파트너 보관 성공 응답</p>\n",
+        "description": "파트너 보관 성공 응답",
         "type": "object",
         "required": [
           "partner"
@@ -14249,7 +14250,7 @@
       },
       "AttachB2bTaxInvoiceFileBody": {
         "title": "세금계산서 파일 첨부 정보",
-        "description": "<p>세금계산서 파일 첨부 정보</p>\n",
+        "description": "세금계산서 파일 첨부 정보",
         "type": "object",
         "required": [
           "brn",
@@ -14260,7 +14261,7 @@
           "brn": {
             "type": "string",
             "title": "사업자등록번호",
-            "description": "<ul>\n<li>없이 숫자 10자리로 구성됩니다.</li>\n</ul>\n"
+            "description": "- 없이 숫자 10자리로 구성됩니다."
           },
           "documentKey": {
             "type": "string",
@@ -14269,7 +14270,7 @@
           "documentKeyType": {
             "$ref": "#/components/schemas/B2bTaxInvoiceDocumentKeyType",
             "title": "문서 번호 유형",
-            "description": "<p>기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.</p>\n"
+            "description": "기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다."
           },
           "fileId": {
             "type": "string",
@@ -14318,7 +14319,7 @@
       },
       "B2bBankAccountNotFoundError": {
         "title": "계좌가 존재하지 않는 경우",
-        "description": "<p>계좌가 존재하지 않는 경우</p>\n",
+        "description": "계좌가 존재하지 않는 경우",
         "type": "object",
         "required": [
           "type"
@@ -14386,7 +14387,7 @@
       },
       "B2bCertificateType": {
         "title": "인증서 타입",
-        "description": "<p>인증서 타입</p>\n",
+        "description": "인증서 타입",
         "type": "string",
         "enum": [
           "E_TAX",
@@ -14408,7 +14409,7 @@
       },
       "B2bCertificateUnregisteredError": {
         "title": "인증서가 등록되어 있지 않은 경우",
-        "description": "<p>인증서가 등록되어 있지 않은 경우</p>\n",
+        "description": "인증서가 등록되어 있지 않은 경우",
         "type": "object",
         "required": [
           "type"
@@ -14426,7 +14427,7 @@
       },
       "B2bCompanyAlreadyRegisteredError": {
         "title": "사업자가 이미 연동되어 있는 경우",
-        "description": "<p>사업자가 이미 연동되어 있는 경우</p>\n",
+        "description": "사업자가 이미 연동되어 있는 경우",
         "type": "object",
         "required": [
           "type"
@@ -14457,7 +14458,7 @@
           "id": {
             "type": "string",
             "title": "담당자 ID",
-            "description": "<p>팝빌 로그인 계정으로 사용됩니다.</p>\n"
+            "description": "팝빌 로그인 계정으로 사용됩니다."
           },
           "name": {
             "type": "string",
@@ -14479,7 +14480,7 @@
           "isManager": {
             "type": "boolean",
             "title": "관리자 여부",
-            "description": "<p>true일 경우 관리자, false일 경우 담당자입니다.</p>\n"
+            "description": "true일 경우 관리자, false일 경우 담당자입니다."
           }
         }
       },
@@ -14497,7 +14498,7 @@
           "id": {
             "type": "string",
             "title": "담당자 ID",
-            "description": "<p>팝빌 로그인 계정으로 사용됩니다.</p>\n"
+            "description": "팝빌 로그인 계정으로 사용됩니다."
           },
           "password": {
             "type": "string",
@@ -14519,7 +14520,7 @@
       },
       "B2bCompanyNotFoundError": {
         "title": "사업자가 존재하지 않는 경우",
-        "description": "<p>사업자가 존재하지 않는 경우</p>\n",
+        "description": "사업자가 존재하지 않는 경우",
         "type": "object",
         "required": [
           "type"
@@ -14537,7 +14538,7 @@
       },
       "B2bCompanyState": {
         "title": "사업자 상태",
-        "description": "<p>사업자 상태</p>\n",
+        "description": "사업자 상태",
         "type": "object",
         "required": [
           "taxationType",
@@ -14549,9 +14550,9 @@
             "title": "사업자 과세 유형"
           },
           "taxationTypeDate": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "과세 유형 변경 일자"
           },
           "businessStatus": {
@@ -14559,9 +14560,9 @@
             "title": "사업자 영업 상태"
           },
           "closedSuspendedDate": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "휴폐업 일자"
           }
         },
@@ -14569,7 +14570,7 @@
       },
       "B2bCompanyStateBusinessStatus": {
         "title": "영업 상태",
-        "description": "<p>영업 상태</p>\n",
+        "description": "영업 상태",
         "type": "string",
         "enum": [
           "IN_BUSINESS",
@@ -14591,7 +14592,7 @@
       },
       "B2bCompanyStateTaxationType": {
         "title": "사업자 과세 유형",
-        "description": "<p>사업자 과세 유형</p>\n",
+        "description": "사업자 과세 유형",
         "type": "string",
         "enum": [
           "NORMAL",
@@ -14621,7 +14622,7 @@
       },
       "B2bContactNotFoundError": {
         "title": "담당자가 존재하지 않는 경우",
-        "description": "<p>담당자가 존재하지 않는 경우</p>\n",
+        "description": "담당자가 존재하지 않는 경우",
         "type": "object",
         "required": [
           "type"
@@ -14639,7 +14640,7 @@
       },
       "B2bExternalServiceError": {
         "title": "외부 서비스에서 에러가 발생한 경우",
-        "description": "<p>외부 서비스에서 에러가 발생한 경우</p>\n",
+        "description": "외부 서비스에서 에러가 발생한 경우",
         "type": "object",
         "required": [
           "type",
@@ -14658,7 +14659,7 @@
       },
       "B2bFileNotFoundError": {
         "title": "업로드한 파일을 찾을 수 없는 경우",
-        "description": "<p>업로드한 파일을 찾을 수 없는 경우</p>\n",
+        "description": "업로드한 파일을 찾을 수 없는 경우",
         "type": "object",
         "required": [
           "type"
@@ -14676,7 +14677,7 @@
       },
       "B2bFinancialSystemCommunicationError": {
         "title": "금융기관과의 통신에 실패한 경우",
-        "description": "<p>금융기관과의 통신에 실패한 경우</p>\n",
+        "description": "금융기관과의 통신에 실패한 경우",
         "type": "object",
         "required": [
           "type"
@@ -14694,7 +14695,7 @@
       },
       "B2bFinancialSystemFailureError": {
         "title": "금융기관 장애",
-        "description": "<p>금융기관 장애</p>\n",
+        "description": "금융기관 장애",
         "type": "object",
         "required": [
           "type"
@@ -14712,7 +14713,7 @@
       },
       "B2bFinancialSystemUnderMaintenanceError": {
         "title": "금융기관 시스템이 점검 중인 경우",
-        "description": "<p>금융기관 시스템이 점검 중인 경우</p>\n",
+        "description": "금융기관 시스템이 점검 중인 경우",
         "type": "object",
         "required": [
           "type"
@@ -14730,7 +14731,7 @@
       },
       "B2bForeignExchangeAccountError": {
         "title": "계좌 정보 조회가 불가능한 외화 계좌인 경우",
-        "description": "<p>계좌 정보 조회가 불가능한 외화 계좌인 경우</p>\n",
+        "description": "계좌 정보 조회가 불가능한 외화 계좌인 경우",
         "type": "object",
         "required": [
           "type"
@@ -14748,7 +14749,7 @@
       },
       "B2bHometaxUnderMaintenanceError": {
         "title": "홈택스가 점검중이거나 순단이 발생한 경우",
-        "description": "<p>홈택스가 점검중이거나 순단이 발생한 경우</p>\n",
+        "description": "홈택스가 점검중이거나 순단이 발생한 경우",
         "type": "object",
         "required": [
           "type"
@@ -14766,7 +14767,7 @@
       },
       "B2bIdAlreadyExistsError": {
         "title": "ID가 이미 사용중인 경우",
-        "description": "<p>ID가 이미 사용중인 경우</p>\n",
+        "description": "ID가 이미 사용중인 경우",
         "type": "object",
         "required": [
           "type"
@@ -14797,7 +14798,7 @@
           "brn": {
             "type": "string",
             "title": "사업자등록번호",
-            "description": "<ul>\n<li>없이 숫자로만 구성됩니다.</li>\n</ul>\n"
+            "description": "- 없이 숫자로만 구성됩니다."
           },
           "name": {
             "type": "string",
@@ -14823,7 +14824,7 @@
       },
       "B2bMemberCompanyNotFoundError": {
         "title": "연동 사업자가 존재하지 않는 경우",
-        "description": "<p>연동 사업자가 존재하지 않는 경우</p>\n",
+        "description": "연동 사업자가 존재하지 않는 경우",
         "type": "object",
         "required": [
           "type"
@@ -14841,7 +14842,7 @@
       },
       "B2bModification": {
         "title": "세금 계산서 수정",
-        "description": "<p>세금 계산서 수정</p>\n",
+        "description": "세금 계산서 수정",
         "type": "object",
         "required": [
           "type",
@@ -14861,7 +14862,7 @@
       },
       "B2bNotEnabledError": {
         "title": "B2B 기능이 활성화되지 않은 경우",
-        "description": "<p>B2B 기능이 활성화되지 않은 경우</p>\n",
+        "description": "B2B 기능이 활성화되지 않은 경우",
         "type": "object",
         "required": [
           "type"
@@ -14879,7 +14880,7 @@
       },
       "B2bRecipientNotFoundError": {
         "title": "공급받는자가 존재하지 않은 경우",
-        "description": "<p>공급받는자가 존재하지 않은 경우</p>\n",
+        "description": "공급받는자가 존재하지 않은 경우",
         "type": "object",
         "required": [
           "type"
@@ -14897,7 +14898,7 @@
       },
       "B2bRegularMaintenanceTimeError": {
         "title": "금융기관 시스템이 정기 점검 중인 경우",
-        "description": "<p>금융기관 시스템이 정기 점검 중인 경우</p>\n",
+        "description": "금융기관 시스템이 정기 점검 중인 경우",
         "type": "object",
         "required": [
           "type"
@@ -14915,7 +14916,7 @@
       },
       "B2bSearchDateType": {
         "title": "조회 기준",
-        "description": "<p>조회 기준</p>\n",
+        "description": "조회 기준",
         "type": "string",
         "enum": [
           "REGISTER",
@@ -14937,7 +14938,7 @@
       },
       "B2bSupplierNotFoundError": {
         "title": "공급자가 존재하지 않은 경우",
-        "description": "<p>공급자가 존재하지 않은 경우</p>\n",
+        "description": "공급자가 존재하지 않은 경우",
         "type": "object",
         "required": [
           "type"
@@ -14955,7 +14956,7 @@
       },
       "B2bSuspendedAccountError": {
         "title": "정지 계좌인 경우",
-        "description": "<p>정지 계좌인 경우</p>\n",
+        "description": "정지 계좌인 경우",
         "type": "object",
         "required": [
           "type"
@@ -15062,7 +15063,7 @@
       },
       "B2bTaxInvoiceAdditionalContact": {
         "title": "추가 담당자",
-        "description": "<p>추가 담당자</p>\n",
+        "description": "추가 담당자",
         "type": "object",
         "required": [
           "email"
@@ -15071,7 +15072,7 @@
           "name": {
             "type": "string",
             "title": "성명",
-            "description": "<p>최대 100자</p>\n"
+            "description": "최대 100자"
           },
           "email": {
             "type": "string",
@@ -15082,7 +15083,7 @@
       },
       "B2bTaxInvoiceAttachment": {
         "title": "세금계산서 첨부파일",
-        "description": "<p>세금계산서 첨부파일</p>\n",
+        "description": "세금계산서 첨부파일",
         "type": "object",
         "required": [
           "id",
@@ -15108,7 +15109,7 @@
       },
       "B2bTaxInvoiceAttachmentNotFoundError": {
         "title": "세금계산서의 첨부파일을 찾을 수 없는 경우",
-        "description": "<p>세금계산서의 첨부파일을 찾을 수 없는 경우</p>\n",
+        "description": "세금계산서의 첨부파일을 찾을 수 없는 경우",
         "type": "object",
         "required": [
           "type"
@@ -15162,18 +15163,18 @@
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 권",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999"
           },
           "bookIssue": {
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 호",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999"
           },
           "writeDate": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "작성일"
           },
           "purposeType": {
@@ -15221,7 +15222,7 @@
               "type": "string"
             },
             "title": "비고",
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개"
           },
           "supplierDocumentKey": {
             "type": "string",
@@ -15253,7 +15254,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceItem"
             },
-            "description": "<p>최대 99개</p>\n"
+            "description": "최대 99개"
           },
           "contacts": {
             "title": "추가 담당자",
@@ -15261,7 +15262,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceAdditionalContact"
             },
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개"
           },
           "statusUpdatedAt": {
             "type": "string",
@@ -15276,7 +15277,7 @@
           "ntsApproveNumber": {
             "type": "string",
             "title": "국세청 승인번호",
-            "description": "<p>세금계산서 발행(전자서명) 시점에 자동으로 부여</p>\n"
+            "description": "세금계산서 발행(전자서명) 시점에 자동으로 부여"
           }
         }
       },
@@ -15290,37 +15291,37 @@
           "brn": {
             "type": "string",
             "title": "사업자등록번호",
-            "description": "<ul>\n<li>를 제외한 10자리</li>\n</ul>\n"
+            "description": "- 를 제외한 10자리"
           },
           "taxRegistrationId": {
             "type": "string",
             "title": "종사업자 식별 번호",
-            "description": "<p>4자리 고정</p>\n"
+            "description": "4자리 고정"
           },
           "name": {
             "type": "string",
             "title": "상호명",
-            "description": "<p>최대 200자</p>\n"
+            "description": "최대 200자"
           },
           "ceoName": {
             "type": "string",
             "title": "대표자 성명",
-            "description": "<p>최대 100자</p>\n"
+            "description": "최대 100자"
           },
           "address": {
             "type": "string",
             "title": "주소",
-            "description": "<p>최대 300자</p>\n"
+            "description": "최대 300자"
           },
           "businessType": {
             "type": "string",
             "title": "업태",
-            "description": "<p>최대 100자</p>\n"
+            "description": "최대 100자"
           },
           "businessClass": {
             "type": "string",
             "title": "종목",
-            "description": "<p>최대 100자</p>\n"
+            "description": "최대 100자"
           },
           "contact": {
             "$ref": "#/components/schemas/B2bTaxInvoiceContact",
@@ -15330,7 +15331,7 @@
       },
       "B2bTaxInvoiceContact": {
         "title": "세금계산서 담당자",
-        "description": "<p>세금계산서 담당자</p>\n",
+        "description": "세금계산서 담당자",
         "type": "object",
         "properties": {
           "name": {
@@ -15358,7 +15359,7 @@
       },
       "B2bTaxInvoiceDocumentKeyType": {
         "title": "문서번호 유형",
-        "description": "<p>문서번호 유형</p>\n",
+        "description": "문서번호 유형",
         "type": "string",
         "enum": [
           "SUPPLIER",
@@ -15376,7 +15377,7 @@
       },
       "B2bTaxInvoiceInput": {
         "title": "세금계산서 생성 요청 정보",
-        "description": "<p>세금계산서 생성 요청 정보</p>\n",
+        "description": "세금계산서 생성 요청 정보",
         "type": "object",
         "required": [
           "taxType",
@@ -15408,9 +15409,9 @@
             "title": "호"
           },
           "writeDate": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "작성일"
           },
           "purposeType": {
@@ -15458,12 +15459,12 @@
               "type": "string"
             },
             "title": "비고",
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개"
           },
           "supplierDocumentKey": {
             "type": "string",
             "title": "공급자 문서번호",
-            "description": "<p>영문 대소문자, 숫자, 특수문자('-','_')만 이용 가능</p>\n"
+            "description": "영문 대소문자, 숫자, 특수문자('-','_')만 이용 가능"
           },
           "supplier": {
             "$ref": "#/components/schemas/B2bTaxInvoiceCompany",
@@ -15472,7 +15473,7 @@
           "recipientDocumentKey": {
             "type": "string",
             "title": "공급받는자 문서번호",
-            "description": "<p>영문 대소문자, 숫자, 특수문자('-','_')만 이용 가능</p>\n"
+            "description": "영문 대소문자, 숫자, 특수문자('-','_')만 이용 가능"
           },
           "recipient": {
             "$ref": "#/components/schemas/B2bTaxInvoiceCompany",
@@ -15481,7 +15482,7 @@
           "sendSms": {
             "type": "boolean",
             "title": "문자 전송 여부",
-            "description": "<p>공급자 담당자 휴대폰번호 {supplier.contact.mobile_phone_number} 값으로 문자 전송 전송시 포인트 차감되며, 실패시 환불 처리 기본값은 false</p>\n"
+            "description": "공급자 담당자 휴대폰번호 {supplier.contact.mobile_phone_number} 값으로 문자 전송 전송시 포인트 차감되며, 실패시 환불 처리 기본값은 false"
           },
           "modification": {
             "$ref": "#/components/schemas/B2bModification",
@@ -15493,7 +15494,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceItem"
             },
-            "description": "<p>최대 99개</p>\n"
+            "description": "최대 99개"
           },
           "contacts": {
             "title": "추가 담당자",
@@ -15501,7 +15502,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceAdditionalContact"
             },
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개"
           }
         },
         "x-portone-title": "세금계산서 생성 요청 정보"
@@ -15544,18 +15545,18 @@
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 권",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999"
           },
           "bookIssue": {
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 호",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999"
           },
           "writeDate": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "작성일"
           },
           "purposeType": {
@@ -15603,7 +15604,7 @@
               "type": "string"
             },
             "title": "비고",
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개"
           },
           "supplierDocumentKey": {
             "type": "string",
@@ -15635,7 +15636,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceItem"
             },
-            "description": "<p>최대 99개</p>\n"
+            "description": "최대 99개"
           },
           "contacts": {
             "title": "추가 담당자",
@@ -15643,7 +15644,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceAdditionalContact"
             },
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개"
           },
           "statusUpdatedAt": {
             "type": "string",
@@ -15658,16 +15659,16 @@
           "ntsApproveNumber": {
             "type": "string",
             "title": "국세청 승인번호",
-            "description": "<p>세금계산서 발행(전자서명) 시점에 자동으로 부여</p>\n"
+            "description": "세금계산서 발행(전자서명) 시점에 자동으로 부여"
           },
           "recipientBusinessStatus": {
             "$ref": "#/components/schemas/B2bCompanyStateBusinessStatus",
             "title": "공급받는자 영업 상태"
           },
           "recipientClosedSuspendedDate": {
-            "description": "<p>상태가 CLOSED, SUSPENDED 상태인 경우에만 결과값 반환</p>\n",
+            "description": "상태가 CLOSED, SUSPENDED 상태인 경우에만 결과값 반환",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "공급받는자 휴폐업일자"
           }
         }
@@ -15710,18 +15711,18 @@
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 권",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999"
           },
           "bookIssue": {
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 호",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999"
           },
           "writeDate": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "작성일"
           },
           "purposeType": {
@@ -15769,7 +15770,7 @@
               "type": "string"
             },
             "title": "비고",
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개"
           },
           "supplierDocumentKey": {
             "type": "string",
@@ -15801,7 +15802,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceItem"
             },
-            "description": "<p>최대 99개</p>\n"
+            "description": "최대 99개"
           },
           "contacts": {
             "title": "추가 담당자",
@@ -15809,7 +15810,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceAdditionalContact"
             },
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개"
           },
           "statusUpdatedAt": {
             "type": "string",
@@ -15824,54 +15825,54 @@
           "ntsApproveNumber": {
             "type": "string",
             "title": "국세청 승인번호",
-            "description": "<p>세금계산서 발행(전자서명) 시점에 자동으로 부여</p>\n"
+            "description": "세금계산서 발행(전자서명) 시점에 자동으로 부여"
           }
         }
       },
       "B2bTaxInvoiceItem": {
         "title": "품목",
-        "description": "<p>품목</p>\n",
+        "description": "품목",
         "type": "object",
         "properties": {
           "purchaseDate": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "결제일"
           },
           "name": {
             "type": "string",
             "title": "품명",
-            "description": "<p>최대 100자</p>\n"
+            "description": "최대 100자"
           },
           "spec": {
             "type": "string",
             "title": "규격",
-            "description": "<p>최대 100자</p>\n"
+            "description": "최대 100자"
           },
           "quantity": {
             "type": "integer",
             "format": "int64",
             "title": "수량",
-            "description": "<p>입력 범위 : -99999999.99 ~ 999999999.99, 10^-quantityScale 단위로 치환됨</p>\n"
+            "description": "입력 범위 : -99999999.99 ~ 999999999.99, 10^-quantityScale 단위로 치환됨"
           },
           "quantityScale": {
             "type": "integer",
             "format": "int32",
             "title": "수량 단위",
-            "description": "<p>입력 범위 : 0 ~ 2, 기본값: 0</p>\n"
+            "description": "입력 범위 : 0 ~ 2, 기본값: 0"
           },
           "unitCostAmount": {
             "type": "integer",
             "format": "int64",
             "title": "단가",
-            "description": "<p>입력 범위 : -99999999999999.99 ~ 999999999999999.99</p>\n"
+            "description": "입력 범위 : -99999999999999.99 ~ 999999999999999.99"
           },
           "unitCostAmountScale": {
             "type": "integer",
             "format": "int32",
             "title": "단가 단위",
-            "description": "<p>입력 범위 : 0 ~ 2, 기본값: 0</p>\n"
+            "description": "입력 범위 : 0 ~ 2, 기본값: 0"
           },
           "supplyCostAmount": {
             "type": "integer",
@@ -15892,7 +15893,7 @@
       },
       "B2bTaxInvoiceModificationType": {
         "title": "수정 사유",
-        "description": "<p>수정 사유</p>\n",
+        "description": "수정 사유",
         "type": "string",
         "enum": [
           "CORRECTION_OF_ENTRY_ERRORS",
@@ -15926,7 +15927,7 @@
       },
       "B2bTaxInvoiceNoRecipientDocumentKeyError": {
         "title": "세금계산서에 공급받는자 문서 번호가 기입되지 않은 경우",
-        "description": "<p>세금계산서에 공급받는자 문서 번호가 기입되지 않은 경우</p>\n",
+        "description": "세금계산서에 공급받는자 문서 번호가 기입되지 않은 경우",
         "type": "object",
         "required": [
           "type"
@@ -15944,7 +15945,7 @@
       },
       "B2bTaxInvoiceNoSupplierDocumentKeyError": {
         "title": "세금계산서에 공급자 문서 번호가 기입되지 않은 경우",
-        "description": "<p>세금계산서에 공급자 문서 번호가 기입되지 않은 경우</p>\n",
+        "description": "세금계산서에 공급자 문서 번호가 기입되지 않은 경우",
         "type": "object",
         "required": [
           "type"
@@ -15962,7 +15963,7 @@
       },
       "B2bTaxInvoiceNonDeletableStatusError": {
         "title": "세금계산서가 삭제 가능한 상태가 아닌 경우",
-        "description": "<p>세금계산서가 삭제 가능한 상태가 아닌 경우</p>\n<p>삭제 가능한 상태는 <code>REGISTERED</code>, <code>ISSUE_REFUSED</code>, <code>REQUEST_CANCELLED_BY_RECIPIENT</code>, <code>ISSUE_CANCELLED_BY_SUPPLIER</code>, <code>SENDING_FAILED</code> 입니다.</p>\n",
+        "description": "세금계산서가 삭제 가능한 상태가 아닌 경우\n\n삭제 가능한 상태는 `REGISTERED`, `ISSUE_REFUSED`, `REQUEST_CANCELLED_BY_RECIPIENT`, `ISSUE_CANCELLED_BY_SUPPLIER`, `SENDING_FAILED` 입니다.",
         "type": "object",
         "required": [
           "type"
@@ -15976,12 +15977,12 @@
           }
         },
         "x-portone-title": "세금계산서가 삭제 가능한 상태가 아닌 경우",
-        "x-portone-description": "<p>삭제 가능한 상태는 <code>REGISTERED</code>, <code>ISSUE_REFUSED</code>, <code>REQUEST_CANCELLED_BY_RECIPIENT</code>, <code>ISSUE_CANCELLED_BY_SUPPLIER</code>, <code>SENDING_FAILED</code> 입니다.</p>\n",
+        "x-portone-description": "삭제 가능한 상태는 `REGISTERED`, `ISSUE_REFUSED`, `REQUEST_CANCELLED_BY_RECIPIENT`, `ISSUE_CANCELLED_BY_SUPPLIER`, `SENDING_FAILED` 입니다.",
         "x-portone-status-code": 400
       },
       "B2bTaxInvoiceNotFoundError": {
         "title": "세금계산서가 존재하지 않은 경우",
-        "description": "<p>세금계산서가 존재하지 않은 경우</p>\n",
+        "description": "세금계산서가 존재하지 않은 경우",
         "type": "object",
         "required": [
           "type"
@@ -15999,7 +16000,7 @@
       },
       "B2bTaxInvoiceNotIssuedStatusError": {
         "title": "세금계산서가 발행된(ISSUED) 상태가 아닌 경우",
-        "description": "<p>세금계산서가 발행된(ISSUED) 상태가 아닌 경우</p>\n",
+        "description": "세금계산서가 발행된(ISSUED) 상태가 아닌 경우",
         "type": "object",
         "required": [
           "type"
@@ -16017,7 +16018,7 @@
       },
       "B2bTaxInvoiceNotRegisteredStatusError": {
         "title": "세금계산서가 임시저장 상태가 아닌 경우",
-        "description": "<p>세금계산서가 임시저장 상태가 아닌 경우</p>\n",
+        "description": "세금계산서가 임시저장 상태가 아닌 경우",
         "type": "object",
         "required": [
           "type"
@@ -16035,7 +16036,7 @@
       },
       "B2bTaxInvoiceNotRequestedStatusError": {
         "title": "세금계산서가 역발행 대기 상태가 아닌 경우",
-        "description": "<p>세금계산서가 역발행 대기 상태가 아닌 경우</p>\n",
+        "description": "세금계산서가 역발행 대기 상태가 아닌 경우",
         "type": "object",
         "required": [
           "type"
@@ -16053,7 +16054,7 @@
       },
       "B2bTaxInvoicePurposeType": {
         "title": "영수/청구",
-        "description": "<p>영수/청구</p>\n",
+        "description": "영수/청구",
         "type": "string",
         "enum": [
           "RECEIPT",
@@ -16103,18 +16104,18 @@
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 권",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999"
           },
           "bookIssue": {
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 호",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999"
           },
           "writeDate": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "작성일"
           },
           "purposeType": {
@@ -16162,7 +16163,7 @@
               "type": "string"
             },
             "title": "비고",
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개"
           },
           "supplierDocumentKey": {
             "type": "string",
@@ -16194,7 +16195,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceItem"
             },
-            "description": "<p>최대 99개</p>\n"
+            "description": "최대 99개"
           },
           "contacts": {
             "title": "추가 담당자",
@@ -16202,7 +16203,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceAdditionalContact"
             },
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개"
           },
           "statusUpdatedAt": {
             "type": "string",
@@ -16247,18 +16248,18 @@
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 권",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999"
           },
           "bookIssue": {
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 호",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999"
           },
           "writeDate": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "작성일"
           },
           "purposeType": {
@@ -16306,7 +16307,7 @@
               "type": "string"
             },
             "title": "비고",
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개"
           },
           "supplierDocumentKey": {
             "type": "string",
@@ -16338,7 +16339,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceItem"
             },
-            "description": "<p>최대 99개</p>\n"
+            "description": "최대 99개"
           },
           "contacts": {
             "title": "추가 담당자",
@@ -16346,7 +16347,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceAdditionalContact"
             },
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개"
           },
           "statusUpdatedAt": {
             "type": "string",
@@ -16391,18 +16392,18 @@
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 권",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999"
           },
           "bookIssue": {
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 호",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999"
           },
           "writeDate": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "작성일"
           },
           "purposeType": {
@@ -16450,7 +16451,7 @@
               "type": "string"
             },
             "title": "비고",
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개"
           },
           "supplierDocumentKey": {
             "type": "string",
@@ -16482,7 +16483,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceItem"
             },
-            "description": "<p>최대 99개</p>\n"
+            "description": "최대 99개"
           },
           "contacts": {
             "title": "추가 담당자",
@@ -16490,7 +16491,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceAdditionalContact"
             },
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개"
           },
           "statusUpdatedAt": {
             "type": "string",
@@ -16535,18 +16536,18 @@
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 권",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999"
           },
           "bookIssue": {
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 호",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999"
           },
           "writeDate": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "작성일"
           },
           "purposeType": {
@@ -16594,7 +16595,7 @@
               "type": "string"
             },
             "title": "비고",
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개"
           },
           "supplierDocumentKey": {
             "type": "string",
@@ -16626,7 +16627,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceItem"
             },
-            "description": "<p>최대 99개</p>\n"
+            "description": "최대 99개"
           },
           "contacts": {
             "title": "추가 담당자",
@@ -16634,7 +16635,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceAdditionalContact"
             },
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개"
           },
           "statusUpdatedAt": {
             "type": "string",
@@ -16682,18 +16683,18 @@
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 권",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999"
           },
           "bookIssue": {
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 호",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999"
           },
           "writeDate": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "작성일"
           },
           "purposeType": {
@@ -16741,7 +16742,7 @@
               "type": "string"
             },
             "title": "비고",
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개"
           },
           "supplierDocumentKey": {
             "type": "string",
@@ -16773,7 +16774,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceItem"
             },
-            "description": "<p>최대 99개</p>\n"
+            "description": "최대 99개"
           },
           "contacts": {
             "title": "추가 담당자",
@@ -16781,7 +16782,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceAdditionalContact"
             },
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개"
           },
           "statusUpdatedAt": {
             "type": "string",
@@ -16796,7 +16797,7 @@
           "ntsApproveNumber": {
             "type": "string",
             "title": "국세청 승인번호",
-            "description": "<p>세금계산서 발행(전자서명) 시점에 자동으로 부여</p>\n"
+            "description": "세금계산서 발행(전자서명) 시점에 자동으로 부여"
           },
           "ntsSentAt": {
             "type": "string",
@@ -16845,18 +16846,18 @@
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 권",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999"
           },
           "bookIssue": {
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 호",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999"
           },
           "writeDate": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "작성일"
           },
           "purposeType": {
@@ -16904,7 +16905,7 @@
               "type": "string"
             },
             "title": "비고",
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개"
           },
           "supplierDocumentKey": {
             "type": "string",
@@ -16936,7 +16937,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceItem"
             },
-            "description": "<p>최대 99개</p>\n"
+            "description": "최대 99개"
           },
           "contacts": {
             "title": "추가 담당자",
@@ -16944,7 +16945,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceAdditionalContact"
             },
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개"
           },
           "statusUpdatedAt": {
             "type": "string",
@@ -16959,7 +16960,7 @@
           "ntsApproveNumber": {
             "type": "string",
             "title": "국세청 승인번호",
-            "description": "<p>세금계산서 발행(전자서명) 시점에 자동으로 부여</p>\n"
+            "description": "세금계산서 발행(전자서명) 시점에 자동으로 부여"
           },
           "ntsSentAt": {
             "type": "string",
@@ -16973,7 +16974,7 @@
           "ntsResultCode": {
             "type": "string",
             "title": "국세청 결과 코드",
-            "description": "<p>국세청 발급 결과 코드로 영문 3자리 + 숫자 3자리로 구성됨</p>\n"
+            "description": "국세청 발급 결과 코드로 영문 3자리 + 숫자 3자리로 구성됨"
           },
           "ntsResultReceivedAt": {
             "type": "string",
@@ -17022,18 +17023,18 @@
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 권",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999"
           },
           "bookIssue": {
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 호",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999"
           },
           "writeDate": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "작성일"
           },
           "purposeType": {
@@ -17081,7 +17082,7 @@
               "type": "string"
             },
             "title": "비고",
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개"
           },
           "supplierDocumentKey": {
             "type": "string",
@@ -17113,7 +17114,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceItem"
             },
-            "description": "<p>최대 99개</p>\n"
+            "description": "최대 99개"
           },
           "contacts": {
             "title": "추가 담당자",
@@ -17121,7 +17122,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceAdditionalContact"
             },
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개"
           },
           "statusUpdatedAt": {
             "type": "string",
@@ -17136,7 +17137,7 @@
           "ntsApproveNumber": {
             "type": "string",
             "title": "국세청 승인번호",
-            "description": "<p>세금계산서 발행(전자서명) 시점에 자동으로 부여</p>\n"
+            "description": "세금계산서 발행(전자서명) 시점에 자동으로 부여"
           },
           "ntsSentAt": {
             "type": "string",
@@ -17150,7 +17151,7 @@
           "ntsResultCode": {
             "type": "string",
             "title": "국세청 결과 코드",
-            "description": "<p>국세청 발급 결과 코드로 영문 3자리 + 숫자 3자리로 구성됨</p>\n"
+            "description": "국세청 발급 결과 코드로 영문 3자리 + 숫자 3자리로 구성됨"
           },
           "ntsResultReceivedAt": {
             "type": "string",
@@ -17213,7 +17214,7 @@
       },
       "B2bTaxInvoiceSummary": {
         "title": "세금계산서 요약",
-        "description": "<p>세금계산서 요약</p>\n",
+        "description": "세금계산서 요약",
         "type": "object",
         "required": [
           "taxType",
@@ -17275,9 +17276,9 @@
             "title": "공급받는자 영업 상태"
           },
           "recipientClosedSuspendedDate": {
-            "description": "<p>상태가 CLOSED, SUSPENDED 상태인 경우에만 결과값 반환</p>\n",
+            "description": "상태가 CLOSED, SUSPENDED 상태인 경우에만 결과값 반환",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "공급받는자 휴폐업일자"
           },
           "issuedAt": {
@@ -17302,7 +17303,7 @@
           "ntsApproveNumber": {
             "type": "string",
             "title": "국세청 승인번호",
-            "description": "<p>세금계산서 발행(전자서명) 시점에 자동으로 부여</p>\n"
+            "description": "세금계산서 발행(전자서명) 시점에 자동으로 부여"
           },
           "ntsResult": {
             "type": "string",
@@ -17321,7 +17322,7 @@
           "ntsResultCode": {
             "type": "string",
             "title": "국세청 결과 코드",
-            "description": "<p>국세청 발급 결과 코드로 영문 3자리 + 숫자 3자리로 구성됨</p>\n"
+            "description": "국세청 발급 결과 코드로 영문 3자리 + 숫자 3자리로 구성됨"
           }
         },
         "x-portone-title": "세금계산서 요약"
@@ -17364,18 +17365,18 @@
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 권",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999"
           },
           "bookIssue": {
             "type": "integer",
             "format": "int32",
             "title": "책번호 - 호",
-            "description": "<p>입력 범위(4자리) : 0 ~ 9999</p>\n"
+            "description": "입력 범위(4자리) : 0 ~ 9999"
           },
           "writeDate": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "작성일"
           },
           "purposeType": {
@@ -17423,7 +17424,7 @@
               "type": "string"
             },
             "title": "비고",
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개"
           },
           "supplierDocumentKey": {
             "type": "string",
@@ -17455,7 +17456,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceItem"
             },
-            "description": "<p>최대 99개</p>\n"
+            "description": "최대 99개"
           },
           "contacts": {
             "title": "추가 담당자",
@@ -17463,7 +17464,7 @@
             "items": {
               "$ref": "#/components/schemas/B2bTaxInvoiceAdditionalContact"
             },
-            "description": "<p>최대 3개</p>\n"
+            "description": "최대 3개"
           },
           "statusUpdatedAt": {
             "type": "string",
@@ -17478,13 +17479,13 @@
           "ntsApproveNumber": {
             "type": "string",
             "title": "국세청 승인번호",
-            "description": "<p>세금계산서 발행(전자서명) 시점에 자동으로 부여</p>\n"
+            "description": "세금계산서 발행(전자서명) 시점에 자동으로 부여"
           }
         }
       },
       "B2bTaxType": {
         "title": "과세 유형",
-        "description": "<p>과세 유형</p>\n",
+        "description": "과세 유형",
         "type": "string",
         "enum": [
           "TAXABLE",
@@ -17506,7 +17507,7 @@
       },
       "Bank": {
         "title": "은행",
-        "description": "<p>은행</p>\n",
+        "description": "은행",
         "type": "string",
         "enum": [
           "BANK_OF_KOREA",
@@ -17828,7 +17829,7 @@
       },
       "BeforeRegisteredPaymentEscrow": {
         "title": "배송 정보 등록 전",
-        "description": "<p>배송 정보 등록 전</p>\n",
+        "description": "배송 정보 등록 전",
         "type": "object",
         "required": [
           "status"
@@ -17843,7 +17844,7 @@
       },
       "BillingKeyAlreadyDeletedError": {
         "title": "빌링키가 이미 삭제된 경우",
-        "description": "<p>빌링키가 이미 삭제된 경우</p>\n",
+        "description": "빌링키가 이미 삭제된 경우",
         "type": "object",
         "required": [
           "type"
@@ -17861,7 +17862,7 @@
       },
       "BillingKeyFailure": {
         "title": "발급 실패 상세 정보",
-        "description": "<p>발급 실패 상세 정보</p>\n",
+        "description": "발급 실패 상세 정보",
         "type": "object",
         "required": [
           "failedAt"
@@ -17889,13 +17890,13 @@
       },
       "BillingKeyFilterInput": {
         "title": "빌링키 다건 조회를 위한 입력 정보",
-        "description": "<p>빌링키 다건 조회를 위한 입력 정보</p>\n",
+        "description": "빌링키 다건 조회를 위한 입력 정보",
         "type": "object",
         "properties": {
           "storeId": {
             "type": "string",
             "title": "상점 아이디",
-            "description": "<p>Merchant 사용자만 사용가능하며, 지정되지 않은 경우 고객사 전체 빌링키를 조회합니다.</p>\n"
+            "description": "Merchant 사용자만 사용가능하며, 지정되지 않은 경우 고객사 전체 빌링키를 조회합니다."
           },
           "timeRangeField": {
             "$ref": "#/components/schemas/BillingKeyTimeRangeField",
@@ -17905,13 +17906,13 @@
             "type": "string",
             "format": "date-time",
             "title": "조회 기준 시점 범위의 시작",
-            "description": "<p>값을 입력하지 않으면 end의 90일 전으로 설정됩니다.</p>\n"
+            "description": "값을 입력하지 않으면 end의 90일 전으로 설정됩니다."
           },
           "until": {
             "type": "string",
             "format": "date-time",
             "title": "조회 기준 시점 범위의 끝",
-            "description": "<p>값을 입력하지 않으면 현재 시점으로 설정됩니다.</p>\n"
+            "description": "값을 입력하지 않으면 현재 시점으로 설정됩니다."
           },
           "status": {
             "title": "빌링키 상태 리스트",
@@ -17919,7 +17920,7 @@
             "items": {
               "$ref": "#/components/schemas/BillingKeyStatus"
             },
-            "description": "<p>값을 입력하지 않으면 빌링키 상태 필터링이 적용되지 않습니다.</p>\n"
+            "description": "값을 입력하지 않으면 빌링키 상태 필터링이 적용되지 않습니다."
           },
           "channelGroupIds": {
             "type": "array",
@@ -17927,7 +17928,7 @@
               "type": "string"
             },
             "title": "채널 그룹 아이디 리스트",
-            "description": "<p>값을 입력하지 않으면 스마트 라우팅 그룹 아이디 필터링이 적용되지 않습니다.</p>\n"
+            "description": "값을 입력하지 않으면 스마트 라우팅 그룹 아이디 필터링이 적용되지 않습니다."
           },
           "customerId": {
             "type": "string",
@@ -17947,7 +17948,7 @@
             "items": {
               "$ref": "#/components/schemas/PgProvider"
             },
-            "description": "<p>값을 입력하지 않으면 PG사 결제 모듈 필터링이 적용되지 않습니다.</p>\n"
+            "description": "값을 입력하지 않으면 PG사 결제 모듈 필터링이 적용되지 않습니다."
           },
           "pgCompanies": {
             "title": "PG사 리스트",
@@ -17955,7 +17956,7 @@
             "items": {
               "$ref": "#/components/schemas/PgCompany"
             },
-            "description": "<p>값을 입력하지 않으면 PG사 필터링이 적용되지 않습니다.</p>\n"
+            "description": "값을 입력하지 않으면 PG사 필터링이 적용되지 않습니다."
           },
           "methods": {
             "title": "결제수단 리스트",
@@ -17963,7 +17964,7 @@
             "items": {
               "$ref": "#/components/schemas/BillingKeyPaymentMethodType"
             },
-            "description": "<p>값을 입력하지 않으면 결제수단 필터링이 적용되지 않습니다.</p>\n"
+            "description": "값을 입력하지 않으면 결제수단 필터링이 적용되지 않습니다."
           },
           "version": {
             "$ref": "#/components/schemas/PortOneVersion",
@@ -17974,7 +17975,7 @@
       },
       "BillingKeyInfo": {
         "title": "빌링키 정보",
-        "description": "<p>빌링키 정보</p>\n",
+        "description": "빌링키 정보",
         "oneOf": [
           {
             "$ref": "#/components/schemas/DeletedBillingKeyInfo"
@@ -18049,7 +18050,7 @@
       },
       "BillingKeyNotFoundError": {
         "title": "빌링키가 존재하지 않는 경우",
-        "description": "<p>빌링키가 존재하지 않는 경우</p>\n",
+        "description": "빌링키가 존재하지 않는 경우",
         "type": "object",
         "required": [
           "type"
@@ -18083,7 +18084,7 @@
       },
       "BillingKeyPaymentInput": {
         "title": "빌링키 결제 요청 입력 정보",
-        "description": "<p>빌링키 결제 요청 입력 정보</p>\n",
+        "description": "빌링키 결제 요청 입력 정보",
         "type": "object",
         "required": [
           "billingKey",
@@ -18095,7 +18096,7 @@
           "storeId": {
             "type": "string",
             "title": "상점 아이디",
-            "description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다."
           },
           "billingKey": {
             "type": "string",
@@ -18104,7 +18105,7 @@
           "channelKey": {
             "type": "string",
             "title": "채널 키",
-            "description": "<p>다수 채널에 대해 발급된 빌링키에 대해, 결제 채널을 특정하고 싶을 때 명시</p>\n"
+            "description": "다수 채널에 대해 발급된 빌링키에 대해, 결제 채널을 특정하고 싶을 때 명시"
           },
           "orderName": {
             "type": "string",
@@ -18153,7 +18154,7 @@
               "type": "string"
             },
             "title": "웹훅 주소",
-            "description": "<p>결제 승인/실패 시 요청을 받을 웹훅 주소입니다.\n상점에 설정되어 있는 값보다 우선적으로 적용됩니다.\n입력된 값이 없을 경우에는 빈 배열로 해석됩니다.</p>\n"
+            "description": "결제 승인/실패 시 요청을 받을 웹훅 주소입니다.\n상점에 설정되어 있는 값보다 우선적으로 적용됩니다.\n입력된 값이 없을 경우에는 빈 배열로 해석됩니다."
           },
           "products": {
             "title": "상품 정보",
@@ -18161,7 +18162,7 @@
             "items": {
               "$ref": "#/components/schemas/PaymentProduct"
             },
-            "description": "<p>입력된 값이 없을 경우에는 빈 배열로 해석됩니다.</p>\n"
+            "description": "입력된 값이 없을 경우에는 빈 배열로 해석됩니다."
           },
           "productCount": {
             "type": "integer",
@@ -18189,7 +18190,7 @@
       },
       "BillingKeyPaymentMethod": {
         "title": "빌링키 발급 수단 정보",
-        "description": "<p>빌링키 발급 수단 정보</p>\n",
+        "description": "빌링키 발급 수단 정보",
         "oneOf": [
           {
             "$ref": "#/components/schemas/BillingKeyPaymentMethodCard"
@@ -18238,7 +18239,7 @@
       },
       "BillingKeyPaymentMethodCard": {
         "title": "카드 정보",
-        "description": "<p>카드 정보</p>\n",
+        "description": "카드 정보",
         "type": "object",
         "required": [
           "type"
@@ -18256,7 +18257,7 @@
       },
       "BillingKeyPaymentMethodEasyPay": {
         "title": "간편 결제 정보",
-        "description": "<p>간편 결제 정보</p>\n",
+        "description": "간편 결제 정보",
         "type": "object",
         "required": [
           "type"
@@ -18278,7 +18279,7 @@
       },
       "BillingKeyPaymentMethodEasyPayCharge": {
         "title": "충전식 포인트 결제 정보",
-        "description": "<p>충전식 포인트 결제 정보</p>\n",
+        "description": "충전식 포인트 결제 정보",
         "type": "object",
         "required": [
           "type"
@@ -18292,7 +18293,7 @@
       },
       "BillingKeyPaymentMethodEasyPayMethod": {
         "title": "간편 결제 수단",
-        "description": "<p>간편 결제 수단</p>\n",
+        "description": "간편 결제 수단",
         "oneOf": [
           {
             "$ref": "#/components/schemas/BillingKeyPaymentMethodCard"
@@ -18327,7 +18328,7 @@
       },
       "BillingKeyPaymentMethodMobile": {
         "title": "모바일 정보",
-        "description": "<p>모바일 정보</p>\n",
+        "description": "모바일 정보",
         "type": "object",
         "required": [
           "type"
@@ -18345,7 +18346,7 @@
       },
       "BillingKeyPaymentMethodPaypal": {
         "title": "페이팔 정보",
-        "description": "<p>페이팔 정보</p>\n",
+        "description": "페이팔 정보",
         "type": "object",
         "required": [
           "type"
@@ -18359,7 +18360,7 @@
       },
       "BillingKeyPaymentMethodTransfer": {
         "title": "계좌이체 정보",
-        "description": "<p>계좌이체 정보</p>\n",
+        "description": "계좌이체 정보",
         "type": "object",
         "required": [
           "type"
@@ -18381,7 +18382,7 @@
       },
       "BillingKeyPaymentMethodType": {
         "title": "빌링키 결제 수단",
-        "description": "<p>빌링키 결제 수단</p>\n",
+        "description": "빌링키 결제 수단",
         "type": "string",
         "enum": [
           "CARD",
@@ -18407,7 +18408,7 @@
       },
       "BillingKeyPaymentSummary": {
         "title": "빌링키 결제 완료된 결제 건 요약 정보",
-        "description": "<p>빌링키 결제 완료된 결제 건 요약 정보</p>\n",
+        "description": "빌링키 결제 완료된 결제 건 요약 정보",
         "type": "object",
         "required": [
           "pgTxId",
@@ -18428,7 +18429,7 @@
       },
       "BillingKeySortBy": {
         "title": "빌링키 정렬 기준",
-        "description": "<p>빌링키 정렬 기준</p>\n",
+        "description": "빌링키 정렬 기준",
         "type": "string",
         "enum": [
           "REQUESTED_AT",
@@ -18449,31 +18450,31 @@
           },
           "STATUS_TIMESTAMP": {
             "title": "상태 변경 시각",
-            "description": "<p>발급 완료 상태의 경우 ISSUED_AT, 삭제 완료 상태의 경우 DELETED_AT</p>\n"
+            "description": "발급 완료 상태의 경우 ISSUED_AT, 삭제 완료 상태의 경우 DELETED_AT"
           }
         }
       },
       "BillingKeySortInput": {
         "title": "빌링키 다건 조회 시 정렬 조건",
-        "description": "<p>빌링키 다건 조회 시 정렬 조건</p>\n",
+        "description": "빌링키 다건 조회 시 정렬 조건",
         "type": "object",
         "properties": {
           "by": {
             "$ref": "#/components/schemas/BillingKeySortBy",
             "title": "정렬 기준 필드",
-            "description": "<p>어떤 필드를 기준으로 정렬할 지 결정합니다. 비워서 보낼 경우, REQUESTED_AT이 기본값으로 설정됩니다.</p>\n"
+            "description": "어떤 필드를 기준으로 정렬할 지 결정합니다. 비워서 보낼 경우, REQUESTED_AT이 기본값으로 설정됩니다."
           },
           "order": {
             "$ref": "#/components/schemas/SortOrder",
             "title": "정렬 순서",
-            "description": "<p>어떤 순서로 정렬할 지 결정합니다. 비워서 보낼 경우, DESC(내림차순)가 기본값으로 설정됩니다.</p>\n"
+            "description": "어떤 순서로 정렬할 지 결정합니다. 비워서 보낼 경우, DESC(내림차순)가 기본값으로 설정됩니다."
           }
         },
         "x-portone-title": "빌링키 다건 조회 시 정렬 조건"
       },
       "BillingKeyStatus": {
         "title": "빌링키 상태",
-        "description": "<p>빌링키 상태</p>\n",
+        "description": "빌링키 상태",
         "type": "string",
         "enum": [
           "ISSUED",
@@ -18487,7 +18488,7 @@
       },
       "BillingKeyTextSearch": {
         "title": "통합검색 입력 정보",
-        "description": "<p>통합검색 입력 정보</p>\n",
+        "description": "통합검색 입력 정보",
         "type": "object",
         "required": [
           "field",
@@ -18505,7 +18506,7 @@
       },
       "BillingKeyTextSearchField": {
         "title": "통합검색 항목",
-        "description": "<p>통합검색 항목</p>\n",
+        "description": "통합검색 항목",
         "type": "string",
         "enum": [
           "CARD_BIN",
@@ -18537,7 +18538,7 @@
       },
       "BillingKeyTimeRangeField": {
         "title": "빌링키 다건 조회 시, 시각 범위를 적용할 필드",
-        "description": "<p>빌링키 다건 조회 시, 시각 범위를 적용할 필드</p>\n",
+        "description": "빌링키 다건 조회 시, 시각 범위를 적용할 필드",
         "type": "string",
         "enum": [
           "REQUESTED_AT",
@@ -18558,13 +18559,13 @@
           },
           "STATUS_TIMESTAMP": {
             "title": "상태 변경 시각",
-            "description": "<p>발급 완료 상태의 경우 ISSUED_AT, 삭제 완료 상태의 경우 DELETED_AT</p>\n"
+            "description": "발급 완료 상태의 경우 ISSUED_AT, 삭제 완료 상태의 경우 DELETED_AT"
           }
         }
       },
       "CancelAmountExceedsCancellableAmountError": {
         "title": "결제 취소 금액이 취소 가능 금액을 초과한 경우",
-        "description": "<p>결제 취소 금액이 취소 가능 금액을 초과한 경우</p>\n",
+        "description": "결제 취소 금액이 취소 가능 금액을 초과한 경우",
         "type": "object",
         "required": [
           "type"
@@ -18582,7 +18583,7 @@
       },
       "CancelB2bTaxInvoiceIssuanceBody": {
         "title": "세금계산서 역발행 취소 정보",
-        "description": "<p>세금계산서 역발행 취소 정보</p>\n",
+        "description": "세금계산서 역발행 취소 정보",
         "type": "object",
         "required": [
           "brn",
@@ -18600,7 +18601,7 @@
           "documentKeyType": {
             "$ref": "#/components/schemas/B2bTaxInvoiceDocumentKeyType",
             "title": "문서 번호 유형",
-            "description": "<p>기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.</p>\n"
+            "description": "기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다."
           },
           "memo": {
             "type": "string",
@@ -18641,7 +18642,7 @@
       },
       "CancelB2bTaxInvoiceRequestBody": {
         "title": "세금계산서 역발행 요청 취소 정보",
-        "description": "<p>세금계산서 역발행 요청 취소 정보</p>\n",
+        "description": "세금계산서 역발행 요청 취소 정보",
         "type": "object",
         "required": [
           "brn",
@@ -18659,7 +18660,7 @@
           "documentKeyType": {
             "$ref": "#/components/schemas/B2bTaxInvoiceDocumentKeyType",
             "title": "문서 번호 유형",
-            "description": "<p>기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.</p>\n"
+            "description": "기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다."
           },
           "memo": {
             "type": "string",
@@ -18742,7 +18743,7 @@
       },
       "CancelCashReceiptResponse": {
         "title": "현금 영수증 취소 성공 응답",
-        "description": "<p>현금 영수증 취소 성공 응답</p>\n",
+        "description": "현금 영수증 취소 성공 응답",
         "type": "object",
         "required": [
           "cancelledAmount",
@@ -18764,7 +18765,7 @@
       },
       "CancelPaymentBody": {
         "title": "결제 취소 요청 입력 정보",
-        "description": "<p>결제 취소 요청 입력 정보</p>\n",
+        "description": "결제 취소 요청 입력 정보",
         "type": "object",
         "required": [
           "reason"
@@ -18773,25 +18774,25 @@
           "storeId": {
             "type": "string",
             "title": "상점 아이디",
-            "description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다."
           },
           "amount": {
             "type": "integer",
             "format": "int64",
             "title": "취소 총 금액",
-            "description": "<p>값을 입력하지 않으면 전액 취소됩니다.</p>\n"
+            "description": "값을 입력하지 않으면 전액 취소됩니다."
           },
           "taxFreeAmount": {
             "type": "integer",
             "format": "int64",
             "title": "취소 금액 중 면세 금액",
-            "description": "<p>값을 입력하지 않으면 전액 과세 취소됩니다.</p>\n"
+            "description": "값을 입력하지 않으면 전액 과세 취소됩니다."
           },
           "vatAmount": {
             "type": "integer",
             "format": "int64",
             "title": "취소 금액 중 부가세액",
-            "description": "<p>값을 입력하지 않으면 자동 계산됩니다.</p>\n"
+            "description": "값을 입력하지 않으면 자동 계산됩니다."
           },
           "reason": {
             "type": "string",
@@ -18800,25 +18801,25 @@
           "requester": {
             "$ref": "#/components/schemas/CancelRequester",
             "title": "취소 요청자",
-            "description": "<p>고객에 의한 취소일 경우 Customer, 관리자에 의한 취소일 경우 Admin으로 입력합니다.</p>\n"
+            "description": "고객에 의한 취소일 경우 Customer, 관리자에 의한 취소일 경우 Admin으로 입력합니다."
           },
           "currentCancellableAmount": {
             "type": "integer",
             "format": "int64",
             "title": "결제 건의 취소 가능 잔액",
-            "description": "<p>본 취소 요청 이전의 취소 가능 잔액으로써, 값을 입력하면 잔액이 일치하는 경우에만 취소가 진행됩니다. 값을 입력하지 않으면 별도의 검증 처리를 수행하지 않습니다.</p>\n"
+            "description": "본 취소 요청 이전의 취소 가능 잔액으로써, 값을 입력하면 잔액이 일치하는 경우에만 취소가 진행됩니다. 값을 입력하지 않으면 별도의 검증 처리를 수행하지 않습니다."
           },
           "refundAccount": {
             "$ref": "#/components/schemas/CancelPaymentBodyRefundAccount",
             "title": "환불 계좌",
-            "description": "<p>계좌 환불일 경우 입력합니다. 계좌 환불이 필요한 경우는 가상계좌 환불, 휴대폰 익월 환불 등이 있습니다.</p>\n"
+            "description": "계좌 환불일 경우 입력합니다. 계좌 환불이 필요한 경우는 가상계좌 환불, 휴대폰 익월 환불 등이 있습니다."
           }
         },
         "x-portone-title": "결제 취소 요청 입력 정보"
       },
       "CancelPaymentBodyRefundAccount": {
         "title": "고객 정보 입력 형식",
-        "description": "<p>고객 정보 입력 형식</p>\n",
+        "description": "고객 정보 입력 형식",
         "type": "object",
         "required": [
           "bank",
@@ -18909,7 +18910,7 @@
       },
       "CancelPaymentResponse": {
         "title": "결제 취소 성공 응답",
-        "description": "<p>결제 취소 성공 응답</p>\n",
+        "description": "결제 취소 성공 응답",
         "type": "object",
         "required": [
           "cancellation"
@@ -18954,7 +18955,7 @@
       },
       "CancelPlatformAdditionalFeePolicyScheduleResponse": {
         "title": "추가 수수료 정책 예약 업데이트 취소 성공 응답",
-        "description": "<p>추가 수수료 정책 예약 업데이트 취소 성공 응답</p>\n",
+        "description": "추가 수수료 정책 예약 업데이트 취소 성공 응답",
         "type": "object",
         "x-portone-title": "추가 수수료 정책 예약 업데이트 취소 성공 응답"
       },
@@ -18990,7 +18991,7 @@
       },
       "CancelPlatformContractScheduleResponse": {
         "title": "계약 예약 업데이트 취소 성공 응답",
-        "description": "<p>계약 예약 업데이트 취소 성공 응답</p>\n",
+        "description": "계약 예약 업데이트 취소 성공 응답",
         "type": "object",
         "x-portone-title": "계약 예약 업데이트 취소 성공 응답"
       },
@@ -19026,7 +19027,7 @@
       },
       "CancelPlatformDiscountSharePolicyScheduleResponse": {
         "title": "할인 분담 정책 예약 업데이트 취소 성공 응답",
-        "description": "<p>할인 분담 정책 예약 업데이트 취소 성공 응답</p>\n",
+        "description": "할인 분담 정책 예약 업데이트 취소 성공 응답",
         "type": "object",
         "x-portone-title": "할인 분담 정책 예약 업데이트 취소 성공 응답"
       },
@@ -19062,7 +19063,7 @@
       },
       "CancelPlatformPartnerScheduleResponse": {
         "title": "파트너 예약 업데이트 취소 성공 응답",
-        "description": "<p>파트너 예약 업데이트 취소 성공 응답</p>\n",
+        "description": "파트너 예약 업데이트 취소 성공 응답",
         "type": "object",
         "x-portone-title": "파트너 예약 업데이트 취소 성공 응답"
       },
@@ -19080,7 +19081,7 @@
       },
       "CancelTaxAmountExceedsCancellableTaxAmountError": {
         "title": "취소 과세 금액이 취소 가능한 과세 금액을 초과한 경우",
-        "description": "<p>취소 과세 금액이 취소 가능한 과세 금액을 초과한 경우</p>\n",
+        "description": "취소 과세 금액이 취소 가능한 과세 금액을 초과한 경우",
         "type": "object",
         "required": [
           "type"
@@ -19098,7 +19099,7 @@
       },
       "CancelTaxFreeAmountExceedsCancellableTaxFreeAmountError": {
         "title": "취소 면세 금액이 취소 가능한 면세 금액을 초과한 경우",
-        "description": "<p>취소 면세 금액이 취소 가능한 면세 금액을 초과한 경우</p>\n",
+        "description": "취소 면세 금액이 취소 가능한 면세 금액을 초과한 경우",
         "type": "object",
         "required": [
           "type"
@@ -19116,7 +19117,7 @@
       },
       "CancellableAmountConsistencyBrokenError": {
         "title": "취소 가능 잔액 검증에 실패한 경우",
-        "description": "<p>취소 가능 잔액 검증에 실패한 경우</p>\n",
+        "description": "취소 가능 잔액 검증에 실패한 경우",
         "type": "object",
         "required": [
           "type"
@@ -19134,7 +19135,7 @@
       },
       "CancelledCashReceipt": {
         "title": "발급 취소",
-        "description": "<p>발급 취소</p>\n",
+        "description": "발급 취소",
         "type": "object",
         "required": [
           "status",
@@ -19229,7 +19230,7 @@
       },
       "CancelledPayment": {
         "title": "결제 취소 상태 건",
-        "description": "<p>결제 취소 상태 건</p>\n",
+        "description": "결제 취소 상태 건",
         "type": "object",
         "required": [
           "status",
@@ -19261,7 +19262,7 @@
           "transactionId": {
             "type": "string",
             "title": "결제 건 포트원 채번 아이디",
-            "description": "<p>V1 결제 건의 경우 imp_uid에 해당합니다.</p>\n"
+            "description": "V1 결제 건의 경우 imp_uid에 해당합니다."
           },
           "merchantId": {
             "type": "string",
@@ -19290,12 +19291,12 @@
           "scheduleId": {
             "type": "string",
             "title": "결제 예약 건 아이디",
-            "description": "<p>결제 예약을 이용한 경우에만 존재</p>\n"
+            "description": "결제 예약을 이용한 경우에만 존재"
           },
           "billingKey": {
             "type": "string",
             "title": "결제 시 사용된 빌링키",
-            "description": "<p>빌링키 결제인 경우에만 존재</p>\n"
+            "description": "빌링키 결제인 경우에만 존재"
           },
           "webhooks": {
             "title": "웹훅 발송 내역",
@@ -19346,7 +19347,7 @@
           "escrow": {
             "$ref": "#/components/schemas/PaymentEscrow",
             "title": "에스크로 결제 정보",
-            "description": "<p>에스크로 결제인 경우 존재합니다.</p>\n"
+            "description": "에스크로 결제인 경우 존재합니다."
           },
           "products": {
             "title": "상품 정보",
@@ -19402,7 +19403,7 @@
       },
       "CancelledPaymentCashReceipt": {
         "title": "취소된 현금영수증",
-        "description": "<p>취소된 현금영수증</p>\n",
+        "description": "취소된 현금영수증",
         "type": "object",
         "required": [
           "status",
@@ -19462,7 +19463,7 @@
       },
       "CancelledPaymentEscrow": {
         "title": "거래 취소",
-        "description": "<p>거래 취소</p>\n",
+        "description": "거래 취소",
         "type": "object",
         "required": [
           "status",
@@ -19497,7 +19498,7 @@
       },
       "Card": {
         "title": "카드 상세 정보",
-        "description": "<p>카드 상세 정보</p>\n",
+        "description": "카드 상세 정보",
         "type": "object",
         "properties": {
           "publisher": {
@@ -19537,7 +19538,7 @@
       },
       "CardBrand": {
         "title": "카드 브랜드",
-        "description": "<p>카드 브랜드</p>\n",
+        "description": "카드 브랜드",
         "type": "string",
         "enum": [
           "LOCAL",
@@ -19561,7 +19562,7 @@
       },
       "CardCompany": {
         "title": "카드사",
-        "description": "<p>카드사</p>\n",
+        "description": "카드사",
         "type": "string",
         "enum": [
           "KOREA_DEVELOPMENT_BANK",
@@ -19871,7 +19872,7 @@
       },
       "CardCredential": {
         "title": "카드 인증 관련 정보",
-        "description": "<p>카드 인증 관련 정보</p>\n",
+        "description": "카드 인증 관련 정보",
         "type": "object",
         "required": [
           "number",
@@ -19904,7 +19905,7 @@
       },
       "CardOwnerType": {
         "title": "카드 소유주 유형",
-        "description": "<p>카드 소유주 유형</p>\n",
+        "description": "카드 소유주 유형",
         "type": "string",
         "enum": [
           "PERSONAL",
@@ -19922,7 +19923,7 @@
       },
       "CardPromotion": {
         "title": "카드 프로모션",
-        "description": "<p>카드 프로모션</p>\n",
+        "description": "카드 프로모션",
         "type": "object",
         "required": [
           "type",
@@ -20017,7 +20018,7 @@
       },
       "CardType": {
         "title": "카드 유형",
-        "description": "<p>카드 유형</p>\n",
+        "description": "카드 유형",
         "type": "string",
         "enum": [
           "CREDIT",
@@ -20039,7 +20040,7 @@
       },
       "Carrier": {
         "title": "통신사",
-        "description": "<p>통신사</p>\n",
+        "description": "통신사",
         "type": "string",
         "enum": [
           "SKT",
@@ -20073,7 +20074,7 @@
       },
       "CashReceipt": {
         "title": "현금영수증 내역",
-        "description": "<p>현금영수증 내역</p>\n",
+        "description": "현금영수증 내역",
         "oneOf": [
           {
             "$ref": "#/components/schemas/CancelledCashReceipt"
@@ -20108,7 +20109,7 @@
       },
       "CashReceiptAlreadyIssuedError": {
         "title": "현금영수증이 이미 발급된 경우",
-        "description": "<p>현금영수증이 이미 발급된 경우</p>\n",
+        "description": "현금영수증이 이미 발급된 경우",
         "type": "object",
         "required": [
           "type"
@@ -20126,7 +20127,7 @@
       },
       "CashReceiptInput": {
         "title": "현금영수증 입력 정보",
-        "description": "<p>현금영수증 입력 정보</p>\n",
+        "description": "현금영수증 입력 정보",
         "type": "object",
         "required": [
           "type"
@@ -20139,14 +20140,14 @@
           "customerIdentityNumber": {
             "type": "string",
             "title": "사용자 식별 번호",
-            "description": "<p>미발행 유형 선택 시 입력하지 않습니다.</p>\n"
+            "description": "미발행 유형 선택 시 입력하지 않습니다."
           }
         },
         "x-portone-title": "현금영수증 입력 정보"
       },
       "CashReceiptInputType": {
         "title": "입력 시 발급 유형",
-        "description": "<p>입력 시 발급 유형</p>\n",
+        "description": "입력 시 발급 유형",
         "type": "string",
         "enum": [
           "PERSONAL",
@@ -20163,13 +20164,13 @@
           },
           "NO_RECEIPT": {
             "title": "미발행",
-            "description": "<p>PG사 설정에 따라 PG사가 자동으로 자진발급 처리할 수 있습니다.</p>\n"
+            "description": "PG사 설정에 따라 PG사가 자동으로 자진발급 처리할 수 있습니다."
           }
         }
       },
       "CashReceiptNotFoundError": {
         "title": "현금영수증이 존재하지 않는 경우",
-        "description": "<p>현금영수증이 존재하지 않는 경우</p>\n",
+        "description": "현금영수증이 존재하지 않는 경우",
         "type": "object",
         "required": [
           "type"
@@ -20187,7 +20188,7 @@
       },
       "CashReceiptNotIssuedError": {
         "title": "현금영수증이 발급되지 않은 경우",
-        "description": "<p>현금영수증이 발급되지 않은 경우</p>\n",
+        "description": "현금영수증이 발급되지 않은 경우",
         "type": "object",
         "required": [
           "type"
@@ -20205,7 +20206,7 @@
       },
       "CashReceiptSummary": {
         "title": "현금영수증 내역",
-        "description": "<p>현금영수증 내역</p>\n",
+        "description": "현금영수증 내역",
         "type": "object",
         "required": [
           "issueNumber",
@@ -20230,7 +20231,7 @@
       },
       "CashReceiptType": {
         "title": "발급 유형",
-        "description": "<p>발급 유형</p>\n",
+        "description": "발급 유형",
         "type": "string",
         "enum": [
           "PERSONAL",
@@ -20248,7 +20249,7 @@
       },
       "Channel": {
         "title": "채널 정보",
-        "description": "<p>채널 정보</p>\n",
+        "description": "채널 정보",
         "type": "object",
         "required": [
           "id",
@@ -20303,7 +20304,7 @@
       },
       "ChannelGroupSummary": {
         "title": "채널 그룹 정보",
-        "description": "<p>채널 그룹 정보</p>\n",
+        "description": "채널 그룹 정보",
         "type": "object",
         "required": [
           "id",
@@ -20328,7 +20329,7 @@
       },
       "ChannelNotFoundError": {
         "title": "요청된 채널이 존재하지 않는 경우",
-        "description": "<p>요청된 채널이 존재하지 않는 경우</p>\n",
+        "description": "요청된 채널이 존재하지 않는 경우",
         "type": "object",
         "required": [
           "type"
@@ -20346,7 +20347,7 @@
       },
       "ChannelSpecificError": {
         "title": "여러 채널을 지정한 요청에서, 채널 각각에서 오류가 발생한 경우",
-        "description": "<p>여러 채널을 지정한 요청에서, 채널 각각에서 오류가 발생한 경우</p>\n",
+        "description": "여러 채널을 지정한 요청에서, 채널 각각에서 오류가 발생한 경우",
         "type": "object",
         "required": [
           "type",
@@ -20405,7 +20406,7 @@
       },
       "ChannelSpecificFailureInvalidRequest": {
         "title": "요청된 입력 정보가 유효하지 않은 경우",
-        "description": "<p>요청된 입력 정보가 유효하지 않은 경우</p>\n<p>허가되지 않은 값, 올바르지 않은 형식의 요청 등이 모두 해당됩니다.</p>\n",
+        "description": "요청된 입력 정보가 유효하지 않은 경우\n\n허가되지 않은 값, 올바르지 않은 형식의 요청 등이 모두 해당됩니다.",
         "type": "object",
         "required": [
           "type",
@@ -20423,12 +20424,12 @@
           }
         },
         "x-portone-title": "요청된 입력 정보가 유효하지 않은 경우",
-        "x-portone-description": "<p>허가되지 않은 값, 올바르지 않은 형식의 요청 등이 모두 해당됩니다.</p>\n",
+        "x-portone-description": "허가되지 않은 값, 올바르지 않은 형식의 요청 등이 모두 해당됩니다.",
         "x-portone-status-code": 400
       },
       "ChannelSpecificFailurePgProvider": {
         "title": "PG사에서 오류를 전달한 경우",
-        "description": "<p>PG사에서 오류를 전달한 경우</p>\n",
+        "description": "PG사에서 오류를 전달한 경우",
         "type": "object",
         "required": [
           "type",
@@ -20458,7 +20459,7 @@
       },
       "ChannelType": {
         "title": "채널 유형",
-        "description": "<p>채널 유형</p>\n",
+        "description": "채널 유형",
         "type": "string",
         "enum": [
           "LIVE",
@@ -20514,7 +20515,7 @@
       },
       "CloseVirtualAccountResponse": {
         "title": "가상계좌 말소 성공 응답",
-        "description": "<p>가상계좌 말소 성공 응답</p>\n",
+        "description": "가상계좌 말소 성공 응답",
         "type": "object",
         "required": [
           "closedAt"
@@ -20530,18 +20531,18 @@
       },
       "ConfirmEscrowBody": {
         "title": "에스크로 구매 확정 입력 정보",
-        "description": "<p>에스크로 구매 확정 입력 정보</p>\n",
+        "description": "에스크로 구매 확정 입력 정보",
         "type": "object",
         "properties": {
           "storeId": {
             "type": "string",
             "title": "상점 아이디",
-            "description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다."
           },
           "fromStore": {
             "type": "boolean",
             "title": "확인 주체가 상점인지 여부",
-            "description": "<p>구매확정요청 주체가 고객사 관리자인지 구매자인지 구분하기 위한 필드입니다.\n네이버페이 전용 파라미터이며, 구분이 모호한 경우 고객사 관리자(true)로 입력합니다.</p>\n"
+            "description": "구매확정요청 주체가 고객사 관리자인지 구매자인지 구분하기 위한 필드입니다.\n네이버페이 전용 파라미터이며, 구분이 모호한 경우 고객사 관리자(true)로 입력합니다."
           }
         },
         "x-portone-title": "에스크로 구매 확정 입력 정보"
@@ -20582,7 +20583,7 @@
       },
       "ConfirmEscrowResponse": {
         "title": "에스크로 구매 확정 성공 응답",
-        "description": "<p>에스크로 구매 확정 성공 응답</p>\n",
+        "description": "에스크로 구매 확정 성공 응답",
         "type": "object",
         "required": [
           "completedAt"
@@ -20598,18 +20599,18 @@
       },
       "ConfirmIdentityVerificationBody": {
         "title": "본인인증 확인을 위한 입력 정보",
-        "description": "<p>본인인증 확인을 위한 입력 정보</p>\n",
+        "description": "본인인증 확인을 위한 입력 정보",
         "type": "object",
         "properties": {
           "storeId": {
             "type": "string",
             "title": "상점 아이디",
-            "description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다."
           },
           "otp": {
             "type": "string",
             "title": "OTP (One-Time Password)",
-            "description": "<p>SMS 방식에서만 사용됩니다.</p>\n"
+            "description": "SMS 방식에서만 사용됩니다."
           }
         },
         "x-portone-title": "본인인증 확인을 위한 입력 정보"
@@ -20654,7 +20655,7 @@
       },
       "ConfirmIdentityVerificationResponse": {
         "title": "본인인증 확인 성공 응답",
-        "description": "<p>본인인증 확인 성공 응답</p>\n",
+        "description": "본인인증 확인 성공 응답",
         "type": "object",
         "required": [
           "identityVerification"
@@ -20669,7 +20670,7 @@
       },
       "ConfirmedPaymentEscrow": {
         "title": "구매 확정",
-        "description": "<p>구매 확정</p>\n",
+        "description": "구매 확정",
         "type": "object",
         "required": [
           "status",
@@ -20709,7 +20710,7 @@
       },
       "Country": {
         "title": "국가",
-        "description": "<p>국가</p>\n",
+        "description": "국가",
         "type": "string",
         "enum": [
           "AD",
@@ -21715,7 +21716,7 @@
       },
       "CreateB2bTaxInvoiceFileUploadLinkBody": {
         "title": "세금계산서 파일 업로드 링크 생성",
-        "description": "<p>세금계산서 파일 업로드 링크 생성</p>\n",
+        "description": "세금계산서 파일 업로드 링크 생성",
         "type": "object",
         "required": [
           "fileName"
@@ -21752,7 +21753,7 @@
       },
       "CreateB2bTaxInvoiceFileUploadLinkResponse": {
         "title": "세금계산서 파일 업로드 링크 생성 성공 응답",
-        "description": "<p>세금계산서 파일 업로드 링크 생성 성공 응답</p>\n",
+        "description": "세금계산서 파일 업로드 링크 생성 성공 응답",
         "type": "object",
         "required": [
           "fileId",
@@ -21808,7 +21809,7 @@
       },
       "CreatePaymentScheduleBody": {
         "title": "결제 예약 요청 입력 정보",
-        "description": "<p>결제 예약 요청 입력 정보</p>\n",
+        "description": "결제 예약 요청 입력 정보",
         "type": "object",
         "required": [
           "payment",
@@ -21871,7 +21872,7 @@
       },
       "CreatePaymentScheduleResponse": {
         "title": "결제 예약 성공 응답",
-        "description": "<p>결제 예약 성공 응답</p>\n",
+        "description": "결제 예약 성공 응답",
         "type": "object",
         "required": [
           "schedule"
@@ -21886,7 +21887,7 @@
       },
       "CreatePlatformAdditionalFeePolicyBody": {
         "title": "추가 수수료 정책 생성을 위한 입력 정보",
-        "description": "<p>추가 수수료 정책 생성을 위한 입력 정보</p>\n",
+        "description": "추가 수수료 정책 생성을 위한 입력 정보",
         "type": "object",
         "required": [
           "name",
@@ -21897,7 +21898,7 @@
           "id": {
             "type": "string",
             "title": "생성할 추가 수수료 정책 아이디",
-            "description": "<p>명시하지 않으면 id 가 임의로 생성됩니다.</p>\n"
+            "description": "명시하지 않으면 id 가 임의로 생성됩니다."
           },
           "name": {
             "type": "string",
@@ -21950,7 +21951,7 @@
       },
       "CreatePlatformAdditionalFeePolicyResponse": {
         "title": "플랫폼 생성 성공 응답 정보",
-        "description": "<p>플랫폼 생성 성공 응답 정보</p>\n",
+        "description": "플랫폼 생성 성공 응답 정보",
         "type": "object",
         "required": [
           "additionalFeePolicy"
@@ -21965,7 +21966,7 @@
       },
       "CreatePlatformContractBody": {
         "title": "계약 객체 생성을 위한 입력 정보",
-        "description": "<p>계약 객체 생성을 위한 입력 정보</p>\n",
+        "description": "계약 객체 생성을 위한 입력 정보",
         "type": "object",
         "required": [
           "name",
@@ -21978,7 +21979,7 @@
           "id": {
             "type": "string",
             "title": "계약에 부여할 고유 아이디",
-            "description": "<p>명시하지 않는 경우 포트원이 임의의 아이디를 발급해드립니다.</p>\n"
+            "description": "명시하지 않는 경우 포트원이 임의의 아이디를 발급해드립니다."
           },
           "name": {
             "type": "string",
@@ -22039,7 +22040,7 @@
       },
       "CreatePlatformContractResponse": {
         "title": "계약 객체 생성 성공 응답",
-        "description": "<p>계약 객체 생성 성공 응답</p>\n",
+        "description": "계약 객체 생성 성공 응답",
         "type": "object",
         "required": [
           "contract"
@@ -22054,7 +22055,7 @@
       },
       "CreatePlatformDiscountSharePolicyBody": {
         "title": "할인 분담 정책 생성을 위한 입력 정보",
-        "description": "<p>할인 분담 정책 생성을 위한 입력 정보</p>\n",
+        "description": "할인 분담 정책 생성을 위한 입력 정보",
         "type": "object",
         "required": [
           "name",
@@ -22064,7 +22065,7 @@
           "id": {
             "type": "string",
             "title": "할인 분담에 부여할 고유 아이디",
-            "description": "<p>명시하지 않는 경우 포트원이 임의의 아이디를 발급해드립니다.</p>\n"
+            "description": "명시하지 않는 경우 포트원이 임의의 아이디를 발급해드립니다."
           },
           "name": {
             "type": "string",
@@ -22114,7 +22115,7 @@
       },
       "CreatePlatformDiscountSharePolicyResponse": {
         "title": "할인 분담 정책 생성 성공 응답",
-        "description": "<p>할인 분담 정책 생성 성공 응답</p>\n",
+        "description": "할인 분담 정책 생성 성공 응답",
         "type": "object",
         "required": [
           "discountSharePolicy"
@@ -22129,7 +22130,7 @@
       },
       "CreatePlatformManualTransferBody": {
         "title": "수기 정산건 생성을 위한 입력 정보",
-        "description": "<p>수기 정산건 생성을 위한 입력 정보</p>\n",
+        "description": "수기 정산건 생성을 위한 입력 정보",
         "type": "object",
         "required": [
           "partnerId",
@@ -22151,15 +22152,15 @@
             "title": "정산 금액"
           },
           "settlementDate": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "정산 일"
           },
           "isForTest": {
             "type": "boolean",
             "title": "테스트 모드 여부",
-            "description": "<p>기본값은 false 입니다.</p>\n"
+            "description": "기본값은 false 입니다."
           },
           "userDefinedProperties": {
             "title": "사용자 정의 속성",
@@ -22207,7 +22208,7 @@
       },
       "CreatePlatformOrderCancelTransferBody": {
         "title": "주문 취소 정산 등록을 위한 입력 정보",
-        "description": "<p>주문 취소 정산 등록을 위한 입력 정보</p>\n<p>하나의 payment에 하나의 정산 건만 존재하는 경우에는 (partnerId, paymentId)로 취소 정산을 등록하실 수 있습니다.\n하나의 payment에 여러 개의 정산 건이 존재하는 경우에는 transferId를 필수로 입력해야 합니다.\ntransferId를 입력한 경우 (partnerId, paymentId)는 생략 가능합니다.</p>\n",
+        "description": "주문 취소 정산 등록을 위한 입력 정보\n\n하나의 payment에 하나의 정산 건만 존재하는 경우에는 (partnerId, paymentId)로 취소 정산을 등록하실 수 있습니다.\n하나의 payment에 여러 개의 정산 건이 존재하는 경우에는 transferId를 필수로 입력해야 합니다.\ntransferId를 입력한 경우 (partnerId, paymentId)는 생략 가능합니다.",
         "type": "object",
         "required": [
           "cancellationId",
@@ -22242,7 +22243,7 @@
             "type": "integer",
             "format": "int64",
             "title": "주문 취소 면세 금액",
-            "description": "<p>주문 취소 항목과 취소 면세 금액을 같이 전달하시면 최종 취소 면세 금액은 주문 취소 항목의 면세 금액이 아닌 전달해주신 취소 면세 금액으로 적용됩니다.</p>\n"
+            "description": "주문 취소 항목과 취소 면세 금액을 같이 전달하시면 최종 취소 면세 금액은 주문 취소 항목의 면세 금액이 아닌 전달해주신 취소 면세 금액으로 적용됩니다."
           },
           "discounts": {
             "title": "할인 정보",
@@ -22252,20 +22253,20 @@
             }
           },
           "settlementStartDate": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "정산 시작일"
           },
           "externalCancellationDetail": {
             "$ref": "#/components/schemas/CreatePlatformOrderCancelTransferBodyExternalCancellationDetail",
             "title": "외부 결제 상세 정보",
-            "description": "<p>해당 정보가 존재하는 경우 외부 결제 취소 정산건으로 등록되고, 존재하지않은 경우 포트원 결제 취소 정산건으로 등록됩니다.</p>\n"
+            "description": "해당 정보가 존재하는 경우 외부 결제 취소 정산건으로 등록되고, 존재하지않은 경우 포트원 결제 취소 정산건으로 등록됩니다."
           },
           "isForTest": {
             "type": "boolean",
             "title": "테스트 모드 여부",
-            "description": "<p>기본값은 false 입니다.</p>\n"
+            "description": "기본값은 false 입니다."
           },
           "userDefinedProperties": {
             "title": "사용자 정의 속성",
@@ -22276,11 +22277,11 @@
           }
         },
         "x-portone-title": "주문 취소 정산 등록을 위한 입력 정보",
-        "x-portone-description": "<p>하나의 payment에 하나의 정산 건만 존재하는 경우에는 (partnerId, paymentId)로 취소 정산을 등록하실 수 있습니다.\n하나의 payment에 여러 개의 정산 건이 존재하는 경우에는 transferId를 필수로 입력해야 합니다.\ntransferId를 입력한 경우 (partnerId, paymentId)는 생략 가능합니다.</p>\n"
+        "x-portone-description": "하나의 payment에 하나의 정산 건만 존재하는 경우에는 (partnerId, paymentId)로 취소 정산을 등록하실 수 있습니다.\n하나의 payment에 여러 개의 정산 건이 존재하는 경우에는 transferId를 필수로 입력해야 합니다.\ntransferId를 입력한 경우 (partnerId, paymentId)는 생략 가능합니다."
       },
       "CreatePlatformOrderCancelTransferBodyDiscount": {
         "title": "할인 정보",
-        "description": "<p>할인 정보</p>\n",
+        "description": "할인 정보",
         "type": "object",
         "required": [
           "sharePolicyId",
@@ -22306,7 +22307,7 @@
       },
       "CreatePlatformOrderCancelTransferBodyExternalCancellationDetail": {
         "title": "외부 결제 상세 정보",
-        "description": "<p>외부 결제 상세 정보</p>\n",
+        "description": "외부 결제 상세 정보",
         "type": "object",
         "properties": {
           "cancelledAt": {
@@ -22319,7 +22320,7 @@
       },
       "CreatePlatformOrderCancelTransferBodyOrderDetail": {
         "title": "주문 취소 정보",
-        "description": "<p>주문 취소 정보</p>\n<p>orderAmount, orderLines, all 중에서 하나만 입력하여야 합니다.</p>\n",
+        "description": "주문 취소 정보\n\norderAmount, orderLines, all 중에서 하나만 입력하여야 합니다.",
         "type": "object",
         "properties": {
           "orderAmount": {
@@ -22340,17 +22341,17 @@
           }
         },
         "x-portone-title": "주문 취소 정보",
-        "x-portone-description": "<p>orderAmount, orderLines, all 중에서 하나만 입력하여야 합니다.</p>\n"
+        "x-portone-description": "orderAmount, orderLines, all 중에서 하나만 입력하여야 합니다."
       },
       "CreatePlatformOrderCancelTransferBodyOrderDetailAll": {
         "title": "전체 금액 취소",
-        "description": "<p>전체 금액 취소</p>\n",
+        "description": "전체 금액 취소",
         "type": "object",
         "x-portone-title": "전체 금액 취소"
       },
       "CreatePlatformOrderCancelTransferBodyOrderLine": {
         "title": "주문 취소 항목 리스트",
-        "description": "<p>주문 취소 항목 리스트</p>\n",
+        "description": "주문 취소 항목 리스트",
         "type": "object",
         "required": [
           "productId",
@@ -22481,7 +22482,7 @@
       },
       "CreatePlatformOrderTransferBody": {
         "title": "주문 정산건 생성을 위한 입력 정보",
-        "description": "<p>주문 정산건 생성을 위한 입력 정보</p>\n",
+        "description": "주문 정산건 생성을 위한 입력 정보",
         "type": "object",
         "required": [
           "partnerId",
@@ -22498,7 +22499,7 @@
           "contractId": {
             "type": "string",
             "title": "계약 아이디",
-            "description": "<p>기본값은 파트너의 기본 계약 아이디 입니다.</p>\n"
+            "description": "기본값은 파트너의 기본 계약 아이디 입니다."
           },
           "memo": {
             "type": "string",
@@ -22516,12 +22517,12 @@
             "type": "integer",
             "format": "int64",
             "title": "주문 면세 금액",
-            "description": "<p>주문 항목과 면세 금액을 같이 전달하시면 최종 면세 금액은 주문 항목의 면세 금액이 아닌 전달해주신 면세 금액으로 적용됩니다.</p>\n"
+            "description": "주문 항목과 면세 금액을 같이 전달하시면 최종 면세 금액은 주문 항목의 면세 금액이 아닌 전달해주신 면세 금액으로 적용됩니다."
           },
           "settlementStartDate": {
-            "description": "<p>기본값은 결제 일시 입니다.</p>\n",
+            "description": "기본값은 결제 일시 입니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "정산 시작일"
           },
           "discounts": {
@@ -22541,12 +22542,12 @@
           "externalPaymentDetail": {
             "$ref": "#/components/schemas/CreatePlatformOrderTransferBodyExternalPaymentDetail",
             "title": "외부 결제 상세 정보",
-            "description": "<p>해당 정보가 존재하는 경우 외부 결제 정산건 으로 등록되고, 존재하지않은 경우 포트원 결제 정산건으로 등록됩니다.</p>\n"
+            "description": "해당 정보가 존재하는 경우 외부 결제 정산건 으로 등록되고, 존재하지않은 경우 포트원 결제 정산건으로 등록됩니다."
           },
           "isForTest": {
             "type": "boolean",
             "title": "테스트 모드 여부",
-            "description": "<p>기본값은 false 입니다.</p>\n"
+            "description": "기본값은 false 입니다."
           },
           "parameters": {
             "$ref": "#/components/schemas/TransferParameters",
@@ -22564,7 +22565,7 @@
       },
       "CreatePlatformOrderTransferBodyAdditionalFee": {
         "title": "추가 수수료 정보",
-        "description": "<p>추가 수수료 정보</p>\n",
+        "description": "추가 수수료 정보",
         "type": "object",
         "required": [
           "policyId"
@@ -22579,7 +22580,7 @@
       },
       "CreatePlatformOrderTransferBodyDiscount": {
         "title": "할인 정보",
-        "description": "<p>할인 정보</p>\n",
+        "description": "할인 정보",
         "type": "object",
         "required": [
           "sharePolicyId",
@@ -22605,7 +22606,7 @@
       },
       "CreatePlatformOrderTransferBodyExternalPaymentDetail": {
         "title": "외부 결제 상세 정보",
-        "description": "<p>외부 결제 상세 정보</p>\n",
+        "description": "외부 결제 상세 정보",
         "type": "object",
         "required": [
           "currency"
@@ -22633,7 +22634,7 @@
       },
       "CreatePlatformOrderTransferBodyOrderDetail": {
         "title": "주문 정보",
-        "description": "<p>주문 정보</p>\n<p>주문 금액 또는 주문 항목 하나만 입력 가능합니다.</p>\n",
+        "description": "주문 정보\n\n주문 금액 또는 주문 항목 하나만 입력 가능합니다.",
         "type": "object",
         "properties": {
           "orderAmount": {
@@ -22650,11 +22651,11 @@
           }
         },
         "x-portone-title": "주문 정보",
-        "x-portone-description": "<p>주문 금액 또는 주문 항목 하나만 입력 가능합니다.</p>\n"
+        "x-portone-description": "주문 금액 또는 주문 항목 하나만 입력 가능합니다."
       },
       "CreatePlatformOrderTransferBodyOrderLine": {
         "title": "주문 항목",
-        "description": "<p>주문 항목</p>\n",
+        "description": "주문 항목",
         "type": "object",
         "required": [
           "product",
@@ -22691,7 +22692,7 @@
       },
       "CreatePlatformOrderTransferBodyProduct": {
         "title": "상품",
-        "description": "<p>상품</p>\n",
+        "description": "상품",
         "type": "object",
         "required": [
           "id",
@@ -22816,7 +22817,7 @@
       },
       "CreatePlatformPartnerBody": {
         "title": "파트너 생성을 위한 입력 정보",
-        "description": "<p>파트너 생성을 위한 입력 정보</p>\n",
+        "description": "파트너 생성을 위한 입력 정보",
         "type": "object",
         "required": [
           "name",
@@ -22830,7 +22831,7 @@
           "id": {
             "type": "string",
             "title": "파트너에 부여할 고유 아이디",
-            "description": "<p>고객사 서버에 등록된 파트너 지칭 아이디와 동일하게 설정하는 것을 권장합니다. 명시하지 않는 경우 포트원이 임의의 아이디를 발급해드립니다.</p>\n"
+            "description": "고객사 서버에 등록된 파트너 지칭 아이디와 동일하게 설정하는 것을 권장합니다. 명시하지 않는 경우 포트원이 임의의 아이디를 발급해드립니다."
           },
           "name": {
             "type": "string",
@@ -22843,17 +22844,17 @@
           "account": {
             "$ref": "#/components/schemas/CreatePlatformPartnerBodyAccount",
             "title": "정산 계좌",
-            "description": "<p>파트너의 사업자등록번호가 존재하는 경우 명시합니다. 별도로 검증하지는 않으며, 번호와 기호 모두 입력 가능합니다.</p>\n"
+            "description": "파트너의 사업자등록번호가 존재하는 경우 명시합니다. 별도로 검증하지는 않으며, 번호와 기호 모두 입력 가능합니다."
           },
           "defaultContractId": {
             "type": "string",
             "title": "기본 계약 아이디",
-            "description": "<p>이미 존재하는 계약 아이디를 등록해야 합니다.</p>\n"
+            "description": "이미 존재하는 계약 아이디를 등록해야 합니다."
           },
           "memo": {
             "type": "string",
             "title": "파트너에 대한 메모",
-            "description": "<p>총 256자까지 입력할 수 있습니다.</p>\n"
+            "description": "총 256자까지 입력할 수 있습니다."
           },
           "tags": {
             "type": "array",
@@ -22861,12 +22862,12 @@
               "type": "string"
             },
             "title": "파트너에 부여할 태그 리스트",
-            "description": "<p>최대 10개까지 입력할 수 있습니다.</p>\n"
+            "description": "최대 10개까지 입력할 수 있습니다."
           },
           "type": {
             "$ref": "#/components/schemas/CreatePlatformPartnerBodyType",
             "title": "파트너 유형별 추가 정보",
-            "description": "<p>사업자/원천징수 대상자 중 추가할 파트너의 유형에 따른 정보를 입력해야 합니다.</p>\n"
+            "description": "사업자/원천징수 대상자 중 추가할 파트너의 유형에 따른 정보를 입력해야 합니다."
           },
           "userDefinedProperties": {
             "$ref": "#/components/schemas/PlatformProperties",
@@ -22877,7 +22878,7 @@
       },
       "CreatePlatformPartnerBodyAccount": {
         "title": "파트너 계좌 등록을 위한 정보",
-        "description": "<p>파트너 계좌 등록을 위한 정보</p>\n",
+        "description": "파트너 계좌 등록을 위한 정보",
         "type": "object",
         "required": [
           "bank",
@@ -22911,7 +22912,7 @@
       },
       "CreatePlatformPartnerBodyContact": {
         "title": "파트너 담당자 정보",
-        "description": "<p>파트너 담당자 정보</p>\n",
+        "description": "파트너 담당자 정보",
         "type": "object",
         "required": [
           "name",
@@ -22935,7 +22936,7 @@
       },
       "CreatePlatformPartnerBodyType": {
         "title": "파트너 생성을 위한 유형별 추가 정보",
-        "description": "<p>파트너 생성을 위한 유형별 추가 정보</p>\n",
+        "description": "파트너 생성을 위한 유형별 추가 정보",
         "type": "object",
         "properties": {
           "business": {
@@ -22969,7 +22970,7 @@
           "taxationType": {
             "$ref": "#/components/schemas/PlatformPartnerTaxationType",
             "title": "사업자 유형",
-            "description": "<p>값을 입력하지 않으면 일반 과세로 설정됩니다.</p>\n"
+            "description": "값을 입력하지 않으면 일반 과세로 설정됩니다."
           },
           "businessRegistrationNumber": {
             "type": "string",
@@ -22998,9 +22999,9 @@
         "type": "object",
         "properties": {
           "birthdate": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "생년월일"
           }
         }
@@ -23010,9 +23011,9 @@
         "type": "object",
         "properties": {
           "birthdate": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "생년월일"
           }
         }
@@ -23073,7 +23074,7 @@
       },
       "CreatePlatformPartnerResponse": {
         "title": "파트너 생성 성공 응답",
-        "description": "<p>파트너 생성 성공 응답</p>\n",
+        "description": "파트너 생성 성공 응답",
         "type": "object",
         "required": [
           "partner"
@@ -23088,7 +23089,7 @@
       },
       "CreatePlatformPartnersBody": {
         "title": "파트너 다건 생성을 위한 입력 정보",
-        "description": "<p>파트너 다건 생성을 위한 입력 정보</p>\n",
+        "description": "파트너 다건 생성을 위한 입력 정보",
         "type": "object",
         "required": [
           "partners"
@@ -23152,7 +23153,7 @@
       },
       "CreatePlatformPartnersResponse": {
         "title": "파트너 다건 생성 성공 응답",
-        "description": "<p>파트너 다건 생성 성공 응답</p>\n",
+        "description": "파트너 다건 생성 성공 응답",
         "type": "object",
         "required": [
           "partners"
@@ -23170,7 +23171,7 @@
       },
       "Currency": {
         "title": "통화 단위",
-        "description": "<p>통화 단위</p>\n",
+        "description": "통화 단위",
         "type": "string",
         "enum": [
           "KRW",
@@ -23904,7 +23905,7 @@
       },
       "CursorPageInfo": {
         "title": "커서 기반 페이지 정보",
-        "description": "<p>커서 기반 페이지 정보</p>\n",
+        "description": "커서 기반 페이지 정보",
         "type": "object",
         "required": [
           "startCursor",
@@ -23930,13 +23931,13 @@
       },
       "Customer": {
         "title": "고객 정보",
-        "description": "<p>고객 정보</p>\n",
+        "description": "고객 정보",
         "type": "object",
         "properties": {
           "id": {
             "type": "string",
             "title": "고객 아이디",
-            "description": "<p>고객사가 지정한 고객의 고유 식별자입니다.</p>\n"
+            "description": "고객사가 지정한 고객의 고유 식별자입니다."
           },
           "name": {
             "type": "string",
@@ -23971,13 +23972,13 @@
       },
       "CustomerInput": {
         "title": "고객 정보 입력 정보",
-        "description": "<p>고객 정보 입력 정보</p>\n",
+        "description": "고객 정보 입력 정보",
         "type": "object",
         "properties": {
           "id": {
             "type": "string",
             "title": "고객 아이디",
-            "description": "<p>고객사가 지정한 고객의 고유 식별자입니다.</p>\n"
+            "description": "고객사가 지정한 고객의 고유 식별자입니다."
           },
           "name": {
             "$ref": "#/components/schemas/CustomerNameInput",
@@ -24028,7 +24029,7 @@
       },
       "CustomerNameInput": {
         "title": "고객 이름 입력 정보",
-        "description": "<p>고객 이름 입력 정보</p>\n<p>두 개의 이름 형식 중 한 가지만 선택하여 입력해주세요.</p>\n",
+        "description": "고객 이름 입력 정보\n\n두 개의 이름 형식 중 한 가지만 선택하여 입력해주세요.",
         "type": "object",
         "properties": {
           "full": {
@@ -24041,11 +24042,11 @@
           }
         },
         "x-portone-title": "고객 이름 입력 정보",
-        "x-portone-description": "<p>두 개의 이름 형식 중 한 가지만 선택하여 입력해주세요.</p>\n"
+        "x-portone-description": "두 개의 이름 형식 중 한 가지만 선택하여 입력해주세요."
       },
       "CustomerSeparatedName": {
         "title": "고객 분리형 이름",
-        "description": "<p>고객 분리형 이름</p>\n",
+        "description": "고객 분리형 이름",
         "type": "object",
         "required": [
           "first",
@@ -24072,20 +24073,20 @@
         ],
         "properties": {
           "from": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n"
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다."
           },
           "until": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n"
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다."
           }
         }
       },
       "DateTimeRange": {
         "title": "시간 범위",
-        "description": "<p>시간 범위</p>\n",
+        "description": "시간 범위",
         "type": "object",
         "required": [
           "from",
@@ -24105,7 +24106,7 @@
       },
       "DayOfWeek": {
         "title": "요일",
-        "description": "<p>요일</p>\n",
+        "description": "요일",
         "type": "string",
         "enum": [
           "SUN",
@@ -24247,7 +24248,7 @@
       },
       "DeleteBillingKeyResponse": {
         "title": "빌링키 삭제 성공 응답",
-        "description": "<p>빌링키 삭제 성공 응답</p>\n",
+        "description": "빌링키 삭제 성공 응답",
         "type": "object",
         "required": [
           "deletedAt"
@@ -24305,7 +24306,7 @@
       },
       "DeletedBillingKeyInfo": {
         "title": "빌링키 삭제 완료 상태 건",
-        "description": "<p>빌링키 삭제 완료 상태 건</p>\n",
+        "description": "빌링키 삭제 완료 상태 건",
         "type": "object",
         "required": [
           "status",
@@ -24340,7 +24341,7 @@
             "items": {
               "$ref": "#/components/schemas/BillingKeyPaymentMethod"
             },
-            "description": "<p>추후 슈퍼빌링키 기능 제공 시 여러 결제수단 정보가 담길 수 있습니다.</p>\n"
+            "description": "추후 슈퍼빌링키 기능 제공 시 여러 결제수단 정보가 담길 수 있습니다."
           },
           "channels": {
             "title": "빌링키 발급 시 사용된 채널",
@@ -24348,7 +24349,7 @@
             "items": {
               "$ref": "#/components/schemas/SelectedChannel"
             },
-            "description": "<p>추후 슈퍼빌링키 기능 제공 시 여러 채널 정보가 담길 수 있습니다.</p>\n"
+            "description": "추후 슈퍼빌링키 기능 제공 시 여러 채널 정보가 담길 수 있습니다."
           },
           "customer": {
             "$ref": "#/components/schemas/Customer",
@@ -24386,7 +24387,7 @@
             "items": {
               "$ref": "#/components/schemas/PgBillingKeyIssueResponse"
             },
-            "description": "<p>슈퍼빌링키의 경우, 빌링키 발급이 성공하더라도 일부 채널에 대한 발급은 실패할 수 있습니다.</p>\n"
+            "description": "슈퍼빌링키의 경우, 빌링키 발급이 성공하더라도 일부 채널에 대한 발급은 실패할 수 있습니다."
           },
           "deletedAt": {
             "type": "string",
@@ -24398,7 +24399,7 @@
       },
       "DeliveredPaymentEscrow": {
         "title": "배송 완료",
-        "description": "<p>배송 완료</p>\n",
+        "description": "배송 완료",
         "type": "object",
         "required": [
           "status",
@@ -24433,7 +24434,7 @@
       },
       "DiscountAmountExceedsTotalAmountError": {
         "title": "프로모션 할인 금액이 결제 시도 금액 이상인 경우",
-        "description": "<p>프로모션 할인 금액이 결제 시도 금액 이상인 경우</p>\n",
+        "description": "프로모션 할인 금액이 결제 시도 금액 이상인 경우",
         "type": "object",
         "required": [
           "type"
@@ -24451,7 +24452,7 @@
       },
       "DownloadPaymentsExcelBody": {
         "title": "결제건 엑셀 다운로드를 위한 입력 정보",
-        "description": "<p>결제건 엑셀 다운로드를 위한 입력 정보</p>\n",
+        "description": "결제건 엑셀 다운로드를 위한 입력 정보",
         "type": "object",
         "required": [
           "filter"
@@ -24475,7 +24476,7 @@
           "storeId": {
             "type": "string",
             "title": "상점 아이디",
-            "description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다."
           },
           "promotionId": {
             "type": "string",
@@ -24642,7 +24643,7 @@
       },
       "DownloadPromotionsExcelBody": {
         "title": "프로모션 내역 엑셀 다운로드를 위한 입력 정보",
-        "description": "<p>프로모션 내역 엑셀 다운로드를 위한 입력 정보</p>\n",
+        "description": "프로모션 내역 엑셀 다운로드를 위한 입력 정보",
         "type": "object",
         "required": [
           "storeId"
@@ -24651,7 +24652,7 @@
           "storeId": {
             "type": "string",
             "title": "상점 아이디",
-            "description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다."
           },
           "datetimeRange": {
             "$ref": "#/components/schemas/DateTimeRange",
@@ -24666,7 +24667,7 @@
       },
       "EasyPayMethodType": {
         "title": "간편 결제 수단",
-        "description": "<p>간편 결제 수단</p>\n",
+        "description": "간편 결제 수단",
         "type": "string",
         "enum": [
           "CARD",
@@ -24682,7 +24683,7 @@
       },
       "EasyPayProvider": {
         "title": "간편 결제사",
-        "description": "<p>간편 결제사</p>\n",
+        "description": "간편 결제사",
         "type": "string",
         "enum": [
           "SAMSUNGPAY",
@@ -24726,7 +24727,7 @@
       },
       "FailedIdentityVerification": {
         "title": "실패한 본인인증 내역",
-        "description": "<p>실패한 본인인증 내역</p>\n",
+        "description": "실패한 본인인증 내역",
         "type": "object",
         "required": [
           "status",
@@ -24777,7 +24778,7 @@
       },
       "FailedPayment": {
         "title": "결제 실패 상태 건",
-        "description": "<p>결제 실패 상태 건</p>\n",
+        "description": "결제 실패 상태 건",
         "type": "object",
         "required": [
           "status",
@@ -24807,7 +24808,7 @@
           "transactionId": {
             "type": "string",
             "title": "결제 건 포트원 채번 아이디",
-            "description": "<p>V1 결제 건의 경우 imp_uid에 해당합니다.</p>\n"
+            "description": "V1 결제 건의 경우 imp_uid에 해당합니다."
           },
           "merchantId": {
             "type": "string",
@@ -24836,12 +24837,12 @@
           "scheduleId": {
             "type": "string",
             "title": "결제 예약 건 아이디",
-            "description": "<p>결제 예약을 이용한 경우에만 존재</p>\n"
+            "description": "결제 예약을 이용한 경우에만 존재"
           },
           "billingKey": {
             "type": "string",
             "title": "결제 시 사용된 빌링키",
-            "description": "<p>빌링키 결제인 경우에만 존재</p>\n"
+            "description": "빌링키 결제인 경우에만 존재"
           },
           "webhooks": {
             "title": "웹훅 발송 내역",
@@ -24892,7 +24893,7 @@
           "escrow": {
             "$ref": "#/components/schemas/PaymentEscrow",
             "title": "에스크로 결제 정보",
-            "description": "<p>에스크로 결제인 경우 존재합니다.</p>\n"
+            "description": "에스크로 결제인 경우 존재합니다."
           },
           "products": {
             "title": "상품 정보",
@@ -24924,7 +24925,7 @@
       },
       "FailedPaymentCancellation": {
         "title": "취소 실패 상태",
-        "description": "<p>취소 실패 상태</p>\n",
+        "description": "취소 실패 상태",
         "type": "object",
         "required": [
           "status",
@@ -24987,7 +24988,7 @@
       },
       "FailedPaymentSchedule": {
         "title": "결제 실패 상태",
-        "description": "<p>결제 실패 상태</p>\n",
+        "description": "결제 실패 상태",
         "type": "object",
         "required": [
           "status",
@@ -25116,7 +25117,7 @@
       },
       "FailedPgBillingKeyIssueResponse": {
         "title": "빌링키 발급 실패 채널 응답",
-        "description": "<p>빌링키 발급 실패 채널 응답</p>\n",
+        "description": "빌링키 발급 실패 채널 응답",
         "type": "object",
         "required": [
           "type",
@@ -25130,7 +25131,7 @@
           "channel": {
             "$ref": "#/components/schemas/SelectedChannel",
             "title": "채널",
-            "description": "<p>빌링키 발급을 시도한 채널입니다.</p>\n"
+            "description": "빌링키 발급을 시도한 채널입니다."
           },
           "failure": {
             "$ref": "#/components/schemas/BillingKeyFailure",
@@ -25141,7 +25142,7 @@
       },
       "ForbiddenError": {
         "title": "요청이 거절된 경우",
-        "description": "<p>요청이 거절된 경우</p>\n",
+        "description": "요청이 거절된 경우",
         "type": "object",
         "required": [
           "type"
@@ -25159,7 +25160,7 @@
       },
       "Gender": {
         "title": "성별",
-        "description": "<p>성별</p>\n",
+        "description": "성별",
         "type": "string",
         "enum": [
           "MALE",
@@ -25196,43 +25197,43 @@
       },
       "GetAllPaymentsByCursorBody": {
         "title": "GetAllPaymentsByCursorBody",
-        "description": "<p>결제 건 커서 기반 대용량 다건 조회를 위한 입력 정보</p>\n",
+        "description": "결제 건 커서 기반 대용량 다건 조회를 위한 입력 정보",
         "type": "object",
         "properties": {
           "storeId": {
             "type": "string",
             "title": "상점 아이디",
-            "description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다."
           },
           "from": {
             "type": "string",
             "format": "date-time",
             "title": "결제 건 생성시점 범위 조건의 시작",
-            "description": "<p>값을 입력하지 않으면 end의 90일 전으로 설정됩니다.</p>\n"
+            "description": "값을 입력하지 않으면 end의 90일 전으로 설정됩니다."
           },
           "until": {
             "type": "string",
             "format": "date-time",
             "title": "결제 건 생성시점 범위 조건의 끝",
-            "description": "<p>값을 입력하지 않으면 현재 시점으로 설정됩니다.</p>\n"
+            "description": "값을 입력하지 않으면 현재 시점으로 설정됩니다."
           },
           "cursor": {
             "type": "string",
             "title": "커서",
-            "description": "<p>결제 건 리스트 중 어디서부터 읽어야 할지 가리키는 값입니다. 최초 요청일 경우 값을 입력하지 마시되, 두번째 요청 부터는 이전 요청 응답값의 cursor를 입력해주시면 됩니다.</p>\n"
+            "description": "결제 건 리스트 중 어디서부터 읽어야 할지 가리키는 값입니다. 최초 요청일 경우 값을 입력하지 마시되, 두번째 요청 부터는 이전 요청 응답값의 cursor를 입력해주시면 됩니다."
           },
           "size": {
             "type": "integer",
             "format": "int32",
             "title": "페이지 크기",
-            "description": "<p>미입력 시 기본값은 10 이며 최대 1000까지 허용</p>\n"
+            "description": "미입력 시 기본값은 10 이며 최대 1000까지 허용"
           }
         },
-        "x-portone-description": "<p>결제 건 커서 기반 대용량 다건 조회를 위한 입력 정보</p>\n"
+        "x-portone-description": "결제 건 커서 기반 대용량 다건 조회를 위한 입력 정보"
       },
       "GetAllPaymentsByCursorResponse": {
         "title": "결제 건 커서 기반 대용량 다건 조회 성공 응답 정보",
-        "description": "<p>결제 건 커서 기반 대용량 다건 조회 성공 응답 정보</p>\n",
+        "description": "결제 건 커서 기반 대용량 다건 조회 성공 응답 정보",
         "type": "object",
         "required": [
           "items"
@@ -25272,7 +25273,7 @@
       },
       "GetAnalyticsAverageAmountChartBody": {
         "title": "고객사의 평균 거래액 현황 조회를 위한 입력 정보",
-        "description": "<p>고객사의 평균 거래액 현황 조회를 위한 입력 정보</p>\n",
+        "description": "고객사의 평균 거래액 현황 조회를 위한 입력 정보",
         "type": "object",
         "required": [
           "from",
@@ -25295,24 +25296,24 @@
           "currency": {
             "$ref": "#/components/schemas/Currency",
             "title": "조회할 결제 통화",
-            "description": "<p>입력된 통화로 발생한 결제내역만 응답에 포함됩니다.</p>\n"
+            "description": "입력된 통화로 발생한 결제내역만 응답에 포함됩니다."
           },
           "excludeCancelled": {
             "type": "boolean",
             "title": "결제취소건 제외 여부",
-            "description": "<p>true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다.</p>\n"
+            "description": "true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다."
           },
           "timeGranularity": {
             "$ref": "#/components/schemas/AnalyticsTimeGranularity",
             "title": "평균 거래액 현황 조회 단위",
-            "description": "<p>시간별, 월별 단위만 지원됩니다.</p>\n"
+            "description": "시간별, 월별 단위만 지원됩니다."
           }
         },
         "x-portone-title": "고객사의 평균 거래액 현황 조회를 위한 입력 정보"
       },
       "GetAnalyticsCancellationRateBody": {
         "title": "고객사의 환불율 조회를 위한 입력 정보",
-        "description": "<p>고객사의 환불율 조회를 위한 입력 정보</p>\n",
+        "description": "고객사의 환불율 조회를 위한 입력 정보",
         "type": "object",
         "required": [
           "from",
@@ -25333,7 +25334,7 @@
           "currency": {
             "$ref": "#/components/schemas/Currency",
             "title": "조회할 결제 통화",
-            "description": "<p>입력된 통화로 발생한 결제내역만 응답에 포함됩니다.</p>\n"
+            "description": "입력된 통화로 발생한 결제내역만 응답에 포함됩니다."
           }
         },
         "x-portone-title": "고객사의 환불율 조회를 위한 입력 정보"
@@ -25362,7 +25363,7 @@
       },
       "GetAnalyticsCardChartBody": {
         "title": "고객사의 카드결제 현황 조회를 위한 입력 정보",
-        "description": "<p>고객사의 카드결제 현황 조회를 위한 입력 정보</p>\n",
+        "description": "고객사의 카드결제 현황 조회를 위한 입력 정보",
         "type": "object",
         "required": [
           "from",
@@ -25385,17 +25386,17 @@
           "currency": {
             "$ref": "#/components/schemas/Currency",
             "title": "조회할 결제 통화",
-            "description": "<p>입력된 통화로 발생한 결제내역만 응답에 포함됩니다.</p>\n"
+            "description": "입력된 통화로 발생한 결제내역만 응답에 포함됩니다."
           },
           "excludeCancelled": {
             "type": "boolean",
             "title": "결제취소건 제외 여부",
-            "description": "<p>true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다.</p>\n"
+            "description": "true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다."
           },
           "timeGranularity": {
             "$ref": "#/components/schemas/AnalyticsTimeGranularity",
             "title": "카드결제 현황 조회 단위",
-            "description": "<p>시간별, 월별 단위만 지원됩니다.</p>\n"
+            "description": "시간별, 월별 단위만 지원됩니다."
           }
         },
         "x-portone-title": "고객사의 카드결제 현황 조회를 위한 입력 정보"
@@ -25424,7 +25425,7 @@
       },
       "GetAnalyticsCardCompanyChartBody": {
         "title": "고객사의 카드사별 결제 현황 조회를 위한 입력 정보",
-        "description": "<p>고객사의 카드사별 결제 현황 조회를 위한 입력 정보</p>\n",
+        "description": "고객사의 카드사별 결제 현황 조회를 위한 입력 정보",
         "type": "object",
         "required": [
           "from",
@@ -25449,17 +25450,17 @@
           "currency": {
             "$ref": "#/components/schemas/Currency",
             "title": "조회할 결제 통화",
-            "description": "<p>입력된 통화로 발생한 결제내역만 응답에 포함됩니다.</p>\n"
+            "description": "입력된 통화로 발생한 결제내역만 응답에 포함됩니다."
           },
           "excludeCancelled": {
             "type": "boolean",
             "title": "결제취소건 제외 여부",
-            "description": "<p>true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다.</p>\n"
+            "description": "true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다."
           },
           "timeGranularity": {
             "$ref": "#/components/schemas/AnalyticsTimeGranularity",
             "title": "카드사별 결제 현황 조회 단위",
-            "description": "<p>시간별, 월별 단위만 지원됩니다.</p>\n"
+            "description": "시간별, 월별 단위만 지원됩니다."
           },
           "cardCompanies": {
             "title": "조회할 카드사",
@@ -25502,7 +25503,7 @@
       },
       "GetAnalyticsEasyPayChartBody": {
         "title": "고객사의 간편결제 현황 조회를 위한 입력 정보",
-        "description": "<p>고객사의 간편결제 현황 조회를 위한 입력 정보</p>\n",
+        "description": "고객사의 간편결제 현황 조회를 위한 입력 정보",
         "type": "object",
         "required": [
           "from",
@@ -25525,17 +25526,17 @@
           "currency": {
             "$ref": "#/components/schemas/Currency",
             "title": "조회할 결제 통화",
-            "description": "<p>입력된 통화로 발생한 결제내역만 응답에 포함됩니다.</p>\n"
+            "description": "입력된 통화로 발생한 결제내역만 응답에 포함됩니다."
           },
           "excludeCancelled": {
             "type": "boolean",
             "title": "결제취소건 제외 여부",
-            "description": "<p>true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다.</p>\n"
+            "description": "true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다."
           },
           "timeGranularity": {
             "$ref": "#/components/schemas/AnalyticsTimeGranularity",
             "title": "간편결제 현황 조회 단위",
-            "description": "<p>시간별, 월별 단위만 지원됩니다.</p>\n"
+            "description": "시간별, 월별 단위만 지원됩니다."
           }
         },
         "x-portone-title": "고객사의 간편결제 현황 조회를 위한 입력 정보"
@@ -25564,7 +25565,7 @@
       },
       "GetAnalyticsEasyPayProviderChartBody": {
         "title": "고객사의 간편결제사별 결제 현황 조회를 위한 입력 정보",
-        "description": "<p>고객사의 간편결제사별 결제 현황 조회를 위한 입력 정보</p>\n",
+        "description": "고객사의 간편결제사별 결제 현황 조회를 위한 입력 정보",
         "type": "object",
         "required": [
           "from",
@@ -25589,17 +25590,17 @@
           "currency": {
             "$ref": "#/components/schemas/Currency",
             "title": "조회할 결제 통화",
-            "description": "<p>입력된 통화로 발생한 결제내역만 응답에 포함됩니다.</p>\n"
+            "description": "입력된 통화로 발생한 결제내역만 응답에 포함됩니다."
           },
           "excludeCancelled": {
             "type": "boolean",
             "title": "결제취소건 제외 여부",
-            "description": "<p>true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다.</p>\n"
+            "description": "true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다."
           },
           "timeGranularity": {
             "$ref": "#/components/schemas/AnalyticsTimeGranularity",
             "title": "간편결제사별 결제 현황 조회 단위",
-            "description": "<p>시간별, 월별 단위만 지원됩니다.</p>\n"
+            "description": "시간별, 월별 단위만 지원됩니다."
           },
           "easyPayProviders": {
             "title": "조회할 간편결제사",
@@ -25660,7 +25661,7 @@
       },
       "GetAnalyticsPaymentChartBody": {
         "title": "고객사의 결제 현황 조회를 위한 입력 정보",
-        "description": "<p>고객사의 결제 현황 조회를 위한 입력 정보</p>\n",
+        "description": "고객사의 결제 현황 조회를 위한 입력 정보",
         "type": "object",
         "required": [
           "from",
@@ -25682,17 +25683,17 @@
           "currency": {
             "$ref": "#/components/schemas/Currency",
             "title": "조회할 결제 통화",
-            "description": "<p>입력된 통화로 발생한 결제내역만 응답에 포함됩니다.</p>\n"
+            "description": "입력된 통화로 발생한 결제내역만 응답에 포함됩니다."
           },
           "excludeCancelled": {
             "type": "boolean",
             "title": "결제취소건 제외 여부",
-            "description": "<p>true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다.</p>\n"
+            "description": "true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다."
           },
           "timeGranularity": {
             "$ref": "#/components/schemas/AnalyticsTimeGranularity",
             "title": "결제 현황 조회 단위",
-            "description": "<p>시간별, 월별 단위만 지원됩니다.</p>\n"
+            "description": "시간별, 월별 단위만 지원됩니다."
           }
         },
         "x-portone-title": "고객사의 결제 현황 조회를 위한 입력 정보"
@@ -25721,7 +25722,7 @@
       },
       "GetAnalyticsPaymentChartInsightBody": {
         "title": "고객사의 결제 현황 인사이트 조회를 위한 입력 정보",
-        "description": "<p>고객사의 결제 현황 인사이트 조회를 위한 입력 정보</p>\n",
+        "description": "고객사의 결제 현황 인사이트 조회를 위한 입력 정보",
         "type": "object",
         "required": [
           "from",
@@ -25743,18 +25744,18 @@
           "currency": {
             "$ref": "#/components/schemas/Currency",
             "title": "조회할 결제 통화",
-            "description": "<p>입력된 통화로 발생한 결제내역만 응답에 포함됩니다.</p>\n"
+            "description": "입력된 통화로 발생한 결제내역만 응답에 포함됩니다."
           },
           "excludeCancelled": {
             "type": "boolean",
             "title": "결제취소건 제외 여부",
-            "description": "<p>true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다.</p>\n"
+            "description": "true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다."
           },
           "timezoneHourOffset": {
             "type": "integer",
             "format": "int32",
             "title": "타임존 시간 오프셋",
-            "description": "<p>입력된 시간 오프셋 기준으로 일, 주, 월이 집계 됩니다.</p>\n"
+            "description": "입력된 시간 오프셋 기준으로 일, 주, 월이 집계 됩니다."
           }
         },
         "x-portone-title": "고객사의 결제 현황 인사이트 조회를 위한 입력 정보"
@@ -25783,7 +25784,7 @@
       },
       "GetAnalyticsPaymentMethodChartBody": {
         "title": "고객사의 결제수단 현황 조회를 위한 입력 정보",
-        "description": "<p>고객사의 결제수단 현황 조회를 위한 입력 정보</p>\n",
+        "description": "고객사의 결제수단 현황 조회를 위한 입력 정보",
         "type": "object",
         "required": [
           "from",
@@ -25805,19 +25806,19 @@
           "currency": {
             "$ref": "#/components/schemas/Currency",
             "title": "조회할 결제 통화",
-            "description": "<p>입력된 통화로 발생한 결제내역만 응답에 포함됩니다.</p>\n"
+            "description": "입력된 통화로 발생한 결제내역만 응답에 포함됩니다."
           },
           "excludeCancelled": {
             "type": "boolean",
             "title": "결제취소건 제외 여부",
-            "description": "<p>true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다.</p>\n"
+            "description": "true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다."
           }
         },
         "x-portone-title": "고객사의 결제수단 현황 조회를 위한 입력 정보"
       },
       "GetAnalyticsPaymentMethodTrendChartBody": {
         "title": "고객사의 결제수단 트렌드 조회를 위한 입력 정보",
-        "description": "<p>고객사의 결제수단 트렌드 조회를 위한 입력 정보</p>\n",
+        "description": "고객사의 결제수단 트렌드 조회를 위한 입력 정보",
         "type": "object",
         "required": [
           "from",
@@ -25840,24 +25841,24 @@
           "currency": {
             "$ref": "#/components/schemas/Currency",
             "title": "조회할 결제 통화",
-            "description": "<p>입력된 통화로 발생한 결제내역만 응답에 포함됩니다.</p>\n"
+            "description": "입력된 통화로 발생한 결제내역만 응답에 포함됩니다."
           },
           "excludeCancelled": {
             "type": "boolean",
             "title": "결제취소건 제외 여부",
-            "description": "<p>true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다.</p>\n"
+            "description": "true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다."
           },
           "timeGranularity": {
             "$ref": "#/components/schemas/AnalyticsTimeGranularity",
             "title": "결제 결제수단 트렌드 조회 단위",
-            "description": "<p>시간별, 월별 단위만 지원됩니다.</p>\n"
+            "description": "시간별, 월별 단위만 지원됩니다."
           }
         },
         "x-portone-title": "고객사의 결제수단 트렌드 조회를 위한 입력 정보"
       },
       "GetAnalyticsPaymentStatusByPaymentClientChartBody": {
         "title": "고객사의 결제환경별 결제전환율 조회를 위한 입력 정보",
-        "description": "<p>고객사의 결제환경별 결제전환율 조회를 위한 입력 정보</p>\n",
+        "description": "고객사의 결제환경별 결제전환율 조회를 위한 입력 정보",
         "type": "object",
         "required": [
           "from",
@@ -25878,14 +25879,14 @@
           "currency": {
             "$ref": "#/components/schemas/Currency",
             "title": "조회할 결제 통화",
-            "description": "<p>입력된 통화로 발생한 결제내역만 응답에 포함됩니다.</p>\n"
+            "description": "입력된 통화로 발생한 결제내역만 응답에 포함됩니다."
           }
         },
         "x-portone-title": "고객사의 결제환경별 결제전환율 조회를 위한 입력 정보"
       },
       "GetAnalyticsPaymentStatusByPaymentMethodChartBody": {
         "title": "고객사의 결제수단별 결제전환율 조회를 위한 입력 정보",
-        "description": "<p>고객사의 결제수단별 결제전환율 조회를 위한 입력 정보</p>\n",
+        "description": "고객사의 결제수단별 결제전환율 조회를 위한 입력 정보",
         "type": "object",
         "required": [
           "from",
@@ -25906,14 +25907,14 @@
           "currency": {
             "$ref": "#/components/schemas/Currency",
             "title": "조회할 결제 통화",
-            "description": "<p>입력된 통화로 발생한 결제내역만 응답에 포함됩니다.</p>\n"
+            "description": "입력된 통화로 발생한 결제내역만 응답에 포함됩니다."
           }
         },
         "x-portone-title": "고객사의 결제수단별 결제전환율 조회를 위한 입력 정보"
       },
       "GetAnalyticsPaymentStatusByPgCompanyChartBody": {
         "title": "고객사의 PG사별 결제전환율 조회를 위한 입력 정보",
-        "description": "<p>고객사의 PG사별 결제전환율 조회를 위한 입력 정보</p>\n",
+        "description": "고객사의 PG사별 결제전환율 조회를 위한 입력 정보",
         "type": "object",
         "required": [
           "from",
@@ -25934,14 +25935,14 @@
           "currency": {
             "$ref": "#/components/schemas/Currency",
             "title": "조회할 결제 통화",
-            "description": "<p>입력된 통화로 발생한 결제내역만 응답에 포함됩니다.</p>\n"
+            "description": "입력된 통화로 발생한 결제내역만 응답에 포함됩니다."
           }
         },
         "x-portone-title": "고객사의 PG사별 결제전환율 조회를 위한 입력 정보"
       },
       "GetAnalyticsPaymentStatusChartBody": {
         "title": "고객사의 결제상태 이력 집계 조회를 위한 입력 정보",
-        "description": "<p>고객사의 결제상태 이력 집계 조회를 위한 입력 정보</p>\n",
+        "description": "고객사의 결제상태 이력 집계 조회를 위한 입력 정보",
         "type": "object",
         "required": [
           "from",
@@ -25962,14 +25963,14 @@
           "currency": {
             "$ref": "#/components/schemas/Currency",
             "title": "조회할 결제 통화",
-            "description": "<p>입력된 통화로 발생한 결제내역만 응답에 포함됩니다.</p>\n"
+            "description": "입력된 통화로 발생한 결제내역만 응답에 포함됩니다."
           }
         },
         "x-portone-title": "고객사의 결제상태 이력 집계 조회를 위한 입력 정보"
       },
       "GetAnalyticsPgCompanyChartBody": {
         "title": "고객사의 결제대행사 현황 조회를 위한 입력 정보",
-        "description": "<p>고객사의 결제대행사 현황 조회를 위한 입력 정보</p>\n",
+        "description": "고객사의 결제대행사 현황 조회를 위한 입력 정보",
         "type": "object",
         "required": [
           "from",
@@ -25991,19 +25992,19 @@
           "currency": {
             "$ref": "#/components/schemas/Currency",
             "title": "조회할 결제 통화",
-            "description": "<p>입력된 통화로 발생한 결제내역만 응답에 포함됩니다.</p>\n"
+            "description": "입력된 통화로 발생한 결제내역만 응답에 포함됩니다."
           },
           "excludeCancelled": {
             "type": "boolean",
             "title": "결제취소건 제외 여부",
-            "description": "<p>true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다.</p>\n"
+            "description": "true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다."
           }
         },
         "x-portone-title": "고객사의 결제대행사 현황 조회를 위한 입력 정보"
       },
       "GetAnalyticsPgCompanyTrendChartBody": {
         "title": "고객사의 결제대행사별 거래 추이 조회를 위한 입력 정보",
-        "description": "<p>고객사의 결제대행사별 거래 추이 조회를 위한 입력 정보</p>\n",
+        "description": "고객사의 결제대행사별 거래 추이 조회를 위한 입력 정보",
         "type": "object",
         "required": [
           "from",
@@ -26027,17 +26028,17 @@
           "currency": {
             "$ref": "#/components/schemas/Currency",
             "title": "조회할 결제 통화",
-            "description": "<p>입력된 통화로 발생한 결제내역만 응답에 포함됩니다.</p>\n"
+            "description": "입력된 통화로 발생한 결제내역만 응답에 포함됩니다."
           },
           "excludeCancelled": {
             "type": "boolean",
             "title": "결제취소건 제외 여부",
-            "description": "<p>true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다.</p>\n"
+            "description": "true 이면 결제취소내역은 응답에 포함 및 반영되지 않습니다. false 또는 값을 명시하지 않은 경우 결제취소내역이 응답에 반영됩니다."
           },
           "timeGranularity": {
             "$ref": "#/components/schemas/AnalyticsTimeGranularity",
             "title": "결제 결제대행사별 거래 추이 조회 단위",
-            "description": "<p>시간별, 월별 단위만 지원됩니다.</p>\n"
+            "description": "시간별, 월별 단위만 지원됩니다."
           },
           "pgCompanies": {
             "title": "조회할 결제대행사",
@@ -26127,7 +26128,7 @@
       },
       "GetB2bBankAccountHolderResponse": {
         "title": "예금주 조회 응답 정보",
-        "description": "<p>예금주 조회 응답 정보</p>\n",
+        "description": "예금주 조회 응답 정보",
         "type": "object",
         "required": [
           "accountHolder"
@@ -26206,7 +26207,7 @@
       },
       "GetB2bCertificateRegistrationUrlResponse": {
         "title": "인증서 등록 URL 조회 응답 정보",
-        "description": "<p>인증서 등록 URL 조회 응답 정보</p>\n",
+        "description": "인증서 등록 URL 조회 응답 정보",
         "type": "object",
         "required": [
           "url"
@@ -26255,7 +26256,7 @@
       },
       "GetB2bContactIdExistenceResponse": {
         "title": "담당자 ID 존재 여부 응답 정보",
-        "description": "<p>담당자 ID 존재 여부 응답 정보</p>\n",
+        "description": "담당자 ID 존재 여부 응답 정보",
         "type": "object",
         "required": [
           "exists"
@@ -26364,7 +26365,7 @@
       },
       "GetB2bTaxInvoiceAttachmentsResponse": {
         "title": "세금계산서 첨부파일 목록 조회 성공 응답",
-        "description": "<p>세금계산서 첨부파일 목록 조회 성공 응답</p>\n",
+        "description": "세금계산서 첨부파일 목록 조회 성공 응답",
         "type": "object",
         "required": [
           "attachments"
@@ -26442,7 +26443,7 @@
       },
       "GetB2bTaxInvoicePdfDownloadUrlResponse": {
         "title": "세금계산서 PDF 다운로드 URL 성공 응답",
-        "description": "<p>세금계산서 PDF 다운로드 URL 성공 응답</p>\n",
+        "description": "세금계산서 PDF 다운로드 URL 성공 응답",
         "type": "object",
         "required": [
           "url"
@@ -26487,7 +26488,7 @@
       },
       "GetB2bTaxInvoicePopupUrlResponse": {
         "title": "세금계산서 팝업 URL 성공 응답",
-        "description": "<p>세금계산서 팝업 URL 성공 응답</p>\n",
+        "description": "세금계산서 팝업 URL 성공 응답",
         "type": "object",
         "required": [
           "url"
@@ -26532,7 +26533,7 @@
       },
       "GetB2bTaxInvoicePrintUrlResponse": {
         "title": "세금계산서 프린트 URL 성공 응답",
-        "description": "<p>세금계산서 프린트 URL 성공 응답</p>\n",
+        "description": "세금계산서 프린트 URL 성공 응답",
         "type": "object",
         "required": [
           "url"
@@ -26573,7 +26574,7 @@
       },
       "GetB2bTaxInvoicesResponse": {
         "title": "세금계산서 다건 조회 성공 응답",
-        "description": "<p>세금계산서 다건 조회 성공 응답</p>\n",
+        "description": "세금계산서 다건 조회 성공 응답",
         "type": "object",
         "required": [
           "items",
@@ -26622,26 +26623,26 @@
       },
       "GetBillingKeyInfosBody": {
         "title": "GetBillingKeyInfosBody",
-        "description": "<p>빌링키 다건 조회를 위한 입력 정보</p>\n",
+        "description": "빌링키 다건 조회를 위한 입력 정보",
         "type": "object",
         "properties": {
           "page": {
             "$ref": "#/components/schemas/PageInput",
             "title": "요청할 페이지 정보",
-            "description": "<p>미 입력 시 number: 0, size: 10 으로 기본값이 적용됩니다.</p>\n"
+            "description": "미 입력 시 number: 0, size: 10 으로 기본값이 적용됩니다."
           },
           "sort": {
             "$ref": "#/components/schemas/BillingKeySortInput",
             "title": "정렬 조건",
-            "description": "<p>미 입력 시 sortBy: TIME_TO_PAY, sortOrder: DESC 으로 기본값이 적용됩니다.</p>\n"
+            "description": "미 입력 시 sortBy: TIME_TO_PAY, sortOrder: DESC 으로 기본값이 적용됩니다."
           },
           "filter": {
             "$ref": "#/components/schemas/BillingKeyFilterInput",
             "title": "조회할 빌링키 조건 필터",
-            "description": "<p>V1 빌링키 건의 경우 일부 필드에 대해 필터가 적용되지 않을 수 있습니다.</p>\n"
+            "description": "V1 빌링키 건의 경우 일부 필드에 대해 필터가 적용되지 않을 수 있습니다."
           }
         },
-        "x-portone-description": "<p>빌링키 다건 조회를 위한 입력 정보</p>\n"
+        "x-portone-description": "빌링키 다건 조회를 위한 입력 정보"
       },
       "GetBillingKeyInfosError": {
         "title": "GetBillingKeyInfosError",
@@ -26667,7 +26668,7 @@
       },
       "GetBillingKeyInfosResponse": {
         "title": "빌링키 다건 조회 성공 응답 정보",
-        "description": "<p>빌링키 다건 조회 성공 응답 정보</p>\n",
+        "description": "빌링키 다건 조회 성공 응답 정보",
         "type": "object",
         "required": [
           "items",
@@ -26760,7 +26761,7 @@
       },
       "GetKakaopayPaymentOrderResponse": {
         "title": "카카오페이 주문 조회 응답",
-        "description": "<p>카카오페이 주문 조회 응답</p>\n",
+        "description": "카카오페이 주문 조회 응답",
         "type": "object",
         "required": [
           "statusCode",
@@ -27259,18 +27260,18 @@
       },
       "GetPaymentSchedulesBody": {
         "title": "결제 예약 다건 조회를 위한 입력 정보",
-        "description": "<p>결제 예약 다건 조회를 위한 입력 정보</p>\n<p>조회 결과는 결제 예정 시점(timeToPay) 기준 최신 순으로 정렬됩니다.</p>\n",
+        "description": "결제 예약 다건 조회를 위한 입력 정보\n\n조회 결과는 결제 예정 시점(timeToPay) 기준 최신 순으로 정렬됩니다.",
         "type": "object",
         "properties": {
           "page": {
             "$ref": "#/components/schemas/PageInput",
             "title": "요청할 페이지 정보",
-            "description": "<p>미 입력 시 number: 0, size: 10 으로 기본값이 적용됩니다.</p>\n"
+            "description": "미 입력 시 number: 0, size: 10 으로 기본값이 적용됩니다."
           },
           "sort": {
             "$ref": "#/components/schemas/PaymentScheduleSortInput",
             "title": "정렬 조건",
-            "description": "<p>미 입력 시 sortBy: TIME_TO_PAY, sortOrder: DESC 으로 기본값이 적용됩니다.</p>\n"
+            "description": "미 입력 시 sortBy: TIME_TO_PAY, sortOrder: DESC 으로 기본값이 적용됩니다."
           },
           "filter": {
             "$ref": "#/components/schemas/PaymentScheduleFilterInput",
@@ -27278,7 +27279,7 @@
           }
         },
         "x-portone-title": "결제 예약 다건 조회를 위한 입력 정보",
-        "x-portone-description": "<p>조회 결과는 결제 예정 시점(timeToPay) 기준 최신 순으로 정렬됩니다.</p>\n"
+        "x-portone-description": "조회 결과는 결제 예정 시점(timeToPay) 기준 최신 순으로 정렬됩니다."
       },
       "GetPaymentSchedulesError": {
         "title": "GetPaymentSchedulesError",
@@ -27304,7 +27305,7 @@
       },
       "GetPaymentSchedulesResponse": {
         "title": "결제 예약 다건 조회 성공 응답 정보",
-        "description": "<p>결제 예약 다건 조회 성공 응답 정보</p>\n",
+        "description": "결제 예약 다건 조회 성공 응답 정보",
         "type": "object",
         "required": [
           "items",
@@ -27415,21 +27416,21 @@
       },
       "GetPaymentsBody": {
         "title": "GetPaymentsBody",
-        "description": "<p>결제 건 다건 조회를 위한 입력 정보</p>\n",
+        "description": "결제 건 다건 조회를 위한 입력 정보",
         "type": "object",
         "properties": {
           "page": {
             "$ref": "#/components/schemas/PageInput",
             "title": "요청할 페이지 정보",
-            "description": "<p>미 입력 시 number: 0, size: 10 으로 기본값이 적용됩니다.</p>\n"
+            "description": "미 입력 시 number: 0, size: 10 으로 기본값이 적용됩니다."
           },
           "filter": {
             "$ref": "#/components/schemas/PaymentFilterInput",
             "title": "조회할 결제 건 조건 필터",
-            "description": "<p>V1 결제 건의 경우 일부 필드에 대해 필터가 적용되지 않을 수 있습니다.</p>\n"
+            "description": "V1 결제 건의 경우 일부 필드에 대해 필터가 적용되지 않을 수 있습니다."
           }
         },
-        "x-portone-description": "<p>결제 건 다건 조회를 위한 입력 정보</p>\n"
+        "x-portone-description": "결제 건 다건 조회를 위한 입력 정보"
       },
       "GetPaymentsError": {
         "title": "GetPaymentsError",
@@ -27455,7 +27456,7 @@
       },
       "GetPaymentsResponse": {
         "title": "결제 건 다건 조회 성공 응답 정보",
-        "description": "<p>결제 건 다건 조회 성공 응답 정보</p>\n",
+        "description": "결제 건 다건 조회 성공 응답 정보",
         "type": "object",
         "required": [
           "items",
@@ -27586,7 +27587,7 @@
       },
       "GetPlatformAccountTransfersResponse": {
         "title": "이체내역 다건 조회 성공 응답 정보",
-        "description": "<p>이체내역 다건 조회 성공 응답 정보</p>\n",
+        "description": "이체내역 다건 조회 성공 응답 정보",
         "type": "object",
         "required": [
           "items",
@@ -27609,7 +27610,7 @@
       },
       "GetPlatformAdditionalFeePoliciesBody": {
         "title": "추가 수수료 정책 다건 조회를 위한 입력 정보",
-        "description": "<p>추가 수수료 정책 다건 조회를 위한 입력 정보</p>\n",
+        "description": "추가 수수료 정책 다건 조회를 위한 입력 정보",
         "type": "object",
         "properties": {
           "page": {
@@ -27651,7 +27652,7 @@
       },
       "GetPlatformAdditionalFeePoliciesResponse": {
         "title": "추가 수수료 정책 다건 조회 성공 응답 정보",
-        "description": "<p>추가 수수료 정책 다건 조회 성공 응답 정보</p>\n",
+        "description": "추가 수수료 정책 다건 조회 성공 응답 정보",
         "type": "object",
         "required": [
           "items",
@@ -27956,7 +27957,7 @@
       },
       "GetPlatformContractsBody": {
         "title": "계약 다건 조회를 위한 입력 정보",
-        "description": "<p>계약 다건 조회를 위한 입력 정보</p>\n",
+        "description": "계약 다건 조회를 위한 입력 정보",
         "type": "object",
         "properties": {
           "page": {
@@ -27998,7 +27999,7 @@
       },
       "GetPlatformContractsResponse": {
         "title": "계약 다건 조회 성공 응답",
-        "description": "<p>계약 다건 조회 성공 응답</p>\n",
+        "description": "계약 다건 조회 성공 응답",
         "type": "object",
         "required": [
           "items",
@@ -28021,7 +28022,7 @@
       },
       "GetPlatformDiscountSharePoliciesBody": {
         "title": "할인 분담 정책 다건 조회를 위한 입력 정보",
-        "description": "<p>할인 분담 정책 다건 조회를 위한 입력 정보</p>\n",
+        "description": "할인 분담 정책 다건 조회를 위한 입력 정보",
         "type": "object",
         "properties": {
           "page": {
@@ -28063,7 +28064,7 @@
       },
       "GetPlatformDiscountSharePoliciesResponse": {
         "title": "할인 분담 정책 다건 조회 성공 응답 정보",
-        "description": "<p>할인 분담 정책 다건 조회 성공 응답 정보</p>\n",
+        "description": "할인 분담 정책 다건 조회 성공 응답 정보",
         "type": "object",
         "required": [
           "items",
@@ -28208,7 +28209,7 @@
       },
       "GetPlatformHolidaysResponse": {
         "title": "공휴일 조회",
-        "description": "<p>공휴일 조회</p>\n",
+        "description": "공휴일 조회",
         "type": "object",
         "required": [
           "holidays"
@@ -28226,13 +28227,13 @@
       },
       "GetPlatformPartnerDashboardBody": {
         "title": "파트너 현황 조회를 위한 입력 정보",
-        "description": "<p>파트너 현황 조회를 위한 입력 정보</p>\n",
+        "description": "파트너 현황 조회를 위한 입력 정보",
         "type": "object",
         "properties": {
           "isForTest": {
             "type": "boolean",
             "title": "테스트 조회 여부",
-            "description": "<p>true 이면 isForTest 가 true 인 파트너들을 조회하고, false 이면 isForTest 가 false 인 파트너들을 조회합니다. 기본값은 false 입니다.</p>\n"
+            "description": "true 이면 isForTest 가 true 인 파트너들을 조회하고, false 이면 isForTest 가 false 인 파트너들을 조회합니다. 기본값은 false 입니다."
           }
         },
         "x-portone-title": "파트너 현황 조회를 위한 입력 정보"
@@ -28389,7 +28390,7 @@
       },
       "GetPlatformPartnerSettlementCurrenciesResponse": {
         "title": "정산내역 통화 조회 결과",
-        "description": "<p>정산내역 통화 조회 결과</p>\n",
+        "description": "정산내역 통화 조회 결과",
         "type": "object",
         "required": [
           "settlementCurrencies"
@@ -28487,7 +28488,7 @@
       },
       "GetPlatformPartnerSettlementDatesResponse": {
         "title": "정산일 리스트 조회 결과",
-        "description": "<p>정산일 리스트 조회 결과</p>\n",
+        "description": "정산일 리스트 조회 결과",
         "type": "object",
         "required": [
           "settlementDates"
@@ -28496,9 +28497,9 @@
           "settlementDates": {
             "type": "array",
             "items": {
-              "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+              "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
               "type": "string",
-              "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n"
+              "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다."
             }
           }
         },
@@ -28506,7 +28507,7 @@
       },
       "GetPlatformPartnerSettlementsBody": {
         "title": "정산내역 다건 조회를 위한 입력 정보",
-        "description": "<p>정산내역 다건 조회를 위한 입력 정보</p>\n",
+        "description": "정산내역 다건 조회를 위한 입력 정보",
         "type": "object",
         "required": [
           "filter",
@@ -28555,7 +28556,7 @@
       },
       "GetPlatformPartnerSettlementsResponse": {
         "title": "정산내역 다건 조회 성공 응답 정보",
-        "description": "<p>정산내역 다건 조회 성공 응답 정보</p>\n",
+        "description": "정산내역 다건 조회 성공 응답 정보",
         "type": "object",
         "required": [
           "items",
@@ -28583,7 +28584,7 @@
       },
       "GetPlatformPartnersBody": {
         "title": "파트너 다건 조회를 위한 입력 정보",
-        "description": "<p>파트너 다건 조회를 위한 입력 정보</p>\n",
+        "description": "파트너 다건 조회를 위한 입력 정보",
         "type": "object",
         "properties": {
           "page": {
@@ -28625,7 +28626,7 @@
       },
       "GetPlatformPartnersResponse": {
         "title": "파트너 다건 조회 성공 응답 정보",
-        "description": "<p>파트너 다건 조회 성공 응답 정보</p>\n",
+        "description": "파트너 다건 조회 성공 응답 정보",
         "type": "object",
         "required": [
           "items",
@@ -28674,7 +28675,7 @@
       },
       "GetPlatformPayableSettlementDatesResponse": {
         "title": "지급 가능한 정산일 리스트 조회 성공 응답 정보",
-        "description": "<p>지급 가능한 정산일 리스트 조회 성공 응답 정보</p>\n",
+        "description": "지급 가능한 정산일 리스트 조회 성공 응답 정보",
         "type": "object",
         "required": [
           "settlementDates"
@@ -28683,9 +28684,9 @@
           "settlementDates": {
             "type": "array",
             "items": {
-              "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+              "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
               "type": "string",
-              "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n"
+              "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다."
             },
             "title": "IN_PROCESS, SETTLED 상태의 Transfer가 등록되어 있는 정산일 리스트"
           }
@@ -28794,9 +28795,9 @@
         ],
         "properties": {
           "settlementDate": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n"
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다."
           },
           "isForTest": {
             "type": "boolean"
@@ -28887,7 +28888,7 @@
       },
       "GetPlatformTransferSummariesBody": {
         "title": "정산건 요약 다건 조회를 위한 입력 정보",
-        "description": "<p>정산건 요약 다건 조회를 위한 입력 정보</p>\n",
+        "description": "정산건 요약 다건 조회를 위한 입력 정보",
         "type": "object",
         "properties": {
           "page": {
@@ -28996,7 +28997,7 @@
       },
       "GetV2SupportedChannelsResponse": {
         "title": "채널 다건 조회 성공 응답 정보",
-        "description": "<p>채널 다건 조회 성공 응답 정보</p>\n",
+        "description": "채널 다건 조회 성공 응답 정보",
         "type": "object",
         "required": [
           "items"
@@ -29014,7 +29015,7 @@
       },
       "GiftCertificateType": {
         "title": "상품권 타입",
-        "description": "<p>상품권 타입</p>\n",
+        "description": "상품권 타입",
         "type": "string",
         "enum": [
           "BOOKNLIFE",
@@ -29044,7 +29045,7 @@
       },
       "IdentityVerification": {
         "title": "본인인증 내역",
-        "description": "<p>본인인증 내역</p>\n",
+        "description": "본인인증 내역",
         "oneOf": [
           {
             "$ref": "#/components/schemas/FailedIdentityVerification"
@@ -29079,7 +29080,7 @@
       },
       "IdentityVerificationAlreadySentError": {
         "title": "본인인증 건이 이미 API로 요청된 상태인 경우",
-        "description": "<p>본인인증 건이 이미 API로 요청된 상태인 경우</p>\n",
+        "description": "본인인증 건이 이미 API로 요청된 상태인 경우",
         "type": "object",
         "required": [
           "type"
@@ -29097,7 +29098,7 @@
       },
       "IdentityVerificationAlreadyVerifiedError": {
         "title": "본인인증 건이 이미 인증 완료된 상태인 경우",
-        "description": "<p>본인인증 건이 이미 인증 완료된 상태인 경우</p>\n",
+        "description": "본인인증 건이 이미 인증 완료된 상태인 경우",
         "type": "object",
         "required": [
           "type"
@@ -29115,7 +29116,7 @@
       },
       "IdentityVerificationMethod": {
         "title": "본인인증 방식",
-        "description": "<p>본인인증 방식</p>\n",
+        "description": "본인인증 방식",
         "type": "string",
         "enum": [
           "SMS",
@@ -29129,7 +29130,7 @@
       },
       "IdentityVerificationNotFoundError": {
         "title": "요청된 본인인증 건이 존재하지 않는 경우",
-        "description": "<p>요청된 본인인증 건이 존재하지 않는 경우</p>\n",
+        "description": "요청된 본인인증 건이 존재하지 않는 경우",
         "type": "object",
         "required": [
           "type"
@@ -29147,7 +29148,7 @@
       },
       "IdentityVerificationNotSentError": {
         "title": "본인인증 건이 API로 요청된 상태가 아닌 경우",
-        "description": "<p>본인인증 건이 API로 요청된 상태가 아닌 경우</p>\n",
+        "description": "본인인증 건이 API로 요청된 상태가 아닌 경우",
         "type": "object",
         "required": [
           "type"
@@ -29165,7 +29166,7 @@
       },
       "IdentityVerificationOperator": {
         "title": "본인인증 통신사",
-        "description": "<p>본인인증 통신사</p>\n",
+        "description": "본인인증 통신사",
         "type": "string",
         "enum": [
           "SKT",
@@ -29199,7 +29200,7 @@
       },
       "IdentityVerificationRequestedCustomer": {
         "title": "요청 시 고객 정보",
-        "description": "<p>요청 시 고객 정보</p>\n",
+        "description": "요청 시 고객 정보",
         "type": "object",
         "properties": {
           "id": {
@@ -29213,14 +29214,14 @@
           "phoneNumber": {
             "type": "string",
             "title": "전화번호",
-            "description": "<p>특수 문자(-) 없이 숫자로만 이루어진 번호 형식입니다.</p>\n"
+            "description": "특수 문자(-) 없이 숫자로만 이루어진 번호 형식입니다."
           }
         },
         "x-portone-title": "요청 시 고객 정보"
       },
       "IdentityVerificationVerifiedCustomer": {
         "title": "인증된 고객 정보",
-        "description": "<p>인증된 고객 정보</p>\n",
+        "description": "인증된 고객 정보",
         "type": "object",
         "required": [
           "name",
@@ -29238,45 +29239,50 @@
           "operator": {
             "$ref": "#/components/schemas/IdentityVerificationOperator",
             "title": "통신사",
-            "description": "<p>다날: 별도 계약이 필요합니다.\nKG이니시스: 제공하지 않습니다.</p>\n"
+            "description": "다날: 별도 계약이 필요합니다.\nKG이니시스: 제공하지 않습니다."
           },
           "phoneNumber": {
             "type": "string",
             "title": "전화번호",
-            "description": "<p>특수 문자(-) 없이 숫자로만 이루어진 번호 형식입니다.\n다날: 별도 계약이 필요합니다.\nKG이니시스: 항상 제공합니다.</p>\n"
+            "description": "특수 문자(-) 없이 숫자로만 이루어진 번호 형식입니다.\n다날: 별도 계약이 필요합니다.\nKG이니시스: 항상 제공합니다."
           },
           "birthDate": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "생년월일 (yyyy-MM-dd)"
           },
           "gender": {
             "$ref": "#/components/schemas/Gender",
             "title": "성별",
-            "description": "<p>다날: 항상 제공합니다.\nKG이니시스: 항상 제공합니다.</p>\n"
+            "description": "다날: 항상 제공합니다.\nKG이니시스: 본인확인에서 제공합니다."
           },
           "isForeigner": {
             "type": "boolean",
             "title": "외국인 여부",
-            "description": "<p>다날: 별도 계약이 필요합니다.\nKG이니시스: 항상 제공합니다.</p>\n"
+            "description": "다날: 별도 계약이 필요합니다.\nKG이니시스: 본인확인에서만 제공합니다."
           },
           "ci": {
             "type": "string",
             "title": "CI (개인 고유 식별키)",
-            "description": "<p>개인을 식별하기 위한 고유 정보입니다.\n다날: 항상 제공합니다.\nKG이니시스: 카카오를 제외한 인증사에서 제공합니다.</p>\n"
+            "description": "개인을 식별하기 위한 고유 정보입니다.\n다날: 항상 제공합니다.\nKG이니시스: 카카오를 제외한 인증사에서 제공합니다."
+          },
+          "ci2": {
+            "type": "string",
+            "title": "CI2 (개인 고유 백업 식별키)",
+            "description": "기존 CI가 유출 등의 이유로 사용할 수 없는 경우에 사용됩니다. 평상시에는 제공되지 않습니다.\n다날: 제공하지 않습니다.\nKG이니시스: 본인확인에서 제공합니다."
           },
           "di": {
             "type": "string",
             "title": "DI (사이트별 개인 고유 식별키)",
-            "description": "<p>중복 가입을 방지하기 위해 개인을 식별하는 사이트별 고유 정보입니다.\n다날: 항상 제공합니다.\nKG이니시스: 제공하지 않습니다.</p>\n"
+            "description": "중복 가입을 방지하기 위해 개인을 식별하는 사이트별 고유 정보입니다.\n다날: 항상 제공합니다.\nKG이니시스: 본인확인에서 제공합니다."
           }
         },
         "x-portone-title": "인증된 고객 정보"
       },
       "InstantBillingKeyPaymentMethodInput": {
         "title": "빌링키 발급 시 결제 수단 입력 양식",
-        "description": "<p>빌링키 발급 시 결제 수단 입력 양식</p>\n",
+        "description": "빌링키 발급 시 결제 수단 입력 양식",
         "type": "object",
         "properties": {
           "card": {
@@ -29287,7 +29293,7 @@
       },
       "InstantBillingKeyPaymentMethodInputCard": {
         "title": "카드 수단 정보 입력 양식",
-        "description": "<p>카드 수단 정보 입력 양식</p>\n",
+        "description": "카드 수단 정보 입력 양식",
         "type": "object",
         "required": [
           "credential"
@@ -29301,7 +29307,7 @@
       },
       "InstantPaymentInput": {
         "title": "수기 결제 요청 정보",
-        "description": "<p>수기 결제 요청 정보</p>\n",
+        "description": "수기 결제 요청 정보",
         "type": "object",
         "required": [
           "method",
@@ -29313,17 +29319,17 @@
           "storeId": {
             "type": "string",
             "title": "상점 아이디",
-            "description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다."
           },
           "channelKey": {
             "type": "string",
             "title": "채널 키",
-            "description": "<p>채널 키 또는 채널 그룹 ID 필수</p>\n"
+            "description": "채널 키 또는 채널 그룹 ID 필수"
           },
           "channelGroupId": {
             "type": "string",
             "title": "채널 그룹 ID",
-            "description": "<p>채널 키 또는 채널 그룹 ID 필수</p>\n"
+            "description": "채널 키 또는 채널 그룹 ID 필수"
           },
           "method": {
             "$ref": "#/components/schemas/InstantPaymentMethodInput",
@@ -29336,12 +29342,12 @@
           "isCulturalExpense": {
             "type": "boolean",
             "title": "문화비 지출 여부",
-            "description": "<p>기본값은 false 입니다.</p>\n"
+            "description": "기본값은 false 입니다."
           },
           "isEscrow": {
             "type": "boolean",
             "title": "에스크로 결제 여부",
-            "description": "<p>기본값은 false 입니다.</p>\n"
+            "description": "기본값은 false 입니다."
           },
           "customer": {
             "$ref": "#/components/schemas/CustomerInput",
@@ -29369,7 +29375,7 @@
               "type": "string"
             },
             "title": "웹훅 주소",
-            "description": "<p>결제 승인/실패 시 요청을 받을 웹훅 주소입니다.\n상점에 설정되어 있는 값보다 우선적으로 적용됩니다.\n입력된 값이 없을 경우에는 빈 배열로 해석됩니다.</p>\n"
+            "description": "결제 승인/실패 시 요청을 받을 웹훅 주소입니다.\n상점에 설정되어 있는 값보다 우선적으로 적용됩니다.\n입력된 값이 없을 경우에는 빈 배열로 해석됩니다."
           },
           "products": {
             "title": "상품 정보",
@@ -29377,7 +29383,7 @@
             "items": {
               "$ref": "#/components/schemas/PaymentProduct"
             },
-            "description": "<p>입력된 값이 없을 경우에는 빈 배열로 해석됩니다.</p>\n"
+            "description": "입력된 값이 없을 경우에는 빈 배열로 해석됩니다."
           },
           "productCount": {
             "type": "integer",
@@ -29401,7 +29407,7 @@
       },
       "InstantPaymentMethodInput": {
         "title": "수기 결제 수단 입력 정보",
-        "description": "<p>수기 결제 수단 입력 정보</p>\n<p>하나의 필드만 입력합니다.</p>\n",
+        "description": "수기 결제 수단 입력 정보\n\n하나의 필드만 입력합니다.",
         "type": "object",
         "properties": {
           "card": {
@@ -29414,11 +29420,11 @@
           }
         },
         "x-portone-title": "수기 결제 수단 입력 정보",
-        "x-portone-description": "<p>하나의 필드만 입력합니다.</p>\n"
+        "x-portone-description": "하나의 필드만 입력합니다."
       },
       "InstantPaymentMethodInputCard": {
         "title": "카드 수단 정보 입력 정보",
-        "description": "<p>카드 수단 정보 입력 정보</p>\n",
+        "description": "카드 수단 정보 입력 정보",
         "type": "object",
         "required": [
           "credential"
@@ -29450,7 +29456,7 @@
       },
       "InstantPaymentMethodInputVirtualAccount": {
         "title": "가상계좌 수단 정보 입력 정보",
-        "description": "<p>가상계좌 수단 정보 입력 정보</p>\n",
+        "description": "가상계좌 수단 정보 입력 정보",
         "type": "object",
         "required": [
           "bank",
@@ -29484,7 +29490,7 @@
       },
       "InstantPaymentMethodInputVirtualAccountCashReceiptInfo": {
         "title": "가상계좌 결제 시 현금영수증 정보",
-        "description": "<p>가상계좌 결제 시 현금영수증 정보</p>\n",
+        "description": "가상계좌 결제 시 현금영수증 정보",
         "type": "object",
         "required": [
           "type",
@@ -29504,14 +29510,14 @@
       },
       "InstantPaymentMethodInputVirtualAccountExpiry": {
         "title": "입금 만료 기한",
-        "description": "<p>입금 만료 기한</p>\n<p>validHours와 dueDate 둘 중 하나의 필드만 입력합니다.</p>\n",
+        "description": "입금 만료 기한\n\nvalidHours와 dueDate 둘 중 하나의 필드만 입력합니다.",
         "type": "object",
         "properties": {
           "validHours": {
             "type": "integer",
             "format": "int32",
             "title": "유효 시간",
-            "description": "<p>시간 단위로 입력합니다.</p>\n"
+            "description": "시간 단위로 입력합니다."
           },
           "dueDate": {
             "type": "string",
@@ -29520,11 +29526,11 @@
           }
         },
         "x-portone-title": "입금 만료 기한",
-        "x-portone-description": "<p>validHours와 dueDate 둘 중 하나의 필드만 입력합니다.</p>\n"
+        "x-portone-description": "validHours와 dueDate 둘 중 하나의 필드만 입력합니다."
       },
       "InstantPaymentMethodInputVirtualAccountOption": {
         "title": "가상계좌 발급 방식",
-        "description": "<p>가상계좌 발급 방식</p>\n",
+        "description": "가상계좌 발급 방식",
         "type": "object",
         "required": [
           "type"
@@ -29537,33 +29543,33 @@
           "fixed": {
             "$ref": "#/components/schemas/InstantPaymentMethodInputVirtualAccountOptionFixed",
             "title": "고정식 가상계좌 발급 방식",
-            "description": "<p>발급 유형을 FIXED 로 선택했을 시에만 입력합니다.</p>\n"
+            "description": "발급 유형을 FIXED 로 선택했을 시에만 입력합니다."
           }
         },
         "x-portone-title": "가상계좌 발급 방식"
       },
       "InstantPaymentMethodInputVirtualAccountOptionFixed": {
         "title": "고정식 가상계좌 발급 유형",
-        "description": "<p>고정식 가상계좌 발급 유형</p>\n<p>pgAccountId, accountNumber 유형 중 한 개의 필드만 입력합니다.</p>\n",
+        "description": "고정식 가상계좌 발급 유형\n\npgAccountId, accountNumber 유형 중 한 개의 필드만 입력합니다.",
         "type": "object",
         "properties": {
           "pgAccountId": {
             "type": "string",
             "title": "Account ID 고정식 가상계좌",
-            "description": "<p>고객사가 가상계좌번호를 직접 관리하지 않고 PG사가 pgAccountId에 매핑되는 가상계좌번호를 내려주는 방식입니다.\n동일한 pgAccountId로 가상계좌 발급 요청시에는 항상 같은 가상계좌번호가 내려옵니다.</p>\n"
+            "description": "고객사가 가상계좌번호를 직접 관리하지 않고 PG사가 pgAccountId에 매핑되는 가상계좌번호를 내려주는 방식입니다.\n동일한 pgAccountId로 가상계좌 발급 요청시에는 항상 같은 가상계좌번호가 내려옵니다."
           },
           "accountNumber": {
             "type": "string",
             "title": "Account Number 고정식 가상계좌",
-            "description": "<p>PG사가 일정 개수만큼의 가상계좌번호를 발급하여 고객사에게 미리 전달하고 고객사가 그 중 하나를 선택하여 사용하는 방식입니다.</p>\n"
+            "description": "PG사가 일정 개수만큼의 가상계좌번호를 발급하여 고객사에게 미리 전달하고 고객사가 그 중 하나를 선택하여 사용하는 방식입니다."
           }
         },
         "x-portone-title": "고정식 가상계좌 발급 유형",
-        "x-portone-description": "<p>pgAccountId, accountNumber 유형 중 한 개의 필드만 입력합니다.</p>\n"
+        "x-portone-description": "pgAccountId, accountNumber 유형 중 한 개의 필드만 입력합니다."
       },
       "InstantPaymentMethodInputVirtualAccountOptionType": {
         "title": "가상계좌 발급 유형",
-        "description": "<p>가상계좌 발급 유형</p>\n",
+        "description": "가상계좌 발급 유형",
         "type": "string",
         "enum": [
           "NORMAL",
@@ -29573,7 +29579,7 @@
         "x-portone-enum": {
           "NORMAL": {
             "title": "회전식 가상계좌",
-            "description": "<p>일반적으로 사용되는 방식이며 PG사에서 직접 채번한 가상계좌번호를 사용합니다.</p>\n"
+            "description": "일반적으로 사용되는 방식이며 PG사에서 직접 채번한 가상계좌번호를 사용합니다."
           },
           "FIXED": {
             "title": "고정식 가상계좌"
@@ -29582,7 +29588,7 @@
       },
       "InstantPaymentSummary": {
         "title": "수기 결제가 완료된 결제 건 요약 정보",
-        "description": "<p>수기 결제가 완료된 결제 건 요약 정보</p>\n",
+        "description": "수기 결제가 완료된 결제 건 요약 정보",
         "type": "object",
         "required": [
           "pgTxId",
@@ -29603,7 +29609,7 @@
       },
       "InvalidRequestError": {
         "title": "요청된 입력 정보가 유효하지 않은 경우",
-        "description": "<p>요청된 입력 정보가 유효하지 않은 경우</p>\n<p>허가되지 않은 값, 올바르지 않은 형식의 요청 등이 모두 해당됩니다.</p>\n",
+        "description": "요청된 입력 정보가 유효하지 않은 경우\n\n허가되지 않은 값, 올바르지 않은 형식의 요청 등이 모두 해당됩니다.",
         "type": "object",
         "required": [
           "type"
@@ -29617,7 +29623,7 @@
           }
         },
         "x-portone-title": "요청된 입력 정보가 유효하지 않은 경우",
-        "x-portone-description": "<p>허가되지 않은 값, 올바르지 않은 형식의 요청 등이 모두 해당됩니다.</p>\n",
+        "x-portone-description": "허가되지 않은 값, 올바르지 않은 형식의 요청 등이 모두 해당됩니다.",
         "x-portone-status-code": 400
       },
       "IssueB2bTaxInvoiceError": {
@@ -29656,7 +29662,7 @@
       },
       "IssueB2bTaxInvoiceRequestBody": {
         "title": "세금계산서 발행 정보",
-        "description": "<p>세금계산서 발행 정보</p>\n",
+        "description": "세금계산서 발행 정보",
         "type": "object",
         "required": [
           "brn",
@@ -29674,7 +29680,7 @@
           "documentKeyType": {
             "$ref": "#/components/schemas/B2bTaxInvoiceDocumentKeyType",
             "title": "문서 번호 유형",
-            "description": "<p>기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.</p>\n"
+            "description": "기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다."
           },
           "memo": {
             "type": "string",
@@ -29689,7 +29695,7 @@
       },
       "IssueBillingKeyBody": {
         "title": "빌링키 발급 요청 양식",
-        "description": "<p>빌링키 발급 요청 양식</p>\n",
+        "description": "빌링키 발급 요청 양식",
         "type": "object",
         "required": [
           "method"
@@ -29698,7 +29704,7 @@
           "storeId": {
             "type": "string",
             "title": "상점 아이디",
-            "description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다."
           },
           "method": {
             "$ref": "#/components/schemas/InstantBillingKeyPaymentMethodInput",
@@ -29707,12 +29713,12 @@
           "channelKey": {
             "type": "string",
             "title": "채널 키",
-            "description": "<p>채널 키 또는 채널 그룹 ID 필수</p>\n"
+            "description": "채널 키 또는 채널 그룹 ID 필수"
           },
           "channelGroupId": {
             "type": "string",
             "title": "채널 그룹 ID",
-            "description": "<p>채널 키 또는 채널 그룹 ID 필수</p>\n"
+            "description": "채널 키 또는 채널 그룹 ID 필수"
           },
           "customer": {
             "$ref": "#/components/schemas/CustomerInput",
@@ -29732,7 +29738,7 @@
               "type": "string"
             },
             "title": "웹훅 주소",
-            "description": "<p>빌링키 발급 시 요청을 받을 웹훅 주소입니다.\n상점에 설정되어 있는 값보다 우선적으로 적용됩니다.\n입력된 값이 없을 경우에는 빈 배열로 해석됩니다.</p>\n"
+            "description": "빌링키 발급 시 요청을 받을 웹훅 주소입니다.\n상점에 설정되어 있는 값보다 우선적으로 적용됩니다.\n입력된 값이 없을 경우에는 빈 배열로 해석됩니다."
           }
         },
         "x-portone-title": "빌링키 발급 요청 양식"
@@ -29773,7 +29779,7 @@
       },
       "IssueBillingKeyResponse": {
         "title": "빌링키 발급 성공 응답",
-        "description": "<p>빌링키 발급 성공 응답</p>\n",
+        "description": "빌링키 발급 성공 응답",
         "type": "object",
         "required": [
           "billingKeyInfo"
@@ -29795,7 +29801,7 @@
       },
       "IssueCashReceiptBody": {
         "title": "현금영수증 발급 요청 양식",
-        "description": "<p>현금영수증 발급 요청 양식</p>\n",
+        "description": "현금영수증 발급 요청 양식",
         "type": "object",
         "required": [
           "paymentId",
@@ -29810,12 +29816,12 @@
           "storeId": {
             "type": "string",
             "title": "상점 아이디",
-            "description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다."
           },
           "paymentId": {
             "type": "string",
             "title": "결제 건 아이디",
-            "description": "<p>외부 결제 건에 대한 수동 발급의 경우, 아이디를 직접 채번하여 입력합니다.</p>\n"
+            "description": "외부 결제 건에 대한 수동 발급의 경우, 아이디를 직접 채번하여 입력합니다."
           },
           "channelKey": {
             "type": "string",
@@ -29855,7 +29861,7 @@
       },
       "IssueCashReceiptCustomerInput": {
         "title": "현금영수증 발급 시 고객 관련 입력 정보",
-        "description": "<p>현금영수증 발급 시 고객 관련 입력 정보</p>\n",
+        "description": "현금영수증 발급 시 고객 관련 입력 정보",
         "type": "object",
         "required": [
           "identityNumber"
@@ -29916,7 +29922,7 @@
       },
       "IssueCashReceiptResponse": {
         "title": "현금 영수증 발급 성공 응답",
-        "description": "<p>현금 영수증 발급 성공 응답</p>\n",
+        "description": "현금 영수증 발급 성공 응답",
         "type": "object",
         "required": [
           "cashReceipt"
@@ -29930,7 +29936,7 @@
       },
       "IssueFailedCashReceipt": {
         "title": "발급 실패",
-        "description": "<p>발급 실패</p>\n",
+        "description": "발급 실패",
         "type": "object",
         "required": [
           "status",
@@ -29974,7 +29980,7 @@
       },
       "IssuedBillingKeyInfo": {
         "title": "빌링키 발급 완료 상태 건",
-        "description": "<p>빌링키 발급 완료 상태 건</p>\n",
+        "description": "빌링키 발급 완료 상태 건",
         "type": "object",
         "required": [
           "status",
@@ -30008,7 +30014,7 @@
             "items": {
               "$ref": "#/components/schemas/BillingKeyPaymentMethod"
             },
-            "description": "<p>추후 슈퍼빌링키 기능 제공 시 여러 결제수단 정보가 담길 수 있습니다.</p>\n"
+            "description": "추후 슈퍼빌링키 기능 제공 시 여러 결제수단 정보가 담길 수 있습니다."
           },
           "channels": {
             "title": "빌링키 발급 시 사용된 채널",
@@ -30016,7 +30022,7 @@
             "items": {
               "$ref": "#/components/schemas/SelectedChannel"
             },
-            "description": "<p>추후 슈퍼빌링키 기능 제공 시 여러 채널 정보가 담길 수 있습니다.</p>\n"
+            "description": "추후 슈퍼빌링키 기능 제공 시 여러 채널 정보가 담길 수 있습니다."
           },
           "customer": {
             "$ref": "#/components/schemas/Customer",
@@ -30054,14 +30060,14 @@
             "items": {
               "$ref": "#/components/schemas/PgBillingKeyIssueResponse"
             },
-            "description": "<p>슈퍼빌링키의 경우, 빌링키 발급이 성공하더라도 일부 채널에 대한 빌링키 발급은 실패할 수 있습니다.</p>\n"
+            "description": "슈퍼빌링키의 경우, 빌링키 발급이 성공하더라도 일부 채널에 대한 빌링키 발급은 실패할 수 있습니다."
           }
         },
         "x-portone-title": "빌링키 발급 완료 상태 건"
       },
       "IssuedCashReceipt": {
         "title": "발급 완료",
-        "description": "<p>발급 완료</p>\n",
+        "description": "발급 완료",
         "type": "object",
         "required": [
           "status",
@@ -30150,7 +30156,7 @@
       },
       "IssuedPaymentCashReceipt": {
         "title": "발급 완료된 현금영수증",
-        "description": "<p>발급 완료된 현금영수증</p>\n",
+        "description": "발급 완료된 현금영수증",
         "type": "object",
         "required": [
           "status",
@@ -30204,7 +30210,7 @@
       },
       "IssuedPgBillingKeyIssueResponse": {
         "title": "빌링키 발급 성공 채널 응답",
-        "description": "<p>빌링키 발급 성공 채널 응답</p>\n",
+        "description": "빌링키 발급 성공 채널 응답",
         "type": "object",
         "required": [
           "type",
@@ -30217,7 +30223,7 @@
           "channel": {
             "$ref": "#/components/schemas/SelectedChannel",
             "title": "채널",
-            "description": "<p>빌링키 발급을 시도한 채널입니다.</p>\n"
+            "description": "빌링키 발급을 시도한 채널입니다."
           },
           "pgTxId": {
             "type": "string",
@@ -30226,14 +30232,14 @@
           "method": {
             "$ref": "#/components/schemas/BillingKeyPaymentMethod",
             "title": "빌링키 결제수단 상세 정보",
-            "description": "<p>채널에 대응되는 PG사에서 응답한 빌링키 발급 수단 정보입니다.</p>\n"
+            "description": "채널에 대응되는 PG사에서 응답한 빌링키 발급 수단 정보입니다."
           }
         },
         "x-portone-title": "빌링키 발급 성공 채널 응답"
       },
       "LoginViaApiKeyBody": {
         "title": "API key 로그인을 위한 입력 정보",
-        "description": "<p>API key 로그인을 위한 입력 정보</p>\n",
+        "description": "API key 로그인을 위한 입력 정보",
         "type": "object",
         "required": [
           "apiKey"
@@ -30266,7 +30272,7 @@
       },
       "LoginViaApiKeyResponse": {
         "title": "API key 로그인 성공 응답",
-        "description": "<p>API key 로그인 성공 응답</p>\n",
+        "description": "API key 로그인 성공 응답",
         "type": "object",
         "required": [
           "accessToken",
@@ -30276,19 +30282,19 @@
           "accessToken": {
             "type": "string",
             "title": "인증에 사용하는 엑세스 토큰",
-            "description": "<p>하루의 유효기간을 가지고 있습니다.</p>\n"
+            "description": "하루의 유효기간을 가지고 있습니다."
           },
           "refreshToken": {
             "type": "string",
             "title": "토큰 재발급 및 유효기간 연장을 위해 사용하는 리프레시 토큰",
-            "description": "<p>일주일의 유효기간을 가지고 있으며, 리프레시 토큰을 통해 유효기간이 연장된 새로운 엑세스 토큰을 발급받을 수 있습니다.</p>\n"
+            "description": "일주일의 유효기간을 가지고 있으며, 리프레시 토큰을 통해 유효기간이 연장된 새로운 엑세스 토큰을 발급받을 수 있습니다."
           }
         },
         "x-portone-title": "API key 로그인 성공 응답"
       },
       "LoginViaApiSecretBody": {
         "title": "API Secret 로그인을 위한 입력 정보",
-        "description": "<p>API Secret 로그인을 위한 입력 정보</p>\n",
+        "description": "API Secret 로그인을 위한 입력 정보",
         "type": "object",
         "required": [
           "apiSecret"
@@ -30321,7 +30327,7 @@
       },
       "LoginViaApiSecretResponse": {
         "title": "API key 로그인 성공 응답",
-        "description": "<p>API key 로그인 성공 응답</p>\n",
+        "description": "API key 로그인 성공 응답",
         "type": "object",
         "required": [
           "accessToken",
@@ -30331,19 +30337,19 @@
           "accessToken": {
             "type": "string",
             "title": "인증에 사용하는 엑세스 토큰",
-            "description": "<p>하루의 유효기간을 가지고 있습니다.</p>\n"
+            "description": "하루의 유효기간을 가지고 있습니다."
           },
           "refreshToken": {
             "type": "string",
             "title": "토큰 재발급 및 유효기간 연장을 위해 사용하는 리프레시 토큰",
-            "description": "<p>일주일의 유효기간을 가지고 있으며, 리프레시 토큰을 통해 유효기간이 연장된 새로운 엑세스 토큰을 발급받을 수 있습니다.</p>\n"
+            "description": "일주일의 유효기간을 가지고 있으며, 리프레시 토큰을 통해 유효기간이 연장된 새로운 엑세스 토큰을 발급받을 수 있습니다."
           }
         },
         "x-portone-title": "API key 로그인 성공 응답"
       },
       "Merchant": {
         "title": "고객사 정보",
-        "description": "<p>고객사 정보</p>\n",
+        "description": "고객사 정보",
         "type": "object",
         "required": [
           "id",
@@ -30367,7 +30373,7 @@
       },
       "ModifyEscrowLogisticsBody": {
         "title": "에스크로 배송 정보 수정 입력 정보",
-        "description": "<p>에스크로 배송 정보 수정 입력 정보</p>\n",
+        "description": "에스크로 배송 정보 수정 입력 정보",
         "type": "object",
         "required": [
           "logistics"
@@ -30376,7 +30382,7 @@
           "storeId": {
             "type": "string",
             "title": "상점 아이디",
-            "description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다."
           },
           "sender": {
             "$ref": "#/components/schemas/PaymentEscrowSenderInput",
@@ -30393,7 +30399,7 @@
           "sendEmail": {
             "type": "boolean",
             "title": "이메일 알림 전송 여부",
-            "description": "<p>에스크로 구매 확정 시 이메일로 알림을 보낼지 여부입니다.</p>\n"
+            "description": "에스크로 구매 확정 시 이메일로 알림을 보낼지 여부입니다."
           },
           "products": {
             "title": "상품 정보",
@@ -30441,7 +30447,7 @@
       },
       "ModifyEscrowLogisticsResponse": {
         "title": "에스크로 배송 정보 수정 성공 응답",
-        "description": "<p>에스크로 배송 정보 수정 성공 응답</p>\n",
+        "description": "에스크로 배송 정보 수정 성공 응답",
         "type": "object",
         "required": [
           "invoiceNumber",
@@ -30468,7 +30474,7 @@
       },
       "MonthDay": {
         "title": "월 및 일자 정보",
-        "description": "<p>월 및 일자 정보</p>\n",
+        "description": "월 및 일자 정보",
         "type": "object",
         "required": [
           "month",
@@ -30488,7 +30494,7 @@
       },
       "OneLineAddress": {
         "title": "한 줄 형식 주소",
-        "description": "<p>한 줄 형식 주소</p>\n<p>한 줄 형식 주소만 존재합니다.</p>\n",
+        "description": "한 줄 형식 주소\n\n한 줄 형식 주소만 존재합니다.",
         "type": "object",
         "required": [
           "type",
@@ -30504,11 +30510,11 @@
           }
         },
         "x-portone-title": "한 줄 형식 주소",
-        "x-portone-description": "<p>한 줄 형식 주소만 존재합니다.</p>\n"
+        "x-portone-description": "한 줄 형식 주소만 존재합니다."
       },
       "PageInfo": {
         "title": "반환된 페이지 결과 정보",
-        "description": "<p>반환된 페이지 결과 정보</p>\n",
+        "description": "반환된 페이지 결과 정보",
         "type": "object",
         "required": [
           "number",
@@ -30536,7 +30542,7 @@
       },
       "PageInput": {
         "title": "다건 조회 API 에 사용되는 페이지 입력 정보",
-        "description": "<p>다건 조회 API 에 사용되는 페이지 입력 정보</p>\n",
+        "description": "다건 조회 API 에 사용되는 페이지 입력 정보",
         "type": "object",
         "properties": {
           "number": {
@@ -30554,7 +30560,7 @@
       },
       "PaidPayment": {
         "title": "결제 완료 상태 건",
-        "description": "<p>결제 완료 상태 건</p>\n",
+        "description": "결제 완료 상태 건",
         "type": "object",
         "required": [
           "status",
@@ -30585,7 +30591,7 @@
           "transactionId": {
             "type": "string",
             "title": "결제 건 포트원 채번 아이디",
-            "description": "<p>V1 결제 건의 경우 imp_uid에 해당합니다.</p>\n"
+            "description": "V1 결제 건의 경우 imp_uid에 해당합니다."
           },
           "merchantId": {
             "type": "string",
@@ -30614,12 +30620,12 @@
           "scheduleId": {
             "type": "string",
             "title": "결제 예약 건 아이디",
-            "description": "<p>결제 예약을 이용한 경우에만 존재</p>\n"
+            "description": "결제 예약을 이용한 경우에만 존재"
           },
           "billingKey": {
             "type": "string",
             "title": "결제 시 사용된 빌링키",
-            "description": "<p>빌링키 결제인 경우에만 존재</p>\n"
+            "description": "빌링키 결제인 경우에만 존재"
           },
           "webhooks": {
             "title": "웹훅 발송 내역",
@@ -30670,7 +30676,7 @@
           "escrow": {
             "$ref": "#/components/schemas/PaymentEscrow",
             "title": "에스크로 결제 정보",
-            "description": "<p>에스크로 결제인 경우 존재합니다.</p>\n"
+            "description": "에스크로 결제인 경우 존재합니다."
           },
           "products": {
             "title": "상품 정보",
@@ -30718,7 +30724,7 @@
       },
       "PartialCancelledPayment": {
         "title": "결제 부분 취소 상태 건",
-        "description": "<p>결제 부분 취소 상태 건</p>\n",
+        "description": "결제 부분 취소 상태 건",
         "type": "object",
         "required": [
           "status",
@@ -30750,7 +30756,7 @@
           "transactionId": {
             "type": "string",
             "title": "결제 건 포트원 채번 아이디",
-            "description": "<p>V1 결제 건의 경우 imp_uid에 해당합니다.</p>\n"
+            "description": "V1 결제 건의 경우 imp_uid에 해당합니다."
           },
           "merchantId": {
             "type": "string",
@@ -30779,12 +30785,12 @@
           "scheduleId": {
             "type": "string",
             "title": "결제 예약 건 아이디",
-            "description": "<p>결제 예약을 이용한 경우에만 존재</p>\n"
+            "description": "결제 예약을 이용한 경우에만 존재"
           },
           "billingKey": {
             "type": "string",
             "title": "결제 시 사용된 빌링키",
-            "description": "<p>빌링키 결제인 경우에만 존재</p>\n"
+            "description": "빌링키 결제인 경우에만 존재"
           },
           "webhooks": {
             "title": "웹훅 발송 내역",
@@ -30835,7 +30841,7 @@
           "escrow": {
             "$ref": "#/components/schemas/PaymentEscrow",
             "title": "에스크로 결제 정보",
-            "description": "<p>에스크로 결제인 경우 존재합니다.</p>\n"
+            "description": "에스크로 결제인 경우 존재합니다."
           },
           "products": {
             "title": "상품 정보",
@@ -30937,7 +30943,7 @@
       },
       "PayInstantlyResponse": {
         "title": "수기 결제 성공 응답",
-        "description": "<p>수기 결제 성공 응답</p>\n",
+        "description": "수기 결제 성공 응답",
         "type": "object",
         "required": [
           "payment"
@@ -30952,7 +30958,7 @@
       },
       "PayPendingPayment": {
         "title": "결제 완료 대기 상태 건",
-        "description": "<p>결제 완료 대기 상태 건</p>\n",
+        "description": "결제 완료 대기 상태 건",
         "type": "object",
         "required": [
           "status",
@@ -31005,12 +31011,12 @@
           "scheduleId": {
             "type": "string",
             "title": "결제 예약 건 아이디",
-            "description": "<p>결제 예약을 이용한 경우에만 존재</p>\n"
+            "description": "결제 예약을 이용한 경우에만 존재"
           },
           "billingKey": {
             "type": "string",
             "title": "결제 시 사용된 빌링키",
-            "description": "<p>빌링키 결제인 경우에만 존재</p>\n"
+            "description": "빌링키 결제인 경우에만 존재"
           },
           "webhooks": {
             "title": "웹훅 발송 내역",
@@ -31061,7 +31067,7 @@
           "escrow": {
             "$ref": "#/components/schemas/PaymentEscrow",
             "title": "에스크로 결제 정보",
-            "description": "<p>에스크로 결제인 경우 존재합니다.</p>\n"
+            "description": "에스크로 결제인 경우 존재합니다."
           },
           "products": {
             "title": "상품 정보",
@@ -31146,7 +31152,7 @@
       },
       "PayWithBillingKeyResponse": {
         "title": "빌링키 결제 성공 응답",
-        "description": "<p>빌링키 결제 성공 응답</p>\n",
+        "description": "빌링키 결제 성공 응답",
         "type": "object",
         "required": [
           "payment"
@@ -31161,7 +31167,7 @@
       },
       "Payment": {
         "title": "결제 건",
-        "description": "<p>결제 건</p>\n",
+        "description": "결제 건",
         "oneOf": [
           {
             "$ref": "#/components/schemas/CancelledPayment"
@@ -31224,7 +31230,7 @@
       },
       "PaymentAlreadyCancelledError": {
         "title": "결제가 이미 취소된 경우",
-        "description": "<p>결제가 이미 취소된 경우</p>\n",
+        "description": "결제가 이미 취소된 경우",
         "type": "object",
         "required": [
           "type"
@@ -31242,7 +31248,7 @@
       },
       "PaymentAmount": {
         "title": "결제 금액 세부 정보",
-        "description": "<p>결제 금액 세부 정보</p>\n",
+        "description": "결제 금액 세부 정보",
         "type": "object",
         "required": [
           "total",
@@ -31277,7 +31283,7 @@
             "type": "integer",
             "format": "int64",
             "title": "할인금액",
-            "description": "<p>카드사 프로모션, 포트원 프로모션, 적립형 포인트 결제, 쿠폰 할인 등을 포함합니다.</p>\n"
+            "description": "카드사 프로모션, 포트원 프로모션, 적립형 포인트 결제, 쿠폰 할인 등을 포함합니다."
           },
           "paid": {
             "type": "integer",
@@ -31299,7 +31305,7 @@
       },
       "PaymentAmountInput": {
         "title": "금액 세부 입력 정보",
-        "description": "<p>금액 세부 입력 정보</p>\n",
+        "description": "금액 세부 입력 정보",
         "type": "object",
         "required": [
           "total"
@@ -31319,14 +31325,14 @@
             "type": "integer",
             "format": "int64",
             "title": "부가세액",
-            "description": "<p>고객사에서 직접 계산이 필요한 경우 입력합니다.\n입력하지 않으면 면세 금액을 제외한 금액의 1/11 로 자동 계산됩니다.</p>\n"
+            "description": "고객사에서 직접 계산이 필요한 경우 입력합니다.\n입력하지 않으면 면세 금액을 제외한 금액의 1/11 로 자동 계산됩니다."
           }
         },
         "x-portone-title": "금액 세부 입력 정보"
       },
       "PaymentCancellation": {
         "title": "결제 취소 내역",
-        "description": "<p>결제 취소 내역</p>\n",
+        "description": "결제 취소 내역",
         "oneOf": [
           {
             "$ref": "#/components/schemas/FailedPaymentCancellation"
@@ -31361,7 +31367,7 @@
       },
       "PaymentCashReceipt": {
         "title": "결제 건 내 현금영수증 정보",
-        "description": "<p>결제 건 내 현금영수증 정보</p>\n",
+        "description": "결제 건 내 현금영수증 정보",
         "oneOf": [
           {
             "$ref": "#/components/schemas/CancelledPaymentCashReceipt"
@@ -31389,7 +31395,7 @@
       },
       "PaymentCashReceiptStatus": {
         "title": "결제건 내 현금영수증 상태",
-        "description": "<p>결제건 내 현금영수증 상태</p>\n",
+        "description": "결제건 내 현금영수증 상태",
         "type": "string",
         "enum": [
           "ISSUED",
@@ -31403,7 +31409,7 @@
       },
       "PaymentClientType": {
         "title": "결제가 발생한 클라이언트 환경",
-        "description": "<p>결제가 발생한 클라이언트 환경</p>\n",
+        "description": "결제가 발생한 클라이언트 환경",
         "type": "string",
         "enum": [
           "SDK_MOBILE",
@@ -31419,7 +31425,7 @@
       },
       "PaymentEscrow": {
         "title": "에스크로 정보",
-        "description": "<p>에스크로 정보</p>\n<p>V1 결제 건의 경우 타입이 REGISTERED 로 고정됩니다.</p>\n",
+        "description": "에스크로 정보\n\nV1 결제 건의 경우 타입이 REGISTERED 로 고정됩니다.",
         "oneOf": [
           {
             "$ref": "#/components/schemas/BeforeRegisteredPaymentEscrow"
@@ -31456,7 +31462,7 @@
           }
         },
         "x-portone-title": "에스크로 정보",
-        "x-portone-description": "<p>V1 결제 건의 경우 타입이 REGISTERED 로 고정됩니다.</p>\n",
+        "x-portone-description": "V1 결제 건의 경우 타입이 REGISTERED 로 고정됩니다.",
         "x-portone-discriminator": {
           "CONFIRMED": {
             "title": "구매 확정"
@@ -31483,7 +31489,7 @@
       },
       "PaymentEscrowReceiverInput": {
         "title": "에스크로 수취인 정보",
-        "description": "<p>에스크로 수취인 정보</p>\n",
+        "description": "에스크로 수취인 정보",
         "type": "object",
         "properties": {
           "name": {
@@ -31507,7 +31513,7 @@
       },
       "PaymentEscrowSenderInput": {
         "title": "에스크로 발송자 정보",
-        "description": "<p>에스크로 발송자 정보</p>\n",
+        "description": "에스크로 발송자 정보",
         "type": "object",
         "properties": {
           "name": {
@@ -31535,7 +31541,7 @@
       },
       "PaymentFilterInput": {
         "title": "결제 건 다건 조회를 위한 입력 정보",
-        "description": "<p>결제 건 다건 조회를 위한 입력 정보</p>\n",
+        "description": "결제 건 다건 조회를 위한 입력 정보",
         "type": "object",
         "properties": {
           "merchantId": {
@@ -31545,7 +31551,7 @@
           "storeId": {
             "type": "string",
             "title": "상점 아이디",
-            "description": "<p>Merchant 사용자만 사용가능하며, 지정되지 않은 경우 고객사 전체 결제 건을 조회합니다.</p>\n"
+            "description": "Merchant 사용자만 사용가능하며, 지정되지 않은 경우 고객사 전체 결제 건을 조회합니다."
           },
           "timestampType": {
             "$ref": "#/components/schemas/PaymentTimestampType",
@@ -31555,13 +31561,13 @@
             "type": "string",
             "format": "date-time",
             "title": "결제 요청/상태 승인 시점 범위의 시작",
-            "description": "<p>값을 입력하지 않으면 end의 90일 전으로 설정됩니다.</p>\n"
+            "description": "값을 입력하지 않으면 end의 90일 전으로 설정됩니다."
           },
           "until": {
             "type": "string",
             "format": "date-time",
             "title": "결제 요청/상태 승인 시점 범위의 끝",
-            "description": "<p>값을 입력하지 않으면 현재 시점으로 설정됩니다.</p>\n"
+            "description": "값을 입력하지 않으면 현재 시점으로 설정됩니다."
           },
           "status": {
             "title": "결제 상태 리스트",
@@ -31569,7 +31575,7 @@
             "items": {
               "$ref": "#/components/schemas/PaymentStatus"
             },
-            "description": "<p>값을 입력하지 않으면 결제상태 필터링이 적용되지 않습니다.</p>\n"
+            "description": "값을 입력하지 않으면 결제상태 필터링이 적용되지 않습니다."
           },
           "methods": {
             "type": "array",
@@ -31577,7 +31583,7 @@
               "$ref": "#/components/schemas/PaymentMethodType"
             },
             "title": "결제수단 리스트",
-            "description": "<p>값을 입력하지 않으면 결제수단 필터링이 적용되지 않습니다.</p>\n"
+            "description": "값을 입력하지 않으면 결제수단 필터링이 적용되지 않습니다."
           },
           "pgProvider": {
             "title": "PG사 리스트",
@@ -31585,7 +31591,7 @@
             "items": {
               "$ref": "#/components/schemas/PgProvider"
             },
-            "description": "<p>값을 입력하지 않으면 결제대행사 필터링이 적용되지 않습니다.</p>\n"
+            "description": "값을 입력하지 않으면 결제대행사 필터링이 적용되지 않습니다."
           },
           "isTest": {
             "type": "boolean",
@@ -31671,7 +31677,7 @@
       },
       "PaymentFilterInputEscrowStatus": {
         "title": "에스크로 상태",
-        "description": "<p>에스크로 상태</p>\n",
+        "description": "에스크로 상태",
         "type": "string",
         "enum": [
           "REGISTERED",
@@ -31693,7 +31699,7 @@
       },
       "PaymentInstallment": {
         "title": "할부 정보",
-        "description": "<p>할부 정보</p>\n",
+        "description": "할부 정보",
         "type": "object",
         "required": [
           "month",
@@ -31714,7 +31720,7 @@
       },
       "PaymentLogistics": {
         "title": "배송정보",
-        "description": "<p>배송정보</p>\n",
+        "description": "배송정보",
         "type": "object",
         "required": [
           "company",
@@ -31749,7 +31755,7 @@
       },
       "PaymentLogisticsCompany": {
         "title": "물류 회사",
-        "description": "<p>물류 회사</p>\n",
+        "description": "물류 회사",
         "type": "string",
         "enum": [
           "LOTTE",
@@ -31879,7 +31885,7 @@
       },
       "PaymentMethod": {
         "title": "결제수단 정보",
-        "description": "<p>결제수단 정보</p>\n",
+        "description": "결제수단 정보",
         "oneOf": [
           {
             "$ref": "#/components/schemas/PaymentMethodCard"
@@ -31935,7 +31941,7 @@
       },
       "PaymentMethodCard": {
         "title": "결제수단 카드 정보",
-        "description": "<p>결제수단 카드 정보</p>\n",
+        "description": "결제수단 카드 정보",
         "type": "object",
         "required": [
           "type"
@@ -31965,7 +31971,7 @@
       },
       "PaymentMethodEasyPay": {
         "title": "간편 결제 상세 정보",
-        "description": "<p>간편 결제 상세 정보</p>\n",
+        "description": "간편 결제 상세 정보",
         "type": "object",
         "required": [
           "type"
@@ -31987,7 +31993,7 @@
       },
       "PaymentMethodEasyPayMethod": {
         "title": "간편 결제 수단",
-        "description": "<p>간편 결제 수단</p>\n",
+        "description": "간편 결제 수단",
         "oneOf": [
           {
             "$ref": "#/components/schemas/PaymentMethodCard"
@@ -32022,7 +32028,7 @@
       },
       "PaymentMethodEasyPayMethodCharge": {
         "title": "충전식 포인트 결제 정보",
-        "description": "<p>충전식 포인트 결제 정보</p>\n",
+        "description": "충전식 포인트 결제 정보",
         "type": "object",
         "required": [
           "type"
@@ -32040,7 +32046,7 @@
       },
       "PaymentMethodGiftCertificate": {
         "title": "상품권 상세 정보",
-        "description": "<p>상품권 상세 정보</p>\n",
+        "description": "상품권 상세 정보",
         "type": "object",
         "required": [
           "type",
@@ -32063,7 +32069,7 @@
       },
       "PaymentMethodGiftCertificateType": {
         "title": "상품권 종류",
-        "description": "<p>상품권 종류</p>\n",
+        "description": "상품권 종류",
         "type": "string",
         "enum": [
           "BOOKNLIFE",
@@ -32083,7 +32089,7 @@
       },
       "PaymentMethodMobile": {
         "title": "모바일 상세 정보",
-        "description": "<p>모바일 상세 정보</p>\n",
+        "description": "모바일 상세 정보",
         "type": "object",
         "required": [
           "type"
@@ -32101,7 +32107,7 @@
       },
       "PaymentMethodTransfer": {
         "title": "계좌 이체 상세 정보",
-        "description": "<p>계좌 이체 상세 정보</p>\n",
+        "description": "계좌 이체 상세 정보",
         "type": "object",
         "required": [
           "type"
@@ -32139,7 +32145,7 @@
       },
       "PaymentMethodVirtualAccount": {
         "title": "가상계좌 상세 정보",
-        "description": "<p>가상계좌 상세 정보</p>\n",
+        "description": "가상계좌 상세 정보",
         "type": "object",
         "required": [
           "type",
@@ -32188,7 +32194,7 @@
       },
       "PaymentMethodVirtualAccountRefundStatus": {
         "title": "가상계좌 환불 상태",
-        "description": "<p>가상계좌 환불 상태</p>\n",
+        "description": "가상계좌 환불 상태",
         "type": "string",
         "enum": [
           "PENDING",
@@ -32214,7 +32220,7 @@
       },
       "PaymentMethodVirtualAccountType": {
         "title": "가상계좌 유형",
-        "description": "<p>가상계좌 유형</p>\n",
+        "description": "가상계좌 유형",
         "type": "string",
         "enum": [
           "FIXED",
@@ -32232,7 +32238,7 @@
       },
       "PaymentNotFoundError": {
         "title": "결제 건이 존재하지 않는 경우",
-        "description": "<p>결제 건이 존재하지 않는 경우</p>\n",
+        "description": "결제 건이 존재하지 않는 경우",
         "type": "object",
         "required": [
           "type"
@@ -32250,7 +32256,7 @@
       },
       "PaymentNotPaidError": {
         "title": "결제가 완료되지 않은 경우",
-        "description": "<p>결제가 완료되지 않은 경우</p>\n",
+        "description": "결제가 완료되지 않은 경우",
         "type": "object",
         "required": [
           "type"
@@ -32268,7 +32274,7 @@
       },
       "PaymentNotWaitingForDepositError": {
         "title": "결제 건이 입금 대기 상태가 아닌 경우",
-        "description": "<p>결제 건이 입금 대기 상태가 아닌 경우</p>\n",
+        "description": "결제 건이 입금 대기 상태가 아닌 경우",
         "type": "object",
         "required": [
           "type"
@@ -32286,7 +32292,7 @@
       },
       "PaymentProduct": {
         "title": "상품 정보",
-        "description": "<p>상품 정보</p>\n",
+        "description": "상품 정보",
         "type": "object",
         "required": [
           "id",
@@ -32298,7 +32304,7 @@
           "id": {
             "type": "string",
             "title": "상품 고유 식별자",
-            "description": "<p>고객사가 직접 부여한 식별자입니다.</p>\n"
+            "description": "고객사가 직접 부여한 식별자입니다."
           },
           "name": {
             "type": "string",
@@ -32307,7 +32313,7 @@
           "tag": {
             "type": "string",
             "title": "상품 태그",
-            "description": "<p>카테고리 등으로 활용될 수 있습니다.</p>\n"
+            "description": "카테고리 등으로 활용될 수 있습니다."
           },
           "code": {
             "type": "string",
@@ -32328,7 +32334,7 @@
       },
       "PaymentProductType": {
         "title": "상품 유형",
-        "description": "<p>상품 유형</p>\n",
+        "description": "상품 유형",
         "type": "string",
         "enum": [
           "PHYSICAL",
@@ -32341,7 +32347,7 @@
           },
           "DIGITAL": {
             "title": "디지털 상품",
-            "description": "<p>서비스, 온라인 상품 등 실물이 존재하지 않는 무형의 상품을 의미합니다.</p>\n"
+            "description": "서비스, 온라인 상품 등 실물이 존재하지 않는 무형의 상품을 의미합니다."
           }
         }
       },
@@ -32379,7 +32385,7 @@
       },
       "PaymentReconciliationActionType": {
         "title": "거래상태",
-        "description": "<p>거래상태</p>\n",
+        "description": "거래상태",
         "type": "string",
         "enum": [
           "APPROVAL",
@@ -32405,7 +32411,7 @@
       },
       "PaymentReconciliationColumn": {
         "title": "거래대사 엑셀파일 필드",
-        "description": "<p>거래대사 엑셀파일 필드</p>\n<p>중복으로 필드를 선택 가능합니다</p>\n",
+        "description": "거래대사 엑셀파일 필드\n\n중복으로 필드를 선택 가능합니다",
         "type": "string",
         "enum": [
           "RECONCILIATION_STATUS",
@@ -32446,7 +32452,7 @@
           "SETTLEMENT_DATE"
         ],
         "x-portone-title": "거래대사 엑셀파일 필드",
-        "x-portone-description": "<p>중복으로 필드를 선택 가능합니다</p>\n",
+        "x-portone-description": "중복으로 필드를 선택 가능합니다",
         "x-portone-enum": {
           "SETTLEMENT_CURRENCY": {
             "title": "정산 통화 필드"
@@ -32560,7 +32566,7 @@
       },
       "PaymentReconciliationExcelFileFilterInput": {
         "title": "거래대사 엑셀 파일 다운로드 필터 목록",
-        "description": "<p>거래대사 엑셀 파일 다운로드 필터 목록</p>\n<p>필드 중복으로 적용됩니다.</p>\n",
+        "description": "거래대사 엑셀 파일 다운로드 필터 목록\n\n필드 중복으로 적용됩니다.",
         "type": "object",
         "properties": {
           "storeIds": {
@@ -32569,7 +32575,7 @@
               "type": "string"
             },
             "title": "거래대사 하위 가맹점 아이디 필터",
-            "description": "<p>storeId가 존재하지 않는 건을 검색하고 싶은 경우 빈 문자열을 포함시켜주세요.</p>\n"
+            "description": "storeId가 존재하지 않는 건을 검색하고 싶은 경우 빈 문자열을 포함시켜주세요."
           },
           "pgSpecifiers": {
             "title": "거래대사 결제사(PG) 식별자 필터",
@@ -32615,7 +32621,7 @@
           }
         },
         "x-portone-title": "거래대사 엑셀 파일 다운로드 필터 목록",
-        "x-portone-description": "<p>필드 중복으로 적용됩니다.</p>\n"
+        "x-portone-description": "필드 중복으로 적용됩니다."
       },
       "PaymentReconciliationIncomparable": {
         "title": "PaymentReconciliationIncomparable",
@@ -33079,7 +33085,7 @@
       },
       "PaymentReconciliationNotMatchedReason": {
         "title": "거래대사 매치 실패 사유",
-        "description": "<p>거래대사 매치 실패 사유</p>\n",
+        "description": "거래대사 매치 실패 사유",
         "type": "string",
         "enum": [
           "PAYMENT_AMOUNT_NOT_MATCHED",
@@ -33113,7 +33119,7 @@
       },
       "PaymentReconciliationOrderInput": {
         "title": "거래대사 거래 건 별 조회 정렬 조건",
-        "description": "<p>거래대사 거래 건 별 조회 정렬 조건</p>\n<p>필드중 하나만 명시하여야 합니다</p>\n",
+        "description": "거래대사 거래 건 별 조회 정렬 조건\n\n필드중 하나만 명시하여야 합니다",
         "type": "object",
         "properties": {
           "settlementDate": {
@@ -33138,11 +33144,11 @@
           }
         },
         "x-portone-title": "거래대사 거래 건 별 조회 정렬 조건",
-        "x-portone-description": "<p>필드중 하나만 명시하여야 합니다</p>\n"
+        "x-portone-description": "필드중 하나만 명시하여야 합니다"
       },
       "PaymentReconciliationSearchConditionInput": {
         "title": "거래대사 거래내역 검색용 필드",
-        "description": "<p>거래대사 거래내역 검색용 필드</p>\n<p>각 필드 중 하나만 적용 됩니다.</p>\n",
+        "description": "거래대사 거래내역 검색용 필드\n\n각 필드 중 하나만 적용 됩니다.",
         "type": "object",
         "properties": {
           "paymentId": {
@@ -33163,11 +33169,11 @@
           }
         },
         "x-portone-title": "거래대사 거래내역 검색용 필드",
-        "x-portone-description": "<p>각 필드 중 하나만 적용 됩니다.</p>\n"
+        "x-portone-description": "각 필드 중 하나만 적용 됩니다."
       },
       "PaymentReconciliationSettlementSummary": {
         "title": "거래대사 정산내역 일별 요약",
-        "description": "<p>거래대사 정산내역 일별 요약</p>\n",
+        "description": "거래대사 정산내역 일별 요약",
         "type": "object",
         "required": [
           "date",
@@ -33178,9 +33184,9 @@
         ],
         "properties": {
           "date": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "정산일"
           },
           "settlementCurrency": {
@@ -33257,7 +33263,7 @@
       },
       "PaymentReconciliationSettlementSummaryColumn": {
         "title": "거래대사 정산 요약 내역 엑셀파일 필드",
-        "description": "<p>거래대사 정산 요약 내역 엑셀파일 필드</p>\n",
+        "description": "거래대사 정산 요약 내역 엑셀파일 필드",
         "type": "string",
         "enum": [
           "SETTLEMENT_DATE",
@@ -33369,7 +33375,7 @@
       },
       "PaymentReconciliationSettlementSummaryExcelFileFilterInput": {
         "title": "거래대사 정산 요약 엑셀 파일 필터",
-        "description": "<p>거래대사 정산 요약 엑셀 파일 필터</p>\n<p>필드 중복으로 적용됩니다.</p>\n",
+        "description": "거래대사 정산 요약 엑셀 파일 필터\n\n필드 중복으로 적용됩니다.",
         "type": "object",
         "properties": {
           "pgSpecifiers": {
@@ -33385,15 +33391,15 @@
               "type": "string"
             },
             "title": "하위 상점 아이디 필터",
-            "description": "<p>storeId가 존재하지 않는 건을 검색하고 싶은 경우 빈 문자열을 포함시켜주세요.</p>\n"
+            "description": "storeId가 존재하지 않는 건을 검색하고 싶은 경우 빈 문자열을 포함시켜주세요."
           }
         },
         "x-portone-title": "거래대사 정산 요약 엑셀 파일 필터",
-        "x-portone-description": "<p>필드 중복으로 적용됩니다.</p>\n"
+        "x-portone-description": "필드 중복으로 적용됩니다."
       },
       "PaymentReconciliationSettlementSummaryFilterInput": {
         "title": "거래대사 정산 요약 내역 필터",
-        "description": "<p>거래대사 정산 요약 내역 필터</p>\n",
+        "description": "거래대사 정산 요약 내역 필터",
         "type": "object",
         "properties": {
           "pgSpecifiers": {
@@ -33431,7 +33437,7 @@
       },
       "PaymentReconciliationStatus": {
         "title": "결제 건의 대사 상태",
-        "description": "<p>결제 건의 대사 상태</p>\n",
+        "description": "결제 건의 대사 상태",
         "type": "string",
         "enum": [
           "MATCHED",
@@ -33457,7 +33463,7 @@
       },
       "PaymentReconciliationTransactionSummary": {
         "title": "거래대사 거래내역 일별 요약",
-        "description": "<p>거래대사 거래내역 일별 요약</p>\n",
+        "description": "거래대사 거래내역 일별 요약",
         "type": "object",
         "required": [
           "date",
@@ -33467,9 +33473,9 @@
         ],
         "properties": {
           "date": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "거래일"
           },
           "currency": {
@@ -33548,7 +33554,7 @@
       },
       "PaymentReconciliationTransactionSummaryColumn": {
         "title": "거래대사 정산 요약 내역 엑셀파일 필드",
-        "description": "<p>거래대사 정산 요약 내역 엑셀파일 필드</p>\n",
+        "description": "거래대사 정산 요약 내역 엑셀파일 필드",
         "type": "string",
         "enum": [
           "TRANSACTION_DATE",
@@ -33666,7 +33672,7 @@
       },
       "PaymentReconciliationTransactionSummaryExcelFilterInput": {
         "title": "거래대사 거래 요약 엑셀 파일 필터",
-        "description": "<p>거래대사 거래 요약 엑셀 파일 필터</p>\n<p>필드 중복으로 적용됩니다.</p>\n",
+        "description": "거래대사 거래 요약 엑셀 파일 필터\n\n필드 중복으로 적용됩니다.",
         "type": "object",
         "properties": {
           "reconciliationStatuses": {
@@ -33689,11 +33695,11 @@
               "type": "string"
             },
             "title": "하위 상점 아이디 필터",
-            "description": "<p>storeId가 존재하지 않는 건을 검색하고 싶은 경우 빈 문자열을 포함시켜주세요.</p>\n"
+            "description": "storeId가 존재하지 않는 건을 검색하고 싶은 경우 빈 문자열을 포함시켜주세요."
           }
         },
         "x-portone-title": "거래대사 거래 요약 엑셀 파일 필터",
-        "x-portone-description": "<p>필드 중복으로 적용됩니다.</p>\n"
+        "x-portone-description": "필드 중복으로 적용됩니다."
       },
       "PaymentReconciliationTransactionSummaryWithCursor": {
         "title": "PaymentReconciliationTransactionSummaryWithCursor",
@@ -33729,7 +33735,7 @@
       },
       "PaymentSchedule": {
         "title": "결제 예약 건",
-        "description": "<p>결제 예약 건</p>\n",
+        "description": "결제 예약 건",
         "oneOf": [
           {
             "$ref": "#/components/schemas/FailedPaymentSchedule"
@@ -33785,7 +33791,7 @@
       },
       "PaymentScheduleAlreadyExistsError": {
         "title": "결제 예약건이 이미 존재하는 경우",
-        "description": "<p>결제 예약건이 이미 존재하는 경우</p>\n",
+        "description": "결제 예약건이 이미 존재하는 경우",
         "type": "object",
         "required": [
           "type"
@@ -33803,7 +33809,7 @@
       },
       "PaymentScheduleAlreadyProcessedError": {
         "title": "결제 예약건이 이미 처리된 경우",
-        "description": "<p>결제 예약건이 이미 처리된 경우</p>\n",
+        "description": "결제 예약건이 이미 처리된 경우",
         "type": "object",
         "required": [
           "type"
@@ -33821,7 +33827,7 @@
       },
       "PaymentScheduleAlreadyRevokedError": {
         "title": "결제 예약건이 이미 취소된 경우",
-        "description": "<p>결제 예약건이 이미 취소된 경우</p>\n",
+        "description": "결제 예약건이 이미 취소된 경우",
         "type": "object",
         "required": [
           "type"
@@ -33839,13 +33845,13 @@
       },
       "PaymentScheduleFilterInput": {
         "title": "결제 예약 건 다건 조회를 위한 입력 정보",
-        "description": "<p>결제 예약 건 다건 조회를 위한 입력 정보</p>\n",
+        "description": "결제 예약 건 다건 조회를 위한 입력 정보",
         "type": "object",
         "properties": {
           "storeId": {
             "type": "string",
             "title": "상점 아이디",
-            "description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다."
           },
           "billingKey": {
             "type": "string",
@@ -33855,13 +33861,13 @@
             "type": "string",
             "format": "date-time",
             "title": "결제 예정 시점 조건 범위의 시작",
-            "description": "<p>값을 입력하지 않으면 파라미터 end의 90일 전으로 설정됩니다.</p>\n"
+            "description": "값을 입력하지 않으면 파라미터 end의 90일 전으로 설정됩니다."
           },
           "until": {
             "type": "string",
             "format": "date-time",
             "title": "결제 예정 시점 조건 범위의 끝",
-            "description": "<p>값을 입력하지 않으면 현재 시점으로 설정됩니다.</p>\n"
+            "description": "값을 입력하지 않으면 현재 시점으로 설정됩니다."
           },
           "status": {
             "title": "결제 예약 건 상태 리스트",
@@ -33869,14 +33875,14 @@
             "items": {
               "$ref": "#/components/schemas/PaymentScheduleStatus"
             },
-            "description": "<p>값을 입력하지 않으면 상태 필터링이 적용되지 않습니다.</p>\n"
+            "description": "값을 입력하지 않으면 상태 필터링이 적용되지 않습니다."
           }
         },
         "x-portone-title": "결제 예약 건 다건 조회를 위한 입력 정보"
       },
       "PaymentScheduleNotFoundError": {
         "title": "결제 예약건이 존재하지 않는 경우",
-        "description": "<p>결제 예약건이 존재하지 않는 경우</p>\n",
+        "description": "결제 예약건이 존재하지 않는 경우",
         "type": "object",
         "required": [
           "type"
@@ -33894,7 +33900,7 @@
       },
       "PaymentScheduleSortBy": {
         "title": "결제 예약 건 정렬 기준",
-        "description": "<p>결제 예약 건 정렬 기준</p>\n",
+        "description": "결제 예약 건 정렬 기준",
         "type": "string",
         "enum": [
           "CREATED_AT",
@@ -33919,25 +33925,25 @@
       },
       "PaymentScheduleSortInput": {
         "title": "결제 예약 건 다건 조회 시 정렬 조건",
-        "description": "<p>결제 예약 건 다건 조회 시 정렬 조건</p>\n",
+        "description": "결제 예약 건 다건 조회 시 정렬 조건",
         "type": "object",
         "properties": {
           "by": {
             "$ref": "#/components/schemas/PaymentScheduleSortBy",
             "title": "정렬 기준 필드",
-            "description": "<p>어떤 필드를 기준으로 정렬할 지 결정합니다. 비워서 보낼 경우, TIME_TO_PAY가 기본값으로 설정됩니다.</p>\n"
+            "description": "어떤 필드를 기준으로 정렬할 지 결정합니다. 비워서 보낼 경우, TIME_TO_PAY가 기본값으로 설정됩니다."
           },
           "order": {
             "$ref": "#/components/schemas/SortOrder",
             "title": "정렬 순서",
-            "description": "<p>어떤 순서로 정렬할 지 결정합니다. 비워서 보낼 경우, DESC(내림차순)가 기본값으로 설정됩니다.</p>\n"
+            "description": "어떤 순서로 정렬할 지 결정합니다. 비워서 보낼 경우, DESC(내림차순)가 기본값으로 설정됩니다."
           }
         },
         "x-portone-title": "결제 예약 건 다건 조회 시 정렬 조건"
       },
       "PaymentScheduleStatus": {
         "title": "결제 예약 건 상태",
-        "description": "<p>결제 예약 건 상태</p>\n",
+        "description": "결제 예약 건 상태",
         "type": "string",
         "enum": [
           "SCHEDULED",
@@ -33971,7 +33977,7 @@
       },
       "PaymentScheduleSummary": {
         "title": "결제 예약 건",
-        "description": "<p>결제 예약 건</p>\n",
+        "description": "결제 예약 건",
         "type": "object",
         "required": [
           "id"
@@ -33986,7 +33992,7 @@
       },
       "PaymentSortBy": {
         "title": "결제 건 정렬 기준",
-        "description": "<p>결제 건 정렬 기준</p>\n",
+        "description": "결제 건 정렬 기준",
         "type": "string",
         "enum": [
           "REQUESTED_AT",
@@ -34004,7 +34010,7 @@
       },
       "PaymentStatus": {
         "title": "결제 건 상태",
-        "description": "<p>결제 건 상태</p>\n",
+        "description": "결제 건 상태",
         "type": "string",
         "enum": [
           "READY",
@@ -34028,7 +34034,7 @@
       },
       "PaymentTextSearch": {
         "title": "통합검색 입력 정보",
-        "description": "<p>통합검색 입력 정보</p>\n",
+        "description": "통합검색 입력 정보",
         "type": "object",
         "required": [
           "field",
@@ -34046,7 +34052,7 @@
       },
       "PaymentTextSearchField": {
         "title": "통합검색 항목",
-        "description": "<p>통합검색 항목</p>\n",
+        "description": "통합검색 항목",
         "type": "string",
         "enum": [
           "ALL",
@@ -34120,14 +34126,14 @@
       },
       "PaymentTimestampType": {
         "title": "조회 시점 기준",
-        "description": "<p>조회 시점 기준</p>\n<p>어떤 시점을 기준으로 조회를 할 것인지 선택합니다.\nCREATED_AT: 결제 건 생성 시점을 기준으로 조회합니다.\nSTATUS_CHANGED_AT: 상태 승인 시점을 기준으로 조회합니다. 결제 건의 최종 상태에 따라 검색 기준이 다르게 적용됩니다.\nready -&gt; 결제 요청 시점 기준\npaid -&gt; 결제 완료 시점 기준\ncancelled -&gt; 결제 취소 시점 기준\nfailed -&gt; 결제 실패 시점 기준\n값을 입력하지 않으면 STATUS_CHANGED_AT 으로 자동 적용됩니다.</p>\n",
+        "description": "조회 시점 기준\n\n어떤 시점을 기준으로 조회를 할 것인지 선택합니다.\nCREATED_AT: 결제 건 생성 시점을 기준으로 조회합니다.\nSTATUS_CHANGED_AT: 상태 승인 시점을 기준으로 조회합니다. 결제 건의 최종 상태에 따라 검색 기준이 다르게 적용됩니다.\nready -> 결제 요청 시점 기준\npaid -> 결제 완료 시점 기준\ncancelled -> 결제 취소 시점 기준\nfailed -> 결제 실패 시점 기준\n값을 입력하지 않으면 STATUS_CHANGED_AT 으로 자동 적용됩니다.",
         "type": "string",
         "enum": [
           "CREATED_AT",
           "STATUS_CHANGED_AT"
         ],
         "x-portone-title": "조회 시점 기준",
-        "x-portone-description": "<p>어떤 시점을 기준으로 조회를 할 것인지 선택합니다.\nCREATED_AT: 결제 건 생성 시점을 기준으로 조회합니다.\nSTATUS_CHANGED_AT: 상태 승인 시점을 기준으로 조회합니다. 결제 건의 최종 상태에 따라 검색 기준이 다르게 적용됩니다.\nready -&gt; 결제 요청 시점 기준\npaid -&gt; 결제 완료 시점 기준\ncancelled -&gt; 결제 취소 시점 기준\nfailed -&gt; 결제 실패 시점 기준\n값을 입력하지 않으면 STATUS_CHANGED_AT 으로 자동 적용됩니다.</p>\n",
+        "x-portone-description": "어떤 시점을 기준으로 조회를 할 것인지 선택합니다.\nCREATED_AT: 결제 건 생성 시점을 기준으로 조회합니다.\nSTATUS_CHANGED_AT: 상태 승인 시점을 기준으로 조회합니다. 결제 건의 최종 상태에 따라 검색 기준이 다르게 적용됩니다.\nready -> 결제 요청 시점 기준\npaid -> 결제 완료 시점 기준\ncancelled -> 결제 취소 시점 기준\nfailed -> 결제 실패 시점 기준\n값을 입력하지 않으면 STATUS_CHANGED_AT 으로 자동 적용됩니다.",
         "x-portone-enum": {
           "CREATED_AT": {
             "title": "결제 건 생성 시점"
@@ -34139,7 +34145,7 @@
       },
       "PaymentWebhook": {
         "title": "성공 웹훅 내역",
-        "description": "<p>성공 웹훅 내역</p>\n",
+        "description": "성공 웹훅 내역",
         "type": "object",
         "required": [
           "id",
@@ -34149,7 +34155,7 @@
           "paymentStatus": {
             "$ref": "#/components/schemas/PaymentWebhookPaymentStatus",
             "title": "웹훅 발송 시 결제 건 상태",
-            "description": "<p>V1 결제 건인 경우, 값이 존재하지 않습니다.</p>\n"
+            "description": "V1 결제 건인 경우, 값이 존재하지 않습니다."
           },
           "id": {
             "type": "string",
@@ -34162,12 +34168,12 @@
           "url": {
             "type": "string",
             "title": "웹훅이 발송된 url",
-            "description": "<p>V1 결제 건인 경우, 값이 존재하지 않습니다.</p>\n"
+            "description": "V1 결제 건인 경우, 값이 존재하지 않습니다."
           },
           "isAsync": {
             "type": "boolean",
             "title": "비동기 웹훅 여부",
-            "description": "<p>V1 결제 건인 경우, 값이 존재하지 않습니다.</p>\n"
+            "description": "V1 결제 건인 경우, 값이 존재하지 않습니다."
           },
           "currentExecutionCount": {
             "type": "integer",
@@ -34201,7 +34207,7 @@
       },
       "PaymentWebhookPaymentStatus": {
         "title": "웹훅 발송 시 결제 건 상태",
-        "description": "<p>웹훅 발송 시 결제 건 상태</p>\n",
+        "description": "웹훅 발송 시 결제 건 상태",
         "type": "string",
         "enum": [
           "READY",
@@ -34225,7 +34231,7 @@
       },
       "PaymentWebhookRequest": {
         "title": "웹훅 요청 정보",
-        "description": "<p>웹훅 요청 정보</p>\n",
+        "description": "웹훅 요청 정보",
         "type": "object",
         "required": [
           "body"
@@ -34249,7 +34255,7 @@
       },
       "PaymentWebhookResponse": {
         "title": "웹훅 응답 정보",
-        "description": "<p>웹훅 응답 정보</p>\n",
+        "description": "웹훅 응답 정보",
         "type": "object",
         "required": [
           "code",
@@ -34280,7 +34286,7 @@
       },
       "PaymentWebhookStatus": {
         "title": "웹훅 전송 상태",
-        "description": "<p>웹훅 전송 상태</p>\n",
+        "description": "웹훅 전송 상태",
         "type": "string",
         "enum": [
           "SUCCEEDED",
@@ -34296,7 +34302,7 @@
       },
       "PaymentWebhookTrigger": {
         "title": "웹훅 실행 트리거",
-        "description": "<p>웹훅 실행 트리거</p>\n<p>수동 웹훅 재발송, 가상계좌 입금, 비동기 취소 승인 시 발생한 웹훅일 때 필드의 값이 존재합니다.</p>\n",
+        "description": "웹훅 실행 트리거\n\n수동 웹훅 재발송, 가상계좌 입금, 비동기 취소 승인 시 발생한 웹훅일 때 필드의 값이 존재합니다.",
         "type": "string",
         "enum": [
           "MANUAL",
@@ -34307,7 +34313,7 @@
           "ASYNC_PAY_FAILED"
         ],
         "x-portone-title": "웹훅 실행 트리거",
-        "x-portone-description": "<p>수동 웹훅 재발송, 가상계좌 입금, 비동기 취소 승인 시 발생한 웹훅일 때 필드의 값이 존재합니다.</p>\n",
+        "x-portone-description": "수동 웹훅 재발송, 가상계좌 입금, 비동기 취소 승인 시 발생한 웹훅일 때 필드의 값이 존재합니다.",
         "x-portone-enum": {
           "ASYNC_CANCEL_APPROVED": {},
           "VIRTUAL_ACCOUNT_DEPOSIT": {},
@@ -34319,7 +34325,7 @@
       },
       "PaymentWithCursor": {
         "title": "결제 건 및 커서 정보",
-        "description": "<p>결제 건 및 커서 정보</p>\n",
+        "description": "결제 건 및 커서 정보",
         "type": "object",
         "required": [
           "payment",
@@ -34357,7 +34363,7 @@
       },
       "PendingPaymentSchedule": {
         "title": "결제 대기 상태",
-        "description": "<p>결제 대기 상태</p>\n",
+        "description": "결제 대기 상태",
         "type": "object",
         "required": [
           "status",
@@ -34486,7 +34492,7 @@
       },
       "PgBillingKeyIssueResponse": {
         "title": "채널 별 빌링키 발급 응답",
-        "description": "<p>채널 별 빌링키 발급 응답</p>\n",
+        "description": "채널 별 빌링키 발급 응답",
         "oneOf": [
           {
             "$ref": "#/components/schemas/FailedPgBillingKeyIssueResponse"
@@ -34514,7 +34520,7 @@
       },
       "PgCompany": {
         "title": "PG사",
-        "description": "<p>PG사</p>\n",
+        "description": "PG사",
         "type": "string",
         "enum": [
           "INICIS",
@@ -34584,7 +34590,7 @@
       },
       "PgProvider": {
         "title": "PG사 결제 모듈",
-        "description": "<p>PG사 결제 모듈</p>\n",
+        "description": "PG사 결제 모듈",
         "type": "string",
         "enum": [
           "HTML5_INICIS",
@@ -34690,7 +34696,7 @@
       },
       "PgProviderError": {
         "title": "PG사에서 오류를 전달한 경우",
-        "description": "<p>PG사에서 오류를 전달한 경우</p>\n",
+        "description": "PG사에서 오류를 전달한 경우",
         "type": "object",
         "required": [
           "type",
@@ -34716,7 +34722,7 @@
       },
       "Platform": {
         "title": "고객사의 플랫폼 기능 관련 정보",
-        "description": "<p>고객사의 플랫폼 기능 관련 정보</p>\n",
+        "description": "고객사의 플랫폼 기능 관련 정보",
         "type": "object",
         "required": [
           "merchantId",
@@ -34750,7 +34756,7 @@
       },
       "PlatformAccount": {
         "title": "플랫폼 정산 계좌",
-        "description": "<p>플랫폼 정산 계좌</p>\n<p><code>currency</code> 가 KRW 일 경우 예금주 조회 API 를 통해 올바른 계좌인지 검증합니다. 그 외의 화폐일 경우 따로 검증하지는 않습니다.</p>\n",
+        "description": "플랫폼 정산 계좌\n\n`currency` 가 KRW 일 경우 예금주 조회 API 를 통해 올바른 계좌인지 검증합니다. 그 외의 화폐일 경우 따로 검증하지는 않습니다.",
         "type": "object",
         "required": [
           "bank",
@@ -34782,11 +34788,11 @@
           }
         },
         "x-portone-title": "플랫폼 정산 계좌",
-        "x-portone-description": "<p><code>currency</code> 가 KRW 일 경우 예금주 조회 API 를 통해 올바른 계좌인지 검증합니다. 그 외의 화폐일 경우 따로 검증하지는 않습니다.</p>\n"
+        "x-portone-description": "`currency` 가 KRW 일 경우 예금주 조회 API 를 통해 올바른 계좌인지 검증합니다. 그 외의 화폐일 경우 따로 검증하지는 않습니다."
       },
       "PlatformAccountHolder": {
         "title": "예금주 조회 성공 응답 정보",
-        "description": "<p>예금주 조회 성공 응답 정보</p>\n",
+        "description": "예금주 조회 성공 응답 정보",
         "type": "object",
         "required": [
           "holderName",
@@ -34806,7 +34812,7 @@
       },
       "PlatformAccountStatus": {
         "title": "플랫폼 계좌 상태",
-        "description": "<p>플랫폼 계좌 상태</p>\n",
+        "description": "플랫폼 계좌 상태",
         "type": "string",
         "enum": [
           "VERIFYING",
@@ -34840,7 +34846,7 @@
       },
       "PlatformAccountTransfer": {
         "title": "계좌 이체",
-        "description": "<p>계좌 이체</p>\n<p>송금 대행을 통해 일어난 정산 금액 지급, 인출 목적의 계좌 이체 결과 정보입니다.</p>\n",
+        "description": "계좌 이체\n\n송금 대행을 통해 일어난 정산 금액 지급, 인출 목적의 계좌 이체 결과 정보입니다.",
         "oneOf": [
           {
             "$ref": "#/components/schemas/PlatformDepositAccountTransfer"
@@ -34861,7 +34867,7 @@
           }
         },
         "x-portone-title": "계좌 이체",
-        "x-portone-description": "<p>송금 대행을 통해 일어난 정산 금액 지급, 인출 목적의 계좌 이체 결과 정보입니다.</p>\n",
+        "x-portone-description": "송금 대행을 통해 일어난 정산 금액 지급, 인출 목적의 계좌 이체 결과 정보입니다.",
         "x-portone-discriminator": {
           "DEPOSIT": {},
           "PARTNER_PAYOUT": {},
@@ -34883,7 +34889,7 @@
       },
       "PlatformAccountTransferType": {
         "title": "계좌 이체 유형",
-        "description": "<p>계좌 이체 유형</p>\n",
+        "description": "계좌 이체 유형",
         "type": "string",
         "enum": [
           "DEPOSIT",
@@ -34905,7 +34911,7 @@
       },
       "PlatformAccountVerificationAlreadyUsedError": {
         "title": "파트너 계좌 검증 아이디를 이미 사용한 경우",
-        "description": "<p>파트너 계좌 검증 아이디를 이미 사용한 경우</p>\n",
+        "description": "파트너 계좌 검증 아이디를 이미 사용한 경우",
         "type": "object",
         "required": [
           "type"
@@ -34923,7 +34929,7 @@
       },
       "PlatformAccountVerificationFailedError": {
         "title": "파트너 계좌 인증이 실패한 경우",
-        "description": "<p>파트너 계좌 인증이 실패한 경우</p>\n",
+        "description": "파트너 계좌 인증이 실패한 경우",
         "type": "object",
         "required": [
           "type"
@@ -34941,7 +34947,7 @@
       },
       "PlatformAccountVerificationNotFoundError": {
         "title": "파트너 계좌 검증 아이디를 찾을 수 없는 경우",
-        "description": "<p>파트너 계좌 검증 아이디를 찾을 수 없는 경우</p>\n",
+        "description": "파트너 계좌 검증 아이디를 찾을 수 없는 경우",
         "type": "object",
         "required": [
           "type"
@@ -34989,7 +34995,7 @@
       },
       "PlatformAdditionalFeePolicy": {
         "title": "추가 수수료 정책",
-        "description": "<p>추가 수수료 정책</p>\n<p>추가 수수료 정책는 고객사의 주문건에 대한 중개수수료에 별도로 추가로 부여되는 수수료입니다. 대표적인 사용 예시로 풀필먼트 수수료, 로켓배송 수수료, 마케팅 채널 수수료등이 있습니다.</p>\n",
+        "description": "추가 수수료 정책\n\n추가 수수료 정책는 고객사의 주문건에 대한 중개수수료에 별도로 추가로 부여되는 수수료입니다. 대표적인 사용 예시로 풀필먼트 수수료, 로켓배송 수수료, 마케팅 채널 수수료등이 있습니다.",
         "type": "object",
         "required": [
           "id",
@@ -35035,7 +35041,7 @@
           }
         },
         "x-portone-title": "추가 수수료 정책",
-        "x-portone-description": "<p>추가 수수료 정책는 고객사의 주문건에 대한 중개수수료에 별도로 추가로 부여되는 수수료입니다. 대표적인 사용 예시로 풀필먼트 수수료, 로켓배송 수수료, 마케팅 채널 수수료등이 있습니다.</p>\n"
+        "x-portone-description": "추가 수수료 정책는 고객사의 주문건에 대한 중개수수료에 별도로 추가로 부여되는 수수료입니다. 대표적인 사용 예시로 풀필먼트 수수료, 로켓배송 수수료, 마케팅 채널 수수료등이 있습니다."
       },
       "PlatformAdditionalFeePolicyAlreadyExistsError": {
         "title": "PlatformAdditionalFeePolicyAlreadyExistsError",
@@ -35055,13 +35061,13 @@
       },
       "PlatformAdditionalFeePolicyFilterInput": {
         "title": "추가 수수료 정책 다건 조회를 위한 필터 조건",
-        "description": "<p>추가 수수료 정책 다건 조회를 위한 필터 조건</p>\n",
+        "description": "추가 수수료 정책 다건 조회를 위한 필터 조건",
         "type": "object",
         "properties": {
           "isArchived": {
             "type": "boolean",
             "title": "보관 조회 여부",
-            "description": "<p>true 이면 보관된 추가 수수료 정책의 필터 옵션을 조회하고, false 이면 보관되지 않은 추가 수수료 정책의 필터 옵션을 조회합니다. 기본값은 false 입니다.</p>\n"
+            "description": "true 이면 보관된 추가 수수료 정책의 필터 옵션을 조회하고, false 이면 보관되지 않은 추가 수수료 정책의 필터 옵션을 조회합니다. 기본값은 false 입니다."
           },
           "vatPayers": {
             "title": "금액 부담 주체",
@@ -35069,7 +35075,7 @@
             "items": {
               "$ref": "#/components/schemas/PlatformPayer"
             },
-            "description": "<p>하나 이상의 값이 존재하는 경우 해당 리스트에 포함되는 부가세 부담 주체에 해당하는 추가 수수료 정책만 조회합니다.</p>\n"
+            "description": "하나 이상의 값이 존재하는 경우 해당 리스트에 포함되는 부가세 부담 주체에 해당하는 추가 수수료 정책만 조회합니다."
           },
           "keyword": {
             "$ref": "#/components/schemas/PlatformAdditionalFeePolicyFilterInputKeyword",
@@ -35080,24 +35086,24 @@
       },
       "PlatformAdditionalFeePolicyFilterInputKeyword": {
         "title": "검색 키워드 입력 정보",
-        "description": "<p>검색 키워드 입력 정보</p>\n<p>검색 키워드 적용을 위한 옵션으로, 명시된 키워드를 포함하는 추가 수수료 정책만 조회합니다. 하위 필드는 명시된 값 중 한 가지만 적용됩니다.</p>\n",
+        "description": "검색 키워드 입력 정보\n\n검색 키워드 적용을 위한 옵션으로, 명시된 키워드를 포함하는 추가 수수료 정책만 조회합니다. 하위 필드는 명시된 값 중 한 가지만 적용됩니다.",
         "type": "object",
         "properties": {
           "name": {
             "type": "string",
-            "description": "<p>해당 값이 포함된 name 을 가진 추가 수수료 정책만 조회합니다.</p>\n"
+            "description": "해당 값이 포함된 name 을 가진 추가 수수료 정책만 조회합니다."
           },
           "id": {
             "type": "string",
-            "description": "<p>해당 값이 포함된 id 를 가진 추가 수수료 정책만 조회합니다.</p>\n"
+            "description": "해당 값이 포함된 id 를 가진 추가 수수료 정책만 조회합니다."
           },
           "fee": {
             "type": "string",
-            "description": "<p>해당 값과 같은 수수료 를 가진 추가 수수료 정책만 조회합니다.</p>\n"
+            "description": "해당 값과 같은 수수료 를 가진 추가 수수료 정책만 조회합니다."
           }
         },
         "x-portone-title": "검색 키워드 입력 정보",
-        "x-portone-description": "<p>검색 키워드 적용을 위한 옵션으로, 명시된 키워드를 포함하는 추가 수수료 정책만 조회합니다. 하위 필드는 명시된 값 중 한 가지만 적용됩니다.</p>\n"
+        "x-portone-description": "검색 키워드 적용을 위한 옵션으로, 명시된 키워드를 포함하는 추가 수수료 정책만 조회합니다. 하위 필드는 명시된 값 중 한 가지만 적용됩니다."
       },
       "PlatformAdditionalFeePolicyNotFoundError": {
         "title": "PlatformAdditionalFeePolicyNotFoundError",
@@ -35165,7 +35171,7 @@
       },
       "PlatformArchivedAdditionalFeePolicyError": {
         "title": "보관된 추가 수수료 정책을 업데이트하려고 하는 경우",
-        "description": "<p>보관된 추가 수수료 정책을 업데이트하려고 하는 경우</p>\n",
+        "description": "보관된 추가 수수료 정책을 업데이트하려고 하는 경우",
         "type": "object",
         "required": [
           "type"
@@ -35183,7 +35189,7 @@
       },
       "PlatformArchivedContractError": {
         "title": "보관된 계약을 업데이트하려고 하는 경우",
-        "description": "<p>보관된 계약을 업데이트하려고 하는 경우</p>\n",
+        "description": "보관된 계약을 업데이트하려고 하는 경우",
         "type": "object",
         "required": [
           "type"
@@ -35201,7 +35207,7 @@
       },
       "PlatformArchivedDiscountSharePolicyError": {
         "title": "보관된 할인 분담 정책을 업데이트하려고 하는 경우",
-        "description": "<p>보관된 할인 분담 정책을 업데이트하려고 하는 경우</p>\n",
+        "description": "보관된 할인 분담 정책을 업데이트하려고 하는 경우",
         "type": "object",
         "required": [
           "type"
@@ -35219,7 +35225,7 @@
       },
       "PlatformArchivedPartnerError": {
         "title": "보관된 파트너를 업데이트하려고 하는 경우",
-        "description": "<p>보관된 파트너를 업데이트하려고 하는 경우</p>\n",
+        "description": "보관된 파트너를 업데이트하려고 하는 경우",
         "type": "object",
         "required": [
           "type"
@@ -35237,7 +35243,7 @@
       },
       "PlatformArchivedPartnersCannotBeScheduledError": {
         "title": "보관된 파트너들을 예약 업데이트하려고 하는 경우",
-        "description": "<p>보관된 파트너들을 예약 업데이트하려고 하는 경우</p>\n",
+        "description": "보관된 파트너들을 예약 업데이트하려고 하는 경우",
         "type": "object",
         "required": [
           "type"
@@ -35349,7 +35355,7 @@
       },
       "PlatformBulkPayoutNotFoundError": {
         "title": "일괄 지급이 존재하지 않는 경우",
-        "description": "<p>일괄 지급이 존재하지 않는 경우</p>\n",
+        "description": "일괄 지급이 존재하지 않는 경우",
         "type": "object",
         "required": [
           "type"
@@ -35484,7 +35490,7 @@
       },
       "PlatformBulkPayoutsSheetField": {
         "title": "다운로드 할 시트 컬럼",
-        "description": "<p>다운로드 할 시트 컬럼</p>\n",
+        "description": "다운로드 할 시트 컬럼",
         "type": "string",
         "enum": [
           "BULK_PAYOUT_ID",
@@ -35582,7 +35588,7 @@
       },
       "PlatformCancellableAmountExceededError": {
         "title": "취소 가능한 금액이 초과한 경우",
-        "description": "<p>취소 가능한 금액이 초과한 경우</p>\n",
+        "description": "취소 가능한 금액이 초과한 경우",
         "type": "object",
         "required": [
           "type",
@@ -35614,7 +35620,7 @@
       },
       "PlatformCancellableAmountType": {
         "title": "금액 타입",
-        "description": "<p>금액 타입</p>\n",
+        "description": "금액 타입",
         "type": "string",
         "enum": [
           "SUPPLY_WITH_VAT",
@@ -35624,7 +35630,7 @@
         "x-portone-enum": {
           "SUPPLY_WITH_VAT": {
             "title": "공급대가",
-            "description": "<p>공급가액과 부가세를 더한 금액입니다.</p>\n"
+            "description": "공급가액과 부가세를 더한 금액입니다."
           },
           "TAX_FREE": {
             "title": "면세 금액"
@@ -35764,7 +35770,7 @@
       },
       "PlatformCannotArchiveScheduledAdditionalFeePolicyError": {
         "title": "예약된 업데이트가 있는 추가 수수료 정책을 보관하려고 하는 경우",
-        "description": "<p>예약된 업데이트가 있는 추가 수수료 정책을 보관하려고 하는 경우</p>\n",
+        "description": "예약된 업데이트가 있는 추가 수수료 정책을 보관하려고 하는 경우",
         "type": "object",
         "required": [
           "type"
@@ -35782,7 +35788,7 @@
       },
       "PlatformCannotArchiveScheduledContractError": {
         "title": "예약된 업데이트가 있는 계약을 보관하려고 하는 경우",
-        "description": "<p>예약된 업데이트가 있는 계약을 보관하려고 하는 경우</p>\n",
+        "description": "예약된 업데이트가 있는 계약을 보관하려고 하는 경우",
         "type": "object",
         "required": [
           "type"
@@ -35800,7 +35806,7 @@
       },
       "PlatformCannotArchiveScheduledDiscountSharePolicyError": {
         "title": "예약된 업데이트가 있는 할인 분담 정책을 보관하려고 하는 경우",
-        "description": "<p>예약된 업데이트가 있는 할인 분담 정책을 보관하려고 하는 경우</p>\n",
+        "description": "예약된 업데이트가 있는 할인 분담 정책을 보관하려고 하는 경우",
         "type": "object",
         "required": [
           "type"
@@ -35818,7 +35824,7 @@
       },
       "PlatformCannotArchiveScheduledPartnerError": {
         "title": "예약된 업데이트가 있는 파트너를 보관하려고 하는 경우",
-        "description": "<p>예약된 업데이트가 있는 파트너를 보관하려고 하는 경우</p>\n",
+        "description": "예약된 업데이트가 있는 파트너를 보관하려고 하는 경우",
         "type": "object",
         "required": [
           "type"
@@ -35836,7 +35842,7 @@
       },
       "PlatformCannotSpecifyTransferError": {
         "title": "정산 건 식별에 실패한 경우",
-        "description": "<p>정산 건 식별에 실패한 경우</p>\n",
+        "description": "정산 건 식별에 실패한 경우",
         "type": "object",
         "required": [
           "type"
@@ -35854,7 +35860,7 @@
       },
       "PlatformContact": {
         "title": "플랫폼 파트너 담당자 연락 정보",
-        "description": "<p>플랫폼 파트너 담당자 연락 정보</p>\n<p>파트너 담당자에게 연락하기 위한 정보들 입니다.</p>\n",
+        "description": "플랫폼 파트너 담당자 연락 정보\n\n파트너 담당자에게 연락하기 위한 정보들 입니다.",
         "type": "object",
         "required": [
           "name",
@@ -35875,11 +35881,11 @@
           }
         },
         "x-portone-title": "플랫폼 파트너 담당자 연락 정보",
-        "x-portone-description": "<p>파트너 담당자에게 연락하기 위한 정보들 입니다.</p>\n"
+        "x-portone-description": "파트너 담당자에게 연락하기 위한 정보들 입니다."
       },
       "PlatformContract": {
         "title": "계약",
-        "description": "<p>계약</p>\n<p>계약은 플랫폼 고객사가 파트너에게 정산해줄 대금과 정산일을 계산하는 데 적용되는 정보입니다.\n고객사의 플랫폼에서 재화 및 서비스를 판매하기 위한 중개수수료와 판매금에 대한 정산일로 구성되어 있습니다.</p>\n",
+        "description": "계약\n\n계약은 플랫폼 고객사가 파트너에게 정산해줄 대금과 정산일을 계산하는 데 적용되는 정보입니다.\n고객사의 플랫폼에서 재화 및 서비스를 판매하기 위한 중개수수료와 판매금에 대한 정산일로 구성되어 있습니다.",
         "type": "object",
         "required": [
           "id",
@@ -35923,7 +35929,7 @@
           "subtractPaymentVatAmount": {
             "type": "boolean",
             "title": "정산 시 결제금액 부가세 감액 여부",
-            "description": "<p>false인 경우 정산금에서 결제 금액 부가세를 감액하지 않고, true인 경우 정산금에서 결제 금액 부가세를 감액합니다.</p>\n"
+            "description": "false인 경우 정산금에서 결제 금액 부가세를 감액하지 않고, true인 경우 정산금에서 결제 금액 부가세를 감액합니다."
           },
           "isArchived": {
             "type": "boolean",
@@ -35936,7 +35942,7 @@
           }
         },
         "x-portone-title": "계약",
-        "x-portone-description": "<p>계약은 플랫폼 고객사가 파트너에게 정산해줄 대금과 정산일을 계산하는 데 적용되는 정보입니다.\n고객사의 플랫폼에서 재화 및 서비스를 판매하기 위한 중개수수료와 판매금에 대한 정산일로 구성되어 있습니다.</p>\n"
+        "x-portone-description": "계약은 플랫폼 고객사가 파트너에게 정산해줄 대금과 정산일을 계산하는 데 적용되는 정보입니다.\n고객사의 플랫폼에서 재화 및 서비스를 판매하기 위한 중개수수료와 판매금에 대한 정산일로 구성되어 있습니다."
       },
       "PlatformContractAlreadyExistsError": {
         "title": "PlatformContractAlreadyExistsError",
@@ -35956,7 +35962,7 @@
       },
       "PlatformContractFilterInput": {
         "title": "계약 다건 조회를 위한 필터 조건",
-        "description": "<p>계약 다건 조회를 위한 필터 조건</p>\n",
+        "description": "계약 다건 조회를 위한 필터 조건",
         "type": "object",
         "properties": {
           "platformFeePayers": {
@@ -35965,7 +35971,7 @@
             "items": {
               "$ref": "#/components/schemas/PlatformPayer"
             },
-            "description": "<p>하나 이상의 값이 존재하는 경우 해당 리스트에 포함되는 수수료 부담 주체를 가진 계약만 조회합니다.</p>\n"
+            "description": "하나 이상의 값이 존재하는 경우 해당 리스트에 포함되는 수수료 부담 주체를 가진 계약만 조회합니다."
           },
           "cycleTypes": {
             "title": "플랫폼 정산 주기 계산 방식",
@@ -35973,7 +35979,7 @@
             "items": {
               "$ref": "#/components/schemas/PlatformSettlementCycleType"
             },
-            "description": "<p>하나 이상의 값이 존재하는 경우 해당 리스트에 포함되는 정산 주기 계산 방식을 가진 계약만 조회합니다.</p>\n"
+            "description": "하나 이상의 값이 존재하는 경우 해당 리스트에 포함되는 정산 주기 계산 방식을 가진 계약만 조회합니다."
           },
           "datePolicies": {
             "title": "플랫폼 정산 기준일",
@@ -35981,12 +35987,12 @@
             "items": {
               "$ref": "#/components/schemas/PlatformSettlementCycleDatePolicy"
             },
-            "description": "<p>하나 이상의 값이 존재하는 경우 해당 리스트에 포함되는 정산 기준일을 가진 계약만 조회합니다.</p>\n"
+            "description": "하나 이상의 값이 존재하는 경우 해당 리스트에 포함되는 정산 기준일을 가진 계약만 조회합니다."
           },
           "isArchived": {
             "type": "boolean",
             "title": "보관 조회 여부",
-            "description": "<p>true 이면 보관된 계약을 조회하고, false 이면 보관되지 않은 계약을 조회합니다. 기본값은 false 입니다.</p>\n"
+            "description": "true 이면 보관된 계약을 조회하고, false 이면 보관되지 않은 계약을 조회합니다. 기본값은 false 입니다."
           },
           "keyword": {
             "$ref": "#/components/schemas/PlatformContractFilterInputKeyword",
@@ -35997,20 +36003,20 @@
       },
       "PlatformContractFilterInputKeyword": {
         "title": "검색 키워드 입력 정보",
-        "description": "<p>검색 키워드 입력 정보</p>\n<p>검색 키워드 적용을 위한 옵션으로, 명시된 키워드를 포함하는 계약만 조회합니다. 하나의 하위 필드에만 값을 명시하여 요청합니다.</p>\n",
+        "description": "검색 키워드 입력 정보\n\n검색 키워드 적용을 위한 옵션으로, 명시된 키워드를 포함하는 계약만 조회합니다. 하나의 하위 필드에만 값을 명시하여 요청합니다.",
         "type": "object",
         "properties": {
           "id": {
             "type": "string",
-            "description": "<p>해당 값이 포함된 id 를 가진 계약만 조회합니다.</p>\n"
+            "description": "해당 값이 포함된 id 를 가진 계약만 조회합니다."
           },
           "name": {
             "type": "string",
-            "description": "<p>해당 값이 포함된 name 을 가진 계약만 조회합니다.</p>\n"
+            "description": "해당 값이 포함된 name 을 가진 계약만 조회합니다."
           }
         },
         "x-portone-title": "검색 키워드 입력 정보",
-        "x-portone-description": "<p>검색 키워드 적용을 위한 옵션으로, 명시된 키워드를 포함하는 계약만 조회합니다. 하나의 하위 필드에만 값을 명시하여 요청합니다.</p>\n"
+        "x-portone-description": "검색 키워드 적용을 위한 옵션으로, 명시된 키워드를 포함하는 계약만 조회합니다. 하나의 하위 필드에만 값을 명시하여 요청합니다."
       },
       "PlatformContractNotFoundError": {
         "title": "PlatformContractNotFoundError",
@@ -36108,7 +36114,7 @@
       },
       "PlatformCurrencyNotSupportedError": {
         "title": "지원 되지 않는 통화를 선택한 경우",
-        "description": "<p>지원 되지 않는 통화를 선택한 경우</p>\n",
+        "description": "지원 되지 않는 통화를 선택한 경우",
         "type": "object",
         "required": [
           "type"
@@ -36210,7 +36216,7 @@
       },
       "PlatformDiscountSharePolicy": {
         "title": "할인 분담 정책",
-        "description": "<p>할인 분담 정책</p>\n<p>할인 분담은 고객사의 주문건에 쿠폰 및 포인트와 같은 할인금액이 적용될 때, 파트너 정산 시 할인금액에 대한 분담 정책을 가지는 객체입니다.\n할인 유형에 대한 아이디와 메모, 그리고 파트너 분담율을 가집니다.</p>\n",
+        "description": "할인 분담 정책\n\n할인 분담은 고객사의 주문건에 쿠폰 및 포인트와 같은 할인금액이 적용될 때, 파트너 정산 시 할인금액에 대한 분담 정책을 가지는 객체입니다.\n할인 유형에 대한 아이디와 메모, 그리고 파트너 분담율을 가집니다.",
         "type": "object",
         "required": [
           "id",
@@ -36235,7 +36241,7 @@
             "type": "integer",
             "format": "int32",
             "title": "할인 분담율",
-            "description": "<p>파트너가 분담할 할인금액의 비율을 의미하는 밀리 퍼센트 단위 (10^-5) 의 음이 아닌 정수이며, 파트너가 부담할 금액은 <code>할인금액 * partnerShareRate * 10^5</code> 로 책정합니다.</p>\n"
+            "description": "파트너가 분담할 할인금액의 비율을 의미하는 밀리 퍼센트 단위 (10^-5) 의 음이 아닌 정수이며, 파트너가 부담할 금액은 `할인금액 * partnerShareRate * 10^5` 로 책정합니다."
           },
           "memo": {
             "type": "string",
@@ -36252,7 +36258,7 @@
           }
         },
         "x-portone-title": "할인 분담 정책",
-        "x-portone-description": "<p>할인 분담은 고객사의 주문건에 쿠폰 및 포인트와 같은 할인금액이 적용될 때, 파트너 정산 시 할인금액에 대한 분담 정책을 가지는 객체입니다.\n할인 유형에 대한 아이디와 메모, 그리고 파트너 분담율을 가집니다.</p>\n"
+        "x-portone-description": "할인 분담은 고객사의 주문건에 쿠폰 및 포인트와 같은 할인금액이 적용될 때, 파트너 정산 시 할인금액에 대한 분담 정책을 가지는 객체입니다.\n할인 유형에 대한 아이디와 메모, 그리고 파트너 분담율을 가집니다."
       },
       "PlatformDiscountSharePolicyAlreadyExistsError": {
         "title": "PlatformDiscountSharePolicyAlreadyExistsError",
@@ -36272,13 +36278,13 @@
       },
       "PlatformDiscountSharePolicyFilterInput": {
         "title": "할인 분담 정책 다건 조회를 위한 필터 조건",
-        "description": "<p>할인 분담 정책 다건 조회를 위한 필터 조건</p>\n",
+        "description": "할인 분담 정책 다건 조회를 위한 필터 조건",
         "type": "object",
         "properties": {
           "isArchived": {
             "type": "boolean",
             "title": "보관 조회 여부",
-            "description": "<p>true 이면 보관된 할인 분담 정책을 조회하고, false 이면 보관되지 않은 할인 분담 정책을 조회합니다. 기본값은 false 입니다.</p>\n"
+            "description": "true 이면 보관된 할인 분담 정책을 조회하고, false 이면 보관되지 않은 할인 분담 정책을 조회합니다. 기본값은 false 입니다."
           },
           "partnerShareRates": {
             "type": "array",
@@ -36286,7 +36292,7 @@
               "type": "integer",
               "format": "int32"
             },
-            "description": "<p>하나 이상의 값이 존재하는 경우 해당 리스트에 포함되는 파트너 분담율을 가진 할인 분담 정책만 조회합니다.</p>\n"
+            "description": "하나 이상의 값이 존재하는 경우 해당 리스트에 포함되는 파트너 분담율을 가진 할인 분담 정책만 조회합니다."
           },
           "keyword": {
             "$ref": "#/components/schemas/PlatformDiscountSharePolicyFilterInputKeyword",
@@ -36297,24 +36303,24 @@
       },
       "PlatformDiscountSharePolicyFilterInputKeyword": {
         "title": "검색 키워드 입력 정보",
-        "description": "<p>검색 키워드 입력 정보</p>\n<p>검색 키워드 적용을 위한 옵션으로, 명시된 키워드를 포함하는 할인 분담 정책만 조회합니다. 하위 필드는 명시된 값 중 한 가지만 적용됩니다.</p>\n",
+        "description": "검색 키워드 입력 정보\n\n검색 키워드 적용을 위한 옵션으로, 명시된 키워드를 포함하는 할인 분담 정책만 조회합니다. 하위 필드는 명시된 값 중 한 가지만 적용됩니다.",
         "type": "object",
         "properties": {
           "id": {
             "type": "string",
-            "description": "<p>해당 값이 포함된 id 를 가진 할인 분담 정책만 조회합니다.</p>\n"
+            "description": "해당 값이 포함된 id 를 가진 할인 분담 정책만 조회합니다."
           },
           "name": {
             "type": "string",
-            "description": "<p>해당 값이 포함된 name 을 가진 할인 분담만 조회합니다.</p>\n"
+            "description": "해당 값이 포함된 name 을 가진 할인 분담만 조회합니다."
           }
         },
         "x-portone-title": "검색 키워드 입력 정보",
-        "x-portone-description": "<p>검색 키워드 적용을 위한 옵션으로, 명시된 키워드를 포함하는 할인 분담 정책만 조회합니다. 하위 필드는 명시된 값 중 한 가지만 적용됩니다.</p>\n"
+        "x-portone-description": "검색 키워드 적용을 위한 옵션으로, 명시된 키워드를 포함하는 할인 분담 정책만 조회합니다. 하위 필드는 명시된 값 중 한 가지만 적용됩니다."
       },
       "PlatformDiscountSharePolicyFilterOptions": {
         "title": "할인 분담 정책 필터 옵션 조회 성공 응답 정보",
-        "description": "<p>할인 분담 정책 필터 옵션 조회 성공 응답 정보</p>\n",
+        "description": "할인 분담 정책 필터 옵션 조회 성공 응답 정보",
         "type": "object",
         "required": [
           "partnerShareRates"
@@ -36389,7 +36395,7 @@
       },
       "PlatformExternalApiFailedError": {
         "title": "외부 api 오류",
-        "description": "<p>외부 api 오류</p>\n",
+        "description": "외부 api 오류",
         "type": "object",
         "required": [
           "type"
@@ -36407,7 +36413,7 @@
       },
       "PlatformExternalApiTemporarilyFailedError": {
         "title": "외부 api의 일시적인 오류",
-        "description": "<p>외부 api의 일시적인 오류</p>\n",
+        "description": "외부 api의 일시적인 오류",
         "type": "object",
         "required": [
           "type"
@@ -36425,7 +36431,7 @@
       },
       "PlatformExternalPayment": {
         "title": "외부 결제 정보",
-        "description": "<p>외부 결제 정보</p>\n",
+        "description": "외부 결제 정보",
         "type": "object",
         "required": [
           "type",
@@ -36462,7 +36468,7 @@
       },
       "PlatformFee": {
         "title": "플랫폼 중개수수료 정보",
-        "description": "<p>플랫폼 중개수수료 정보</p>\n",
+        "description": "플랫폼 중개수수료 정보",
         "oneOf": [
           {
             "$ref": "#/components/schemas/PlatformFixedAmountFee"
@@ -36490,7 +36496,7 @@
       },
       "PlatformFeeInput": {
         "title": "수수료 계산 방식을 특정하기 위한 입력 정보",
-        "description": "<p>수수료 계산 방식을 특정하기 위한 입력 정보</p>\n<p>정률 수수료를 설정하고 싶은 경우 <code>fixedRate</code> 필드에, 정액 수수료를 설정하고 싶은 경우 <code>fixedAmount</code> 필드에 값을 명시해 요청합니다.\n두 필드 모두 값이 들어있지 않은 경우 요청이 거절됩니다.</p>\n",
+        "description": "수수료 계산 방식을 특정하기 위한 입력 정보\n\n정률 수수료를 설정하고 싶은 경우 `fixedRate` 필드에, 정액 수수료를 설정하고 싶은 경우 `fixedAmount` 필드에 값을 명시해 요청합니다.\n두 필드 모두 값이 들어있지 않은 경우 요청이 거절됩니다.",
         "type": "object",
         "properties": {
           "fixedRate": {
@@ -36505,11 +36511,11 @@
           }
         },
         "x-portone-title": "수수료 계산 방식을 특정하기 위한 입력 정보",
-        "x-portone-description": "<p>정률 수수료를 설정하고 싶은 경우 <code>fixedRate</code> 필드에, 정액 수수료를 설정하고 싶은 경우 <code>fixedAmount</code> 필드에 값을 명시해 요청합니다.\n두 필드 모두 값이 들어있지 않은 경우 요청이 거절됩니다.</p>\n"
+        "x-portone-description": "정률 수수료를 설정하고 싶은 경우 `fixedRate` 필드에, 정액 수수료를 설정하고 싶은 경우 `fixedAmount` 필드에 값을 명시해 요청합니다.\n두 필드 모두 값이 들어있지 않은 경우 요청이 거절됩니다."
       },
       "PlatformFixedAmountFee": {
         "title": "정액 수수료",
-        "description": "<p>정액 수수료</p>\n<p>총 금액에 무관하게 정해진 수수료 금액을 책정합니다.</p>\n",
+        "description": "정액 수수료\n\n총 금액에 무관하게 정해진 수수료 금액을 책정합니다.",
         "type": "object",
         "required": [
           "type",
@@ -36526,11 +36532,11 @@
           }
         },
         "x-portone-title": "정액 수수료",
-        "x-portone-description": "<p>총 금액에 무관하게 정해진 수수료 금액을 책정합니다.</p>\n"
+        "x-portone-description": "총 금액에 무관하게 정해진 수수료 금액을 책정합니다."
       },
       "PlatformFixedRateFee": {
         "title": "정률 수수료",
-        "description": "<p>정률 수수료</p>\n<p>총 금액에 정해진 비율을 곱한 만큼의 수수료를 책정합니다.</p>\n",
+        "description": "정률 수수료\n\n총 금액에 정해진 비율을 곱한 만큼의 수수료를 책정합니다.",
         "type": "object",
         "required": [
           "type",
@@ -36544,15 +36550,15 @@
             "type": "integer",
             "format": "int32",
             "title": "수수료율",
-            "description": "<p>총 금액 대비 수수료 비율을 의미하며, 밀리 퍼센트 단위 (10^-5) 의 음이 아닌 정수입니다. <code>총 금액 * rate * 10^5</code> (<code>rate * 10^3 %</code>) 만큼 수수료를 책정합니다.</p>\n"
+            "description": "총 금액 대비 수수료 비율을 의미하며, 밀리 퍼센트 단위 (10^-5) 의 음이 아닌 정수입니다. `총 금액 * rate * 10^5` (`rate * 10^3 %`) 만큼 수수료를 책정합니다."
           }
         },
         "x-portone-title": "정률 수수료",
-        "x-portone-description": "<p>총 금액에 정해진 비율을 곱한 만큼의 수수료를 책정합니다.</p>\n"
+        "x-portone-description": "총 금액에 정해진 비율을 곱한 만큼의 수수료를 책정합니다."
       },
       "PlatformHoliday": {
         "title": "공휴일",
-        "description": "<p>공휴일</p>\n",
+        "description": "공휴일",
         "type": "object",
         "required": [
           "name",
@@ -36564,9 +36570,9 @@
             "title": "이름"
           },
           "date": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "날짜"
           }
         },
@@ -36574,7 +36580,7 @@
       },
       "PlatformInsufficientDataToChangePartnerTypeError": {
         "title": "파트너 타입 수정에 필요한 데이터가 부족한 경우",
-        "description": "<p>파트너 타입 수정에 필요한 데이터가 부족한 경우</p>\n",
+        "description": "파트너 타입 수정에 필요한 데이터가 부족한 경우",
         "type": "object",
         "required": [
           "type"
@@ -36617,7 +36623,7 @@
       },
       "PlatformManualTransfer": {
         "title": "수기 정산건",
-        "description": "<p>수기 정산건</p>\n",
+        "description": "수기 정산건",
         "type": "object",
         "required": [
           "type",
@@ -36655,9 +36661,9 @@
             "title": "메모"
           },
           "settlementDate": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "정산 일"
           },
           "settlementCurrency": {
@@ -36725,9 +36731,9 @@
             "type": "string"
           },
           "settlementDate": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n"
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다."
           },
           "settlementCurrency": {
             "$ref": "#/components/schemas/Currency"
@@ -36757,7 +36763,7 @@
       },
       "PlatformNonUpdatableStatusError": {
         "title": "업데이트 불가능한 상태를 업데이트하려는 경우",
-        "description": "<p>업데이트 불가능한 상태를 업데이트하려는 경우</p>\n",
+        "description": "업데이트 불가능한 상태를 업데이트하려는 경우",
         "type": "object",
         "required": [
           "type"
@@ -36775,7 +36781,7 @@
       },
       "PlatformNotEnabledError": {
         "title": "플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우",
-        "description": "<p>플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우</p>\n",
+        "description": "플랫폼 기능이 활성화되지 않아 요청을 처리할 수 없는 경우",
         "type": "object",
         "required": [
           "type"
@@ -36793,7 +36799,7 @@
       },
       "PlatformNotSupportedBankError": {
         "title": "지원하지 않는 은행인 경우",
-        "description": "<p>지원하지 않는 은행인 경우</p>\n",
+        "description": "지원하지 않는 은행인 경우",
         "type": "object",
         "required": [
           "type"
@@ -36811,7 +36817,7 @@
       },
       "PlatformOrderCancelTransfer": {
         "title": "주문 취소 정산건",
-        "description": "<p>주문 취소 정산건</p>\n",
+        "description": "주문 취소 정산건",
         "type": "object",
         "required": [
           "type",
@@ -36857,9 +36863,9 @@
             "title": "메모"
           },
           "settlementDate": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "정산 일"
           },
           "settlementCurrency": {
@@ -36896,9 +36902,9 @@
             "title": "결제 정보"
           },
           "settlementStartDate": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "정산 시작일"
           },
           "orderLines": {
@@ -36975,9 +36981,9 @@
             "type": "string"
           },
           "settlementDate": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n"
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다."
           },
           "settlementCurrency": {
             "$ref": "#/components/schemas/Currency"
@@ -37006,9 +37012,9 @@
             "$ref": "#/components/schemas/PlatformTransferSummaryPayment"
           },
           "settlementStartDate": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n"
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다."
           }
         }
       },
@@ -37030,7 +37036,7 @@
       },
       "PlatformOrderSettlementAmount": {
         "title": "정산 금액 정보",
-        "description": "<p>정산 금액 정보</p>\n<p>정산 금액과 정산 금액 계산에 사용된 금액 정보들 입니다.</p>\n",
+        "description": "정산 금액 정보\n\n정산 금액과 정산 금액 계산에 사용된 금액 정보들 입니다.",
         "type": "object",
         "required": [
           "settlement",
@@ -37072,19 +37078,19 @@
             "type": "integer",
             "format": "int64",
             "title": "결제 금액 부가세 부담금액",
-            "description": "<p>참조된 계약의 결제 금액 부가세 감액 여부에 따라 false인 경우 0원, true인 경우 결제 금액 부가세입니다.</p>\n"
+            "description": "참조된 계약의 결제 금액 부가세 감액 여부에 따라 false인 경우 0원, true인 경우 결제 금액 부가세입니다."
           },
           "taxFree": {
             "type": "integer",
             "format": "int64",
             "title": "결제 면세 금액",
-            "description": "<p>해당 필드는 deprecated되어 9월까지만 유지되고 이후 삭제될 예정입니다. 대신 paymentTaxFree 필드를 사용해주세요.</p>\n"
+            "description": "해당 필드는 deprecated되어 9월까지만 유지되고 이후 삭제될 예정입니다. 대신 paymentTaxFree 필드를 사용해주세요."
           },
           "supply": {
             "type": "integer",
             "format": "int64",
             "title": "결제 공급가액",
-            "description": "<p>해당 필드는 deprecated되어 9월까지만 유지되고 이후 삭제될 예정입니다. 대신 paymentSupply 필드를 사용해주세요.</p>\n"
+            "description": "해당 필드는 deprecated되어 9월까지만 유지되고 이후 삭제될 예정입니다. 대신 paymentSupply 필드를 사용해주세요."
           },
           "paymentTaxFree": {
             "type": "integer",
@@ -37148,11 +37154,11 @@
           }
         },
         "x-portone-title": "정산 금액 정보",
-        "x-portone-description": "<p>정산 금액과 정산 금액 계산에 사용된 금액 정보들 입니다.</p>\n"
+        "x-portone-description": "정산 금액과 정산 금액 계산에 사용된 금액 정보들 입니다."
       },
       "PlatformOrderTransfer": {
         "title": "주문 정산건",
-        "description": "<p>주문 정산건</p>\n",
+        "description": "주문 정산건",
         "type": "object",
         "required": [
           "type",
@@ -37197,9 +37203,9 @@
             "title": "메모"
           },
           "settlementDate": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "정산 일"
           },
           "settlementCurrency": {
@@ -37236,9 +37242,9 @@
             "title": "결제 정보"
           },
           "settlementStartDate": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "정산 시작일"
           },
           "orderLines": {
@@ -37271,7 +37277,7 @@
       },
       "PlatformOrderTransferAdditionalFee": {
         "title": "추가 수수료 정보",
-        "description": "<p>추가 수수료 정보</p>\n",
+        "description": "추가 수수료 정보",
         "type": "object",
         "required": [
           "policy",
@@ -37314,7 +37320,7 @@
       },
       "PlatformOrderTransferCancellation": {
         "title": "주문 취소 정보",
-        "description": "<p>주문 취소 정보</p>\n",
+        "description": "주문 취소 정보",
         "type": "object",
         "required": [
           "id",
@@ -37335,7 +37341,7 @@
       },
       "PlatformOrderTransferDiscount": {
         "title": "할인 정보",
-        "description": "<p>할인 정보</p>\n",
+        "description": "할인 정보",
         "type": "object",
         "required": [
           "sharePolicy",
@@ -37374,7 +37380,7 @@
       },
       "PlatformOrderTransferOrderLine": {
         "title": "주문 항목",
-        "description": "<p>주문 항목</p>\n",
+        "description": "주문 항목",
         "type": "object",
         "required": [
           "product",
@@ -37416,7 +37422,7 @@
       },
       "PlatformOrderTransferProduct": {
         "title": "상품",
-        "description": "<p>상품</p>\n",
+        "description": "상품",
         "type": "object",
         "required": [
           "id",
@@ -37492,9 +37498,9 @@
             "type": "string"
           },
           "settlementDate": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n"
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다."
           },
           "settlementCurrency": {
             "$ref": "#/components/schemas/Currency"
@@ -37523,15 +37529,15 @@
             "$ref": "#/components/schemas/PlatformTransferSummaryPayment"
           },
           "settlementStartDate": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n"
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다."
           }
         }
       },
       "PlatformPartner": {
         "title": "파트너",
-        "description": "<p>파트너</p>\n<p>파트너는 고객사가 정산해주어야 할 대상입니다.\n기본 사업자 정보와 정산정보, 그리고 적용될 계약의 정보를 등록 및 관리할 수 있습니다.</p>\n",
+        "description": "파트너\n\n파트너는 고객사가 정산해주어야 할 대상입니다.\n기본 사업자 정보와 정산정보, 그리고 적용될 계약의 정보를 등록 및 관리할 수 있습니다.",
         "type": "object",
         "required": [
           "id",
@@ -37605,11 +37611,11 @@
           }
         },
         "x-portone-title": "파트너",
-        "x-portone-description": "<p>파트너는 고객사가 정산해주어야 할 대상입니다.\n기본 사업자 정보와 정산정보, 그리고 적용될 계약의 정보를 등록 및 관리할 수 있습니다.</p>\n"
+        "x-portone-description": "파트너는 고객사가 정산해주어야 할 대상입니다.\n기본 사업자 정보와 정산정보, 그리고 적용될 계약의 정보를 등록 및 관리할 수 있습니다."
       },
       "PlatformPartnerBusinessStatus": {
         "title": "플랫폼 파트너 사업자 상태",
-        "description": "<p>플랫폼 파트너 사업자 상태</p>\n",
+        "description": "플랫폼 파트너 사업자 상태",
         "type": "string",
         "enum": [
           "NOT_VERIFIED",
@@ -37647,7 +37653,7 @@
       },
       "PlatformPartnerContractSummary": {
         "title": "파트너 계약 요약 정보",
-        "description": "<p>파트너 계약 요약 정보</p>\n",
+        "description": "파트너 계약 요약 정보",
         "type": "object",
         "required": [
           "id",
@@ -37667,7 +37673,7 @@
       },
       "PlatformPartnerDashboard": {
         "title": "파트너 현황 조회 성공 응답",
-        "description": "<p>파트너 현황 조회 성공 응답</p>\n",
+        "description": "파트너 현황 조회 성공 응답",
         "type": "object",
         "required": [
           "totalPartner",
@@ -37683,9 +37689,9 @@
             "title": "정산 예정인 파트너 현황"
           },
           "upcomingSettlementDate": {
-            "description": "<p>정산이 예정되어 있지 않은 경우 값이 주어지지 않습니다.</p>\n",
+            "description": "정산이 예정되어 있지 않은 경우 값이 주어지지 않습니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "예정된 정산일"
           }
         },
@@ -37693,7 +37699,7 @@
       },
       "PlatformPartnerDashboardCount": {
         "title": "파트너 현황 정보",
-        "description": "<p>파트너 현황 정보</p>\n",
+        "description": "파트너 현황 정보",
         "type": "object",
         "required": [
           "total",
@@ -37715,20 +37721,20 @@
       },
       "PlatformPartnerFilterInput": {
         "title": "파트너 필터 입력 정보",
-        "description": "<p>파트너 필터 입력 정보</p>\n",
+        "description": "파트너 필터 입력 정보",
         "type": "object",
         "properties": {
           "isArchived": {
             "type": "boolean",
             "title": "보관 조회 여부",
-            "description": "<p>true 이면 보관된 파트너를 조회하고, false 이면 보관되지 않은 파트너를 조회합니다. 기본값은 false 입니다.</p>\n"
+            "description": "true 이면 보관된 파트너를 조회하고, false 이면 보관되지 않은 파트너를 조회합니다. 기본값은 false 입니다."
           },
           "tags": {
             "type": "array",
             "items": {
               "type": "string"
             },
-            "description": "<p>하나 이상의 값이 존재하는 경우 해당 리스트에 포함되는 태그를 하나 이상 가지는 파트너만 조회합니다.</p>\n"
+            "description": "하나 이상의 값이 존재하는 경우 해당 리스트에 포함되는 태그를 하나 이상 가지는 파트너만 조회합니다."
           },
           "banks": {
             "title": "은행",
@@ -37736,7 +37742,7 @@
             "items": {
               "$ref": "#/components/schemas/Bank"
             },
-            "description": "<p>하나 이상의 값이 존재하는 경우,  해당 리스트에 포함되는 계좌 은행을 가진 파트너만 조회합니다.</p>\n"
+            "description": "하나 이상의 값이 존재하는 경우,  해당 리스트에 포함되는 계좌 은행을 가진 파트너만 조회합니다."
           },
           "accountCurrencies": {
             "title": "통화 단위",
@@ -37744,21 +37750,21 @@
             "items": {
               "$ref": "#/components/schemas/Currency"
             },
-            "description": "<p>하나 이상의 값이 존재하는 경우,  해당 리스트에 포함되는 계좌 통화를 가진 파트너만 조회합니다.</p>\n"
+            "description": "하나 이상의 값이 존재하는 경우,  해당 리스트에 포함되는 계좌 통화를 가진 파트너만 조회합니다."
           },
           "ids": {
             "type": "array",
             "items": {
               "type": "string"
             },
-            "description": "<p>하나 이상의 값이 존재하는 경우,  해당 리스트에 포함되는 아이디를 가진 파트너만 조회합니다.</p>\n"
+            "description": "하나 이상의 값이 존재하는 경우,  해당 리스트에 포함되는 아이디를 가진 파트너만 조회합니다."
           },
           "contractIds": {
             "type": "array",
             "items": {
               "type": "string"
             },
-            "description": "<p>하나 이상의 값이 존재하는 경우,  해당 리스트에 포함되는 기본 계약 id를 가진 파트너만 조회합니다.</p>\n"
+            "description": "하나 이상의 값이 존재하는 경우,  해당 리스트에 포함되는 기본 계약 id를 가진 파트너만 조회합니다."
           },
           "keyword": {
             "$ref": "#/components/schemas/PlatformPartnerFilterInputKeyword",
@@ -37769,48 +37775,48 @@
       },
       "PlatformPartnerFilterInputKeyword": {
         "title": "파트너 검색 키워드 입력 정보",
-        "description": "<p>파트너 검색 키워드 입력 정보</p>\n<p>검색 키워드 적용을 위한 옵션으로, 명시된 키워드를 포함하는 파트너만 조회합니다. 하나의 하위 필드에만 값을 명시하여 요청합니다.</p>\n",
+        "description": "파트너 검색 키워드 입력 정보\n\n검색 키워드 적용을 위한 옵션으로, 명시된 키워드를 포함하는 파트너만 조회합니다. 하나의 하위 필드에만 값을 명시하여 요청합니다.",
         "type": "object",
         "properties": {
           "id": {
             "type": "string",
-            "description": "<p>해당 값이 포함된 id 를 가진 파트너만 조회합니다.</p>\n"
+            "description": "해당 값이 포함된 id 를 가진 파트너만 조회합니다."
           },
           "name": {
             "type": "string",
-            "description": "<p>해당 값이 포함된 이름 을 가진 파트너만 조회합니다.</p>\n"
+            "description": "해당 값이 포함된 이름 을 가진 파트너만 조회합니다."
           },
           "email": {
             "type": "string",
-            "description": "<p>해당 값이 포함된 이메일 주소를 가진 파트너만 조회합니다.</p>\n"
+            "description": "해당 값이 포함된 이메일 주소를 가진 파트너만 조회합니다."
           },
           "businessRegistrationNumber": {
             "type": "string",
-            "description": "<p>해당 값이 포함된 사업자등록번호를 가진 파트너만 조회합니다.</p>\n"
+            "description": "해당 값이 포함된 사업자등록번호를 가진 파트너만 조회합니다."
           },
           "defaultContractId": {
             "type": "string",
-            "description": "<p>해당 값이 포함된 기본 계약 아이디를 가진 파트너만 조회합니다.</p>\n"
+            "description": "해당 값이 포함된 기본 계약 아이디를 가진 파트너만 조회합니다."
           },
           "memo": {
             "type": "string",
-            "description": "<p>해당 값이 포함된 메모를 가진 파트너만 조회합니다.</p>\n"
+            "description": "해당 값이 포함된 메모를 가진 파트너만 조회합니다."
           },
           "accountNumber": {
             "type": "string",
-            "description": "<p>해당 값이 포함된 계좌번호를 가진 파트너만 조회합니다.</p>\n"
+            "description": "해당 값이 포함된 계좌번호를 가진 파트너만 조회합니다."
           },
           "accountHolder": {
             "type": "string",
-            "description": "<p>해당 값이 포함된 계좌 예금주명을 가진 파트너만 조회합니다.</p>\n"
+            "description": "해당 값이 포함된 계좌 예금주명을 가진 파트너만 조회합니다."
           }
         },
         "x-portone-title": "파트너 검색 키워드 입력 정보",
-        "x-portone-description": "<p>검색 키워드 적용을 위한 옵션으로, 명시된 키워드를 포함하는 파트너만 조회합니다. 하나의 하위 필드에만 값을 명시하여 요청합니다.</p>\n"
+        "x-portone-description": "검색 키워드 적용을 위한 옵션으로, 명시된 키워드를 포함하는 파트너만 조회합니다. 하나의 하위 필드에만 값을 명시하여 요청합니다."
       },
       "PlatformPartnerFilterOptions": {
         "title": "파트너 필터 옵션 조회 성공 응답 정보",
-        "description": "<p>파트너 필터 옵션 조회 성공 응답 정보</p>\n",
+        "description": "파트너 필터 옵션 조회 성공 응답 정보",
         "type": "object",
         "required": [
           "tags",
@@ -37940,9 +37946,9 @@
             "title": "파트너"
           },
           "settlementDate": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "정산 일"
           },
           "settlementCurrency": {
@@ -38016,9 +38022,9 @@
             "title": "파트너"
           },
           "settlementDate": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "정산 일"
           },
           "settlementCurrency": {
@@ -38083,9 +38089,9 @@
             "title": "파트너"
           },
           "settlementDate": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "정산 일"
           },
           "settlementCurrency": {
@@ -38298,7 +38304,7 @@
       },
       "PlatformPartnerSettlementDashboard": {
         "title": "정산내역 대시보드",
-        "description": "<p>정산내역 대시보드</p>\n",
+        "description": "정산내역 대시보드",
         "type": "object",
         "required": [
           "currencyStats"
@@ -38316,7 +38322,7 @@
       },
       "PlatformPartnerSettlementDashboardCurrencyStat": {
         "title": "정산 통화별 정산내역 통계",
-        "description": "<p>정산 통화별 정산내역 통계</p>\n",
+        "description": "정산 통화별 정산내역 통계",
         "type": "object",
         "required": [
           "currency",
@@ -38345,7 +38351,7 @@
             "type": "integer",
             "format": "int64",
             "title": "총 정산 수수료 금액",
-            "description": "<p>중개 수수료, 중개 수수료 부가세, 추가 수수료, 추가 수수료 부가세, 할인 분담금, 결제금액 부가세 부담금을 더한 금액 입니다.</p>\n"
+            "description": "중개 수수료, 중개 수수료 부가세, 추가 수수료, 추가 수수료 부가세, 할인 분담금, 결제금액 부가세 부담금을 더한 금액 입니다."
           },
           "manualAmount": {
             "type": "integer",
@@ -38366,9 +38372,9 @@
           "settlementDates": {
             "type": "array",
             "items": {
-              "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+              "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
               "type": "string",
-              "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n"
+              "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다."
             }
           },
           "contractIds": {
@@ -38432,7 +38438,7 @@
       },
       "PlatformPartnerSettlementNotFoundError": {
         "title": "정산내역을 찾을 수 없는 경우",
-        "description": "<p>정산내역을 찾을 수 없는 경우</p>\n",
+        "description": "정산내역을 찾을 수 없는 경우",
         "type": "object",
         "required": [
           "type"
@@ -38450,7 +38456,7 @@
       },
       "PlatformPartnerSettlementSheetField": {
         "title": "다운로드 할 시트 컬럼",
-        "description": "<p>다운로드 할 시트 컬럼</p>\n",
+        "description": "다운로드 할 시트 컬럼",
         "type": "string",
         "enum": [
           "PARTNER_SETTLEMENT_ID",
@@ -38493,7 +38499,7 @@
         "x-portone-enum": {
           "TAXATION_TYPE_OR_INCOME_TYPE": {
             "title": "과세 유형 또는 소득 유형",
-            "description": "<p>파트너 유형이 사업자인 경우 과세 유형, 원천징수 대상자인 소득 유형입니다.</p>\n"
+            "description": "파트너 유형이 사업자인 경우 과세 유형, 원천징수 대상자인 소득 유형입니다."
           },
           "PARTNER_ID": {
             "title": "파트너 아이디"
@@ -38530,7 +38536,7 @@
           },
           "SETTLEMENT_TAX_FREE_AMOUNT": {
             "title": "결제 면세액",
-            "description": "<p>해당 필드는 deprecated되어 9월까지만 유지되고 이후 삭제될 예정입니다. 대신 SETTLEMENT_PAYMENT_TAX_FREE_AMOUNT 필드를 사용해주세요.</p>\n"
+            "description": "해당 필드는 deprecated되어 9월까지만 유지되고 이후 삭제될 예정입니다. 대신 SETTLEMENT_PAYMENT_TAX_FREE_AMOUNT 필드를 사용해주세요."
           },
           "SETTLEMENT_ADDITIONAL_FEE_VAT_AMOUNT": {
             "title": "추가 수수료 부가세"
@@ -38582,7 +38588,7 @@
           },
           "SETTLEMENT_SUPPLY_AMOUNT": {
             "title": "결제 공급가액",
-            "description": "<p>해당 필드는 deprecated되어 9월까지만 유지되고 이후 삭제될 예정입니다. 대신 SETTLEMENT_PAYMENT_SUPPLY_AMOUNT 필드를 사용해주세요.</p>\n"
+            "description": "해당 필드는 deprecated되어 9월까지만 유지되고 이후 삭제될 예정입니다. 대신 SETTLEMENT_PAYMENT_SUPPLY_AMOUNT 필드를 사용해주세요."
           },
           "SETTLEMENT_ADDITIONAL_FEE_AMOUNT": {
             "title": "추가 수수료"
@@ -38603,7 +38609,7 @@
       },
       "PlatformPartnerSettlementStatus": {
         "title": "정산 상태",
-        "description": "<p>정산 상태</p>\n",
+        "description": "정산 상태",
         "type": "string",
         "enum": [
           "PAYOUT_PREPARED",
@@ -38666,7 +38672,7 @@
       },
       "PlatformPartnerSettlementType": {
         "title": "정산 유형",
-        "description": "<p>정산 유형</p>\n",
+        "description": "정산 유형",
         "type": "string",
         "enum": [
           "MANUAL",
@@ -38688,7 +38694,7 @@
       },
       "PlatformPartnerStatus": {
         "title": "플랫폼 파트너 상태",
-        "description": "<p>플랫폼 파트너 상태</p>\n",
+        "description": "플랫폼 파트너 상태",
         "type": "string",
         "enum": [
           "PENDING",
@@ -38710,7 +38716,7 @@
       },
       "PlatformPartnerTaxationType": {
         "title": "플랫폼 파트너 과세 유형",
-        "description": "<p>플랫폼 파트너 과세 유형</p>\n",
+        "description": "플랫폼 파트너 과세 유형",
         "type": "string",
         "enum": [
           "NORMAL",
@@ -38736,7 +38742,7 @@
       },
       "PlatformPartnerType": {
         "title": "파트너 유형별 추가 정보",
-        "description": "<p>파트너 유형별 추가 정보</p>\n",
+        "description": "파트너 유형별 추가 정보",
         "oneOf": [
           {
             "$ref": "#/components/schemas/PlatformPartnerTypeBusiness"
@@ -38771,7 +38777,7 @@
       },
       "PlatformPartnerTypeBusiness": {
         "title": "사업자 파트너 정보",
-        "description": "<p>사업자 파트너 정보</p>\n<p>사업자 유형의 파트너 추가 정보 입니다.</p>\n",
+        "description": "사업자 파트너 정보\n\n사업자 유형의 파트너 추가 정보 입니다.",
         "type": "object",
         "required": [
           "type",
@@ -38819,11 +38825,11 @@
           }
         },
         "x-portone-title": "사업자 파트너 정보",
-        "x-portone-description": "<p>사업자 유형의 파트너 추가 정보 입니다.</p>\n"
+        "x-portone-description": "사업자 유형의 파트너 추가 정보 입니다."
       },
       "PlatformPartnerTypeNonWhtPayer": {
         "title": "원천징수 비대상자 파트너 정보",
-        "description": "<p>원천징수 비대상자 파트너 정보</p>\n<p>비사업자 유형의 파트너 추가 정보 입니다.</p>\n",
+        "description": "원천징수 비대상자 파트너 정보\n\n비사업자 유형의 파트너 추가 정보 입니다.",
         "type": "object",
         "required": [
           "type"
@@ -38833,18 +38839,18 @@
             "type": "string"
           },
           "birthdate": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "생년월일"
           }
         },
         "x-portone-title": "원천징수 비대상자 파트너 정보",
-        "x-portone-description": "<p>비사업자 유형의 파트너 추가 정보 입니다.</p>\n"
+        "x-portone-description": "비사업자 유형의 파트너 추가 정보 입니다."
       },
       "PlatformPartnerTypeWhtPayer": {
         "title": "원천징수 대상자 파트너 정보",
-        "description": "<p>원천징수 대상자 파트너 정보</p>\n<p>비사업자 유형의 파트너 추가 정보 입니다.</p>\n",
+        "description": "원천징수 대상자 파트너 정보\n\n비사업자 유형의 파트너 추가 정보 입니다.",
         "type": "object",
         "required": [
           "type"
@@ -38854,25 +38860,25 @@
             "type": "string"
           },
           "birthdate": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "생년월일"
           }
         },
         "x-portone-title": "원천징수 대상자 파트너 정보",
-        "x-portone-description": "<p>비사업자 유형의 파트너 추가 정보 입니다.</p>\n"
+        "x-portone-description": "비사업자 유형의 파트너 추가 정보 입니다."
       },
       "PlatformPayer": {
         "title": "금액 부담 주체",
-        "description": "<p>금액 부담 주체</p>\n<p>플랫폼에서 발생한 결제 수수료, 부가세 등 금액을 부담하는 주체를 나타냅니다.</p>\n",
+        "description": "금액 부담 주체\n\n플랫폼에서 발생한 결제 수수료, 부가세 등 금액을 부담하는 주체를 나타냅니다.",
         "type": "string",
         "enum": [
           "PARTNER",
           "MERCHANT"
         ],
         "x-portone-title": "금액 부담 주체",
-        "x-portone-description": "<p>플랫폼에서 발생한 결제 수수료, 부가세 등 금액을 부담하는 주체를 나타냅니다.</p>\n",
+        "x-portone-description": "플랫폼에서 발생한 결제 수수료, 부가세 등 금액을 부담하는 주체를 나타냅니다.",
         "x-portone-enum": {
           "PARTNER": {
             "title": "파트너가 부담하는 경우"
@@ -38884,7 +38890,7 @@
       },
       "PlatformPayment": {
         "title": "결제 정보",
-        "description": "<p>결제 정보</p>\n",
+        "description": "결제 정보",
         "oneOf": [
           {
             "$ref": "#/components/schemas/PlatformExternalPayment"
@@ -38912,7 +38918,7 @@
       },
       "PlatformPaymentChannel": {
         "title": "채널",
-        "description": "<p>채널</p>\n",
+        "description": "채널",
         "type": "object",
         "required": [
           "id",
@@ -38946,7 +38952,7 @@
       },
       "PlatformPaymentMethod": {
         "title": "결제 수단",
-        "description": "<p>결제 수단</p>\n",
+        "description": "결제 수단",
         "oneOf": [
           {
             "$ref": "#/components/schemas/PlatformPaymentMethodCard"
@@ -39002,7 +39008,7 @@
       },
       "PlatformPaymentMethodCard": {
         "title": "카드",
-        "description": "<p>카드</p>\n",
+        "description": "카드",
         "type": "object",
         "required": [
           "type"
@@ -39020,7 +39026,7 @@
       },
       "PlatformPaymentMethodEasyPay": {
         "title": "간편 결제",
-        "description": "<p>간편 결제</p>\n",
+        "description": "간편 결제",
         "type": "object",
         "required": [
           "type"
@@ -39042,7 +39048,7 @@
       },
       "PlatformPaymentMethodEasyPayInput": {
         "title": "간편 결제 입력 정보",
-        "description": "<p>간편 결제 입력 정보</p>\n",
+        "description": "간편 결제 입력 정보",
         "type": "object",
         "properties": {
           "provider": {
@@ -39058,7 +39064,7 @@
       },
       "PlatformPaymentMethodGiftCertificate": {
         "title": "상품권",
-        "description": "<p>상품권</p>\n",
+        "description": "상품권",
         "type": "object",
         "required": [
           "type"
@@ -39076,7 +39082,7 @@
       },
       "PlatformPaymentMethodInput": {
         "title": "결제 수단 입력 정보",
-        "description": "<p>결제 수단 입력 정보</p>\n",
+        "description": "결제 수단 입력 정보",
         "type": "object",
         "properties": {
           "card": {
@@ -39108,7 +39114,7 @@
       },
       "PlatformPaymentMethodMobile": {
         "title": "모바일",
-        "description": "<p>모바일</p>\n",
+        "description": "모바일",
         "type": "object",
         "required": [
           "type"
@@ -39126,7 +39132,7 @@
       },
       "PlatformPaymentMethodTransfer": {
         "title": "계좌이체",
-        "description": "<p>계좌이체</p>\n",
+        "description": "계좌이체",
         "type": "object",
         "required": [
           "type"
@@ -39144,7 +39150,7 @@
       },
       "PlatformPaymentMethodVirtualAccount": {
         "title": "가상계좌",
-        "description": "<p>가상계좌</p>\n",
+        "description": "가상계좌",
         "type": "object",
         "required": [
           "type"
@@ -39318,7 +39324,7 @@
       },
       "PlatformPayoutFilterInputCriteria": {
         "title": "검색 기준 입력 정보",
-        "description": "<p>검색 기준 입력 정보</p>\n",
+        "description": "검색 기준 입력 정보",
         "type": "object",
         "properties": {
           "timestampRange": {
@@ -39421,7 +39427,7 @@
       },
       "PlatformPayoutsSheetField": {
         "title": "다운로드 할 시트 컬럼",
-        "description": "<p>다운로드 할 시트 컬럼</p>\n",
+        "description": "다운로드 할 시트 컬럼",
         "type": "string",
         "enum": [
           "PAYOUT_ID",
@@ -39490,7 +39496,7 @@
           },
           "TAXATION_TYPE_OR_INCOME_TYPE": {
             "title": "과세 유형 또는 소득 유형",
-            "description": "<p>파트너 유형이 사업자인 경우 과세 유형, 원천징수 대상자인 소득 유형입니다.</p>\n"
+            "description": "파트너 유형이 사업자인 경우 과세 유형, 원천징수 대상자인 소득 유형입니다."
           },
           "INCOME_TYPE": {
             "title": "소득 유형"
@@ -39520,7 +39526,7 @@
       },
       "PlatformPortOnePayment": {
         "title": "포트원 결제 정보",
-        "description": "<p>포트원 결제 정보</p>\n",
+        "description": "포트원 결제 정보",
         "type": "object",
         "required": [
           "type",
@@ -39569,7 +39575,7 @@
       },
       "PlatformPortOnePaymentCancelAmountType": {
         "title": "금액 타입",
-        "description": "<p>금액 타입</p>\n",
+        "description": "금액 타입",
         "type": "string",
         "enum": [
           "SUPPLY_WITH_VAT",
@@ -39579,7 +39585,7 @@
         "x-portone-enum": {
           "SUPPLY_WITH_VAT": {
             "title": "공급대가",
-            "description": "<p>공급가액과 부가세를 더한 금액입니다.</p>\n"
+            "description": "공급가액과 부가세를 더한 금액입니다."
           },
           "TAX_FREE": {
             "title": "면세 금액"
@@ -39718,7 +39724,7 @@
       },
       "PlatformRoundType": {
         "title": "금액에 대한 소수점 처리 방식",
-        "description": "<p>금액에 대한 소수점 처리 방식</p>\n",
+        "description": "금액에 대한 소수점 처리 방식",
         "type": "string",
         "enum": [
           "OFF",
@@ -39740,7 +39746,7 @@
       },
       "PlatformSettlementAmountExceededError": {
         "title": "정산 가능한 금액을 초과한 경우",
-        "description": "<p>정산 가능한 금액을 초과한 경우</p>\n",
+        "description": "정산 가능한 금액을 초과한 경우",
         "type": "object",
         "required": [
           "type",
@@ -39758,7 +39764,7 @@
           "productId": {
             "type": "string",
             "title": "상품 아이디",
-            "description": "<p>주문 항목의 상품 아이디입니다.</p>\n"
+            "description": "주문 항목의 상품 아이디입니다."
           },
           "requestedAmount": {
             "type": "integer",
@@ -39776,7 +39782,7 @@
       },
       "PlatformSettlementCancelAmountExceededPortOneCancelError": {
         "title": "정산 취소 요청 금액이 포트원 결제 취소 내역의 취소 금액을 초과한 경우",
-        "description": "<p>정산 취소 요청 금액이 포트원 결제 취소 내역의 취소 금액을 초과한 경우</p>\n",
+        "description": "정산 취소 요청 금액이 포트원 결제 취소 내역의 취소 금액을 초과한 경우",
         "type": "object",
         "required": [
           "type",
@@ -39813,7 +39819,7 @@
       },
       "PlatformSettlementCycle": {
         "title": "정산 주기",
-        "description": "<p>정산 주기</p>\n<p>지체일, 정산일, 기준일로 구성되며, 해당 요소들의 조합으로 실제 정산일을 계산합니다.</p>\n",
+        "description": "정산 주기\n\n지체일, 정산일, 기준일로 구성되며, 해당 요소들의 조합으로 실제 정산일을 계산합니다.",
         "type": "object",
         "required": [
           "lagDays",
@@ -39825,7 +39831,7 @@
             "type": "integer",
             "format": "int32",
             "title": "지체일 (d+n 의 n)",
-            "description": "<p>정산시작일(통상 주문완료일)로부터 더해진 다음 날짜로부터 가장 가까운 날에 정산이 됩니다. 최소 1 에서 최대 10 까지 지정할 수 있습니다.</p>\n"
+            "description": "정산시작일(통상 주문완료일)로부터 더해진 다음 날짜로부터 가장 가까운 날에 정산이 됩니다. 최소 1 에서 최대 10 까지 지정할 수 있습니다."
           },
           "datePolicy": {
             "$ref": "#/components/schemas/PlatformSettlementCycleDatePolicy",
@@ -39837,11 +39843,11 @@
           }
         },
         "x-portone-title": "정산 주기",
-        "x-portone-description": "<p>지체일, 정산일, 기준일로 구성되며, 해당 요소들의 조합으로 실제 정산일을 계산합니다.</p>\n"
+        "x-portone-description": "지체일, 정산일, 기준일로 구성되며, 해당 요소들의 조합으로 실제 정산일을 계산합니다."
       },
       "PlatformSettlementCycleDatePolicy": {
         "title": "플랫폼 정산 기준일",
-        "description": "<p>플랫폼 정산 기준일</p>\n",
+        "description": "플랫폼 정산 기준일",
         "type": "string",
         "enum": [
           "HOLIDAY_BEFORE",
@@ -39863,7 +39869,7 @@
       },
       "PlatformSettlementCycleInput": {
         "title": "플랫폼 정산 주기 입력 정보",
-        "description": "<p>플랫폼 정산 주기 입력 정보</p>\n",
+        "description": "플랫폼 정산 주기 입력 정보",
         "type": "object",
         "required": [
           "lagDays",
@@ -39875,7 +39881,7 @@
             "type": "integer",
             "format": "int32",
             "title": "지체일 (d+n 의 n)",
-            "description": "<p>정산시작일(통상 주문완료일)로부터 더해진 다음 날짜로부터 가장 가까운 날에 정산이 됩니다. 최소 1 에서 최대 10 까지 지정할 수 있습니다.</p>\n"
+            "description": "정산시작일(통상 주문완료일)로부터 더해진 다음 날짜로부터 가장 가까운 날에 정산이 됩니다. 최소 1 에서 최대 10 까지 지정할 수 있습니다."
           },
           "datePolicy": {
             "$ref": "#/components/schemas/PlatformSettlementCycleDatePolicy",
@@ -39890,7 +39896,7 @@
       },
       "PlatformSettlementCycleMethod": {
         "title": "플랫폼 정산 주기 계산 방식",
-        "description": "<p>플랫폼 정산 주기 계산 방식</p>\n",
+        "description": "플랫폼 정산 주기 계산 방식",
         "oneOf": [
           {
             "$ref": "#/components/schemas/PlatformSettlementCycleMethodDaily"
@@ -39932,7 +39938,7 @@
       },
       "PlatformSettlementCycleMethodDaily": {
         "title": "매일 정산",
-        "description": "<p>매일 정산</p>\n",
+        "description": "매일 정산",
         "type": "object",
         "required": [
           "type"
@@ -39950,7 +39956,7 @@
       },
       "PlatformSettlementCycleMethodInput": {
         "title": "플랫폼 정산 주기 계산 방식 입력 정보",
-        "description": "<p>플랫폼 정산 주기 계산 방식 입력 정보</p>\n<p>하나의 하위 필드에만 값을 명시하여 요청합니다.</p>\n",
+        "description": "플랫폼 정산 주기 계산 방식 입력 정보\n\n하나의 하위 필드에만 값을 명시하여 요청합니다.",
         "type": "object",
         "properties": {
           "daily": {
@@ -39971,11 +39977,11 @@
           }
         },
         "x-portone-title": "플랫폼 정산 주기 계산 방식 입력 정보",
-        "x-portone-description": "<p>하나의 하위 필드에만 값을 명시하여 요청합니다.</p>\n"
+        "x-portone-description": "하나의 하위 필드에만 값을 명시하여 요청합니다."
       },
       "PlatformSettlementCycleMethodManualDates": {
         "title": "정해진 날짜(월, 일)에 정산",
-        "description": "<p>정해진 날짜(월, 일)에 정산</p>\n",
+        "description": "정해진 날짜(월, 일)에 정산",
         "type": "object",
         "required": [
           "type",
@@ -40013,7 +40019,7 @@
       },
       "PlatformSettlementCycleMethodMonthly": {
         "title": "매월 정해진 날(일)에 정산",
-        "description": "<p>매월 정해진 날(일)에 정산</p>\n",
+        "description": "매월 정해진 날(일)에 정산",
         "type": "object",
         "required": [
           "type",
@@ -40051,7 +40057,7 @@
       },
       "PlatformSettlementCycleMethodWeekly": {
         "title": "매주 정해진 요일에 정산",
-        "description": "<p>매주 정해진 요일에 정산</p>\n",
+        "description": "매주 정해진 요일에 정산",
         "type": "object",
         "required": [
           "type",
@@ -40089,7 +40095,7 @@
       },
       "PlatformSettlementCycleType": {
         "title": "플랫폼 정산 주기 계산 방식",
-        "description": "<p>플랫폼 정산 주기 계산 방식</p>\n",
+        "description": "플랫폼 정산 주기 계산 방식",
         "type": "string",
         "enum": [
           "DAILY",
@@ -40115,7 +40121,7 @@
       },
       "PlatformSettlementFormula": {
         "title": "플랫폼 내 발생하는 여러 수수료 및 할인 분담에 관한 계산식 정보",
-        "description": "<p>플랫폼 내 발생하는 여러 수수료 및 할인 분담에 관한 계산식 정보</p>\n",
+        "description": "플랫폼 내 발생하는 여러 수수료 및 할인 분담에 관한 계산식 정보",
         "type": "object",
         "required": [
           "platformFee",
@@ -40357,7 +40363,7 @@
       },
       "PlatformSettlementParameterNotFoundError": {
         "title": "정산 파라미터가 존재하지 않는 경우",
-        "description": "<p>정산 파라미터가 존재하지 않는 경우</p>\n",
+        "description": "정산 파라미터가 존재하지 않는 경우",
         "type": "object",
         "required": [
           "type"
@@ -40375,7 +40381,7 @@
       },
       "PlatformSettlementParameterValue": {
         "title": "플랫폼 정산 파라미터 값",
-        "description": "<p>플랫폼 정산 파라미터 값</p>\n",
+        "description": "플랫폼 정산 파라미터 값",
         "type": "object",
         "required": [
           "decimal"
@@ -40390,14 +40396,14 @@
             "type": "integer",
             "format": "int32",
             "title": "소수 자리수",
-            "description": "<p>정산 시 필요한 <code>decimalScale</code>이 지정되지 않은 경우 기본값으로 0을 사용합니다.\n입력 가능한 법위는 0 ~ 5 입니다.</p>\n"
+            "description": "정산 시 필요한 `decimalScale`이 지정되지 않은 경우 기본값으로 0을 사용합니다.\n입력 가능한 법위는 0 ~ 5 입니다."
           }
         },
         "x-portone-title": "플랫폼 정산 파라미터 값"
       },
       "PlatformSettlementPaymentAmountExceededPortOnePaymentError": {
         "title": "정산 요청 결제 금액이 포트원 결제 내역의 결제 금액을 초과한 경우",
-        "description": "<p>정산 요청 결제 금액이 포트원 결제 내역의 결제 금액을 초과한 경우</p>\n",
+        "description": "정산 요청 결제 금액이 포트원 결제 내역의 결제 금액을 초과한 경우",
         "type": "object",
         "required": [
           "type",
@@ -40430,7 +40436,7 @@
       },
       "PlatformSettlementRule": {
         "title": "플랫폼 정산건 처리 방식에 관한 규칙",
-        "description": "<p>플랫폼 정산건 처리 방식에 관한 규칙</p>\n",
+        "description": "플랫폼 정산건 처리 방식에 관한 규칙",
         "type": "object",
         "required": [
           "supportsMultipleOrderTransfersPerPartner",
@@ -40455,7 +40461,7 @@
       },
       "PlatformSettlementSupplyWithVatAmountExceededPortOnePaymentError": {
         "title": "정산 요청 공급대가가 포트원 결제 내역의 공급대가를 초과한 경우",
-        "description": "<p>정산 요청 공급대가가 포트원 결제 내역의 공급대가를 초과한 경우</p>\n",
+        "description": "정산 요청 공급대가가 포트원 결제 내역의 공급대가를 초과한 경우",
         "type": "object",
         "required": [
           "type",
@@ -40488,7 +40494,7 @@
       },
       "PlatformSettlementTaxFreeAmountExceededPortOnePaymentError": {
         "title": "정산 요청 면세 금액이 포트원 결제 내역의 면세 금액을 초과한 경우",
-        "description": "<p>정산 요청 면세 금액이 포트원 결제 내역의 면세 금액을 초과한 경우</p>\n",
+        "description": "정산 요청 면세 금액이 포트원 결제 내역의 면세 금액을 초과한 경우",
         "type": "object",
         "required": [
           "type",
@@ -40521,7 +40527,7 @@
       },
       "PlatformTransfer": {
         "title": "정산건",
-        "description": "<p>정산건</p>\n<p>정산건은 파트너에 정산해줄 정산 금액과 정산 방식 등이 포함되어 있는 정산 정보입니다.\n정산 방식은은 주문 정산, 주문 취소 정산, 수기 정산이 있습니다.</p>\n",
+        "description": "정산건\n\n정산건은 파트너에 정산해줄 정산 금액과 정산 방식 등이 포함되어 있는 정산 정보입니다.\n정산 방식은은 주문 정산, 주문 취소 정산, 수기 정산이 있습니다.",
         "oneOf": [
           {
             "$ref": "#/components/schemas/PlatformManualTransfer"
@@ -40542,7 +40548,7 @@
           }
         },
         "x-portone-title": "정산건",
-        "x-portone-description": "<p>정산건은 파트너에 정산해줄 정산 금액과 정산 방식 등이 포함되어 있는 정산 정보입니다.\n정산 방식은은 주문 정산, 주문 취소 정산, 수기 정산이 있습니다.</p>\n",
+        "x-portone-description": "정산건은 파트너에 정산해줄 정산 금액과 정산 방식 등이 포함되어 있는 정산 정보입니다.\n정산 방식은은 주문 정산, 주문 취소 정산, 수기 정산이 있습니다.",
         "x-portone-discriminator": {
           "MANUAL": {
             "title": "수기 정산건"
@@ -40634,7 +40640,7 @@
       },
       "PlatformTransferFilterInput": {
         "title": "정산건 필터 입력 정보",
-        "description": "<p>정산건 필터 입력 정보</p>\n<p>정산 시작일 범위와 정산 일 범위는 둘 중 하나만 입력 가능합니다.</p>\n",
+        "description": "정산건 필터 입력 정보\n\n정산 시작일 범위와 정산 일 범위는 둘 중 하나만 입력 가능합니다.",
         "type": "object",
         "properties": {
           "settlementStartDateRange": {
@@ -40651,7 +40657,7 @@
               "type": "string"
             },
             "title": "파트너 태그 리스트",
-            "description": "<p>하나 이상의 값이 존재하는 경우 해당 리스트에 포함되는 태그를 하나 이상 가지는 파트너에 대한 정산건만 조회합니다.</p>\n"
+            "description": "하나 이상의 값이 존재하는 경우 해당 리스트에 포함되는 태그를 하나 이상 가지는 파트너에 대한 정산건만 조회합니다."
           },
           "contractIds": {
             "type": "array",
@@ -40659,7 +40665,7 @@
               "type": "string"
             },
             "title": "계약 아이디 리스트",
-            "description": "<p>하나 이상의 값이 존재하는 경우 해당 리스트에 포함되는 계약 아이디를 가지는 정산건만 조회합니다.</p>\n"
+            "description": "하나 이상의 값이 존재하는 경우 해당 리스트에 포함되는 계약 아이디를 가지는 정산건만 조회합니다."
           },
           "discountSharePolicyIds": {
             "type": "array",
@@ -40667,7 +40673,7 @@
               "type": "string"
             },
             "title": "할인 분담 정책 아이디 리스트",
-            "description": "<p>하나 이상의 값이 존재하는 경우 해당 리스트에 포함되는 할인 분담 정책 아이디를 하나 이상 가지는 정산건만 조회합니다.</p>\n"
+            "description": "하나 이상의 값이 존재하는 경우 해당 리스트에 포함되는 할인 분담 정책 아이디를 하나 이상 가지는 정산건만 조회합니다."
           },
           "additionalFeePolicyIds": {
             "type": "array",
@@ -40675,7 +40681,7 @@
               "type": "string"
             },
             "title": "추가 수수료 정책 아이디 리스트",
-            "description": "<p>하나 이상의 값이 존재하는 경우 해당 리스트에 포함되는 추가 수수료 아이디를 하나 이상 가지는 정산건만 조회합니다.</p>\n"
+            "description": "하나 이상의 값이 존재하는 경우 해당 리스트에 포함되는 추가 수수료 아이디를 하나 이상 가지는 정산건만 조회합니다."
           },
           "paymentMethodTypes": {
             "type": "array",
@@ -40683,7 +40689,7 @@
               "$ref": "#/components/schemas/PaymentMethodType"
             },
             "title": "결제 수단 리스트",
-            "description": "<p>하나 이상의 값이 존재하는 경우 해당 리스트에 포함되는 결제 수단을 가지는 파트너만 조회합니다.</p>\n"
+            "description": "하나 이상의 값이 존재하는 경우 해당 리스트에 포함되는 결제 수단을 가지는 파트너만 조회합니다."
           },
           "channelKeys": {
             "type": "array",
@@ -40691,7 +40697,7 @@
               "type": "string"
             },
             "title": "채널 키 리스트",
-            "description": "<p>하나 이상의 값이 존재하는 경우 해당 리스트에 포함되는 채널 키를 가지는 정산건만 조회합니다.</p>\n"
+            "description": "하나 이상의 값이 존재하는 경우 해당 리스트에 포함되는 채널 키를 가지는 정산건만 조회합니다."
           },
           "types": {
             "type": "array",
@@ -40699,7 +40705,7 @@
               "$ref": "#/components/schemas/PlatformTransferType"
             },
             "title": "정산 방식 리스트",
-            "description": "<p>하나 이상의 값이 존재하는 경우 해당 리스트에 포함되는 정산 방식의 정산건만 조회합니다.</p>\n"
+            "description": "하나 이상의 값이 존재하는 경우 해당 리스트에 포함되는 정산 방식의 정산건만 조회합니다."
           },
           "statuses": {
             "title": "정산 상태 리스트",
@@ -40707,7 +40713,7 @@
             "items": {
               "$ref": "#/components/schemas/PlatformTransferStatus"
             },
-            "description": "<p>하나 이상의 값이 존재하는 경우 해당 리스트에 포함되는 정산 상태인 정산건만 조회합니다.</p>\n"
+            "description": "하나 이상의 값이 존재하는 경우 해당 리스트에 포함되는 정산 상태인 정산건만 조회합니다."
           },
           "keyword": {
             "$ref": "#/components/schemas/PlatformTransferFilterInputKeyword",
@@ -40719,52 +40725,52 @@
           }
         },
         "x-portone-title": "정산건 필터 입력 정보",
-        "x-portone-description": "<p>정산 시작일 범위와 정산 일 범위는 둘 중 하나만 입력 가능합니다.</p>\n"
+        "x-portone-description": "정산 시작일 범위와 정산 일 범위는 둘 중 하나만 입력 가능합니다."
       },
       "PlatformTransferFilterInputKeyword": {
         "title": "정산건 검색 키워드 입력 정보",
-        "description": "<p>정산건 검색 키워드 입력 정보</p>\n<p>검색 키워드 적용을 위한 옵션으로, 명시된 키워드를 포함하는 정산건만 조회합니다. 하나의 하위 필드에만 값을 명시하여 요청합니다.</p>\n",
+        "description": "정산건 검색 키워드 입력 정보\n\n검색 키워드 적용을 위한 옵션으로, 명시된 키워드를 포함하는 정산건만 조회합니다. 하나의 하위 필드에만 값을 명시하여 요청합니다.",
         "type": "object",
         "properties": {
           "all": {
             "type": "string",
-            "description": "<p>해당 값이 포함된 정보를 가진 정산건만 조회합니다.</p>\n"
+            "description": "해당 값이 포함된 정보를 가진 정산건만 조회합니다."
           },
           "paymentId": {
             "type": "string",
-            "description": "<p>해당 값이랑 일치하는 paymentId 를 가진 정산건만 조회합니다.</p>\n"
+            "description": "해당 값이랑 일치하는 paymentId 를 가진 정산건만 조회합니다."
           },
           "transferId": {
             "type": "string",
-            "description": "<p>해당 값이랑 일치하는 transferId 를 가진 정산건만 조회합니다.</p>\n"
+            "description": "해당 값이랑 일치하는 transferId 를 가진 정산건만 조회합니다."
           },
           "transferMemo": {
             "type": "string",
-            "description": "<p>해당 값이 포함된 transferMemo 를 가진 정산건만 조회합니다.</p>\n"
+            "description": "해당 값이 포함된 transferMemo 를 가진 정산건만 조회합니다."
           },
           "productId": {
             "type": "string",
-            "description": "<p>해당 값이랑 일치하는 productId 를 가진 정산건만 조회합니다.</p>\n"
+            "description": "해당 값이랑 일치하는 productId 를 가진 정산건만 조회합니다."
           },
           "productName": {
             "type": "string",
-            "description": "<p>해당 값이랑 일치하는 productName 을 가진 정산건만 조회합니다.</p>\n"
+            "description": "해당 값이랑 일치하는 productName 을 가진 정산건만 조회합니다."
           },
           "partnerId": {
             "type": "string",
-            "description": "<p>해당 값이랑 일치하는 partnerId 를 가진 정산건만 조회합니다.</p>\n"
+            "description": "해당 값이랑 일치하는 partnerId 를 가진 정산건만 조회합니다."
           },
           "partnerName": {
             "type": "string",
-            "description": "<p>해당 값이 포함된 partnerName 을 가진 정산건만 조회합니다.</p>\n"
+            "description": "해당 값이 포함된 partnerName 을 가진 정산건만 조회합니다."
           },
           "partnerMemo": {
             "type": "string",
-            "description": "<p>해당 값이 포함된 partnerMemo 를 가진 정산건만 조회합니다.</p>\n"
+            "description": "해당 값이 포함된 partnerMemo 를 가진 정산건만 조회합니다."
           }
         },
         "x-portone-title": "정산건 검색 키워드 입력 정보",
-        "x-portone-description": "<p>검색 키워드 적용을 위한 옵션으로, 명시된 키워드를 포함하는 정산건만 조회합니다. 하나의 하위 필드에만 값을 명시하여 요청합니다.</p>\n"
+        "x-portone-description": "검색 키워드 적용을 위한 옵션으로, 명시된 키워드를 포함하는 정산건만 조회합니다. 하나의 하위 필드에만 값을 명시하여 요청합니다."
       },
       "PlatformTransferFilterOptions": {
         "title": "PlatformTransferFilterOptions",
@@ -40844,7 +40850,7 @@
       },
       "PlatformTransferSheetField": {
         "title": "다운로드 할 시트 컬럼",
-        "description": "<p>다운로드 할 시트 컬럼</p>\n",
+        "description": "다운로드 할 시트 컬럼",
         "type": "string",
         "enum": [
           "STATUS",
@@ -40884,7 +40890,7 @@
         "x-portone-enum": {
           "TAXATION_TYPE_OR_INCOME_TYPE": {
             "title": "과세 유형 또는 소득 유형",
-            "description": "<p>파트너 유형이 사업자인 경우 과세 유형, 원천징수 대상자인 소득 유형입니다.</p>\n"
+            "description": "파트너 유형이 사업자인 경우 과세 유형, 원천징수 대상자인 소득 유형입니다."
           },
           "SETTLEMENT_DISCOUNT_SHARE_AMOUNT": {
             "title": "할인 분담금"
@@ -40924,7 +40930,7 @@
           },
           "SETTLEMENT_TAX_FREE_AMOUNT": {
             "title": "결제 면세액",
-            "description": "<p>해당 필드는 deprecated되어 9월까지만 유지되고 이후 삭제될 예정입니다. 대신 SETTLEMENT_PAYMENT_TAX_FREE_AMOUNT 필드를 사용해주세요.</p>\n"
+            "description": "해당 필드는 deprecated되어 9월까지만 유지되고 이후 삭제될 예정입니다. 대신 SETTLEMENT_PAYMENT_TAX_FREE_AMOUNT 필드를 사용해주세요."
           },
           "SETTLEMENT_ADDITIONAL_FEE_VAT_AMOUNT": {
             "title": "추가 수수료 부가세"
@@ -40961,7 +40967,7 @@
           },
           "SETTLEMENT_SUPPLY_AMOUNT": {
             "title": "결제 공급가액",
-            "description": "<p>해당 필드는 deprecated되어 9월까지만 유지되고 이후 삭제될 예정입니다. 대신 SETTLEMENT_PAYMENT_SUPPLY_AMOUNT 필드를 사용해주세요.</p>\n"
+            "description": "해당 필드는 deprecated되어 9월까지만 유지되고 이후 삭제될 예정입니다. 대신 SETTLEMENT_PAYMENT_SUPPLY_AMOUNT 필드를 사용해주세요."
           },
           "SETTLEMENT_ADDITIONAL_FEE_AMOUNT": {
             "title": "추가 수수료"
@@ -40985,7 +40991,7 @@
       },
       "PlatformTransferStatus": {
         "title": "정산 상태",
-        "description": "<p>정산 상태</p>\n",
+        "description": "정산 상태",
         "type": "string",
         "enum": [
           "SCHEDULED",
@@ -41095,7 +41101,7 @@
       },
       "PlatformTransferSummaryPartnerType": {
         "title": "파트너 유형",
-        "description": "<p>파트너 유형</p>\n",
+        "description": "파트너 유형",
         "type": "string",
         "enum": [
           "BUSINESS",
@@ -41180,7 +41186,7 @@
       },
       "PlatformUserDefinedPropertyKeyValue": {
         "title": "사용자 정의 속성",
-        "description": "<p>사용자 정의 속성</p>\n",
+        "description": "사용자 정의 속성",
         "type": "object",
         "required": [
           "key",
@@ -41200,7 +41206,7 @@
       },
       "PlatformUserDefinedPropertyNotFoundError": {
         "title": "사용자 정의 속성이 존재 하지 않는 경우",
-        "description": "<p>사용자 정의 속성이 존재 하지 않는 경우</p>\n",
+        "description": "사용자 정의 속성이 존재 하지 않는 경우",
         "type": "object",
         "required": [
           "type"
@@ -41230,7 +41236,7 @@
       },
       "PortOneVersion": {
         "title": "포트원 버전",
-        "description": "<p>포트원 버전</p>\n",
+        "description": "포트원 버전",
         "type": "string",
         "enum": [
           "V1",
@@ -41244,13 +41250,13 @@
       },
       "PreRegisterPaymentBody": {
         "title": "결제 정보 사전 등록 입력 정보",
-        "description": "<p>결제 정보 사전 등록 입력 정보</p>\n",
+        "description": "결제 정보 사전 등록 입력 정보",
         "type": "object",
         "properties": {
           "storeId": {
             "type": "string",
             "title": "상점 아이디",
-            "description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다."
           },
           "totalAmount": {
             "type": "integer",
@@ -41297,13 +41303,13 @@
       },
       "PreRegisterPaymentResponse": {
         "title": "결제 사전 등록 성공 응답",
-        "description": "<p>결제 사전 등록 성공 응답</p>\n",
+        "description": "결제 사전 등록 성공 응답",
         "type": "object",
         "x-portone-title": "결제 사전 등록 성공 응답"
       },
       "Promotion": {
         "title": "프로모션",
-        "description": "<p>프로모션</p>\n",
+        "description": "프로모션",
         "oneOf": [
           {
             "$ref": "#/components/schemas/CardPromotion"
@@ -41342,7 +41348,7 @@
       },
       "PromotionCardCompany": {
         "title": "프로모션 적용 가능한 카드사",
-        "description": "<p>프로모션 적용 가능한 카드사</p>\n",
+        "description": "프로모션 적용 가능한 카드사",
         "type": "string",
         "enum": [
           "WOORI_CARD",
@@ -41414,7 +41420,7 @@
       },
       "PromotionNotFoundError": {
         "title": "프로모션이 존재하지 않는 경우",
-        "description": "<p>프로모션이 존재하지 않는 경우</p>\n",
+        "description": "프로모션이 존재하지 않는 경우",
         "type": "object",
         "required": [
           "type"
@@ -41432,7 +41438,7 @@
       },
       "PromotionPayMethodDoesNotMatchError": {
         "title": "결제수단이 프로모션에 지정된 것과 일치하지 않는 경우",
-        "description": "<p>결제수단이 프로모션에 지정된 것과 일치하지 않는 경우</p>\n",
+        "description": "결제수단이 프로모션에 지정된 것과 일치하지 않는 경우",
         "type": "object",
         "required": [
           "type"
@@ -41534,7 +41540,7 @@
       },
       "ReadyIdentityVerification": {
         "title": "준비 상태의 본인인증 내역",
-        "description": "<p>준비 상태의 본인인증 내역</p>\n",
+        "description": "준비 상태의 본인인증 내역",
         "type": "object",
         "required": [
           "status",
@@ -41585,7 +41591,7 @@
       },
       "ReadyPayment": {
         "title": "준비 상태의 결제 건",
-        "description": "<p>준비 상태의 결제 건</p>\n",
+        "description": "준비 상태의 결제 건",
         "type": "object",
         "required": [
           "status",
@@ -41614,7 +41620,7 @@
           "transactionId": {
             "type": "string",
             "title": "결제 건 포트원 채번 아이디",
-            "description": "<p>V1 결제 건의 경우 imp_uid에 해당합니다.</p>\n"
+            "description": "V1 결제 건의 경우 imp_uid에 해당합니다."
           },
           "merchantId": {
             "type": "string",
@@ -41643,12 +41649,12 @@
           "scheduleId": {
             "type": "string",
             "title": "결제 예약 건 아이디",
-            "description": "<p>결제 예약을 이용한 경우에만 존재</p>\n"
+            "description": "결제 예약을 이용한 경우에만 존재"
           },
           "billingKey": {
             "type": "string",
             "title": "결제 시 사용된 빌링키",
-            "description": "<p>빌링키 결제인 경우에만 존재</p>\n"
+            "description": "빌링키 결제인 경우에만 존재"
           },
           "webhooks": {
             "title": "웹훅 발송 내역",
@@ -41699,7 +41705,7 @@
           "escrow": {
             "$ref": "#/components/schemas/PaymentEscrow",
             "title": "에스크로 결제의 배송 정보",
-            "description": "<p>에스크로 결제인 경우 존재합니다.</p>\n"
+            "description": "에스크로 결제인 경우 존재합니다."
           },
           "products": {
             "title": "상품 정보",
@@ -41726,7 +41732,7 @@
       },
       "ReconciliationDateConditionInput": {
         "title": "거래 대사 날짜 범위 조회 필드",
-        "description": "<p>거래 대사 날짜 범위 조회 필드</p>\n<p>필드 중 하나만 적용됩니다.</p>\n",
+        "description": "거래 대사 날짜 범위 조회 필드\n\n필드 중 하나만 적용됩니다.",
         "type": "object",
         "properties": {
           "settlementDateRange": {
@@ -41739,7 +41745,7 @@
           }
         },
         "x-portone-title": "거래 대사 날짜 범위 조회 필드",
-        "x-portone-description": "<p>필드 중 하나만 적용됩니다.</p>\n"
+        "x-portone-description": "필드 중 하나만 적용됩니다."
       },
       "ReconciliationEasyPayMethod": {
         "title": "ReconciliationEasyPayMethod",
@@ -41797,7 +41803,7 @@
       },
       "ReconciliationEasyPayProvider": {
         "title": "대사용 간편 결제 PG사",
-        "description": "<p>대사용 간편 결제 PG사</p>\n",
+        "description": "대사용 간편 결제 PG사",
         "type": "string",
         "enum": [
           "PAYCO",
@@ -41920,7 +41926,7 @@
       },
       "ReconciliationPaymentMethodArs": {
         "title": "ARS 결제",
-        "description": "<p>ARS 결제</p>\n",
+        "description": "ARS 결제",
         "type": "object",
         "required": [
           "type"
@@ -41935,7 +41941,7 @@
       },
       "ReconciliationPaymentMethodCard": {
         "title": "카드 결제",
-        "description": "<p>카드 결제</p>\n",
+        "description": "카드 결제",
         "type": "object",
         "required": [
           "type"
@@ -41967,7 +41973,7 @@
       },
       "ReconciliationPaymentMethodCharge": {
         "title": "간편결제 충전",
-        "description": "<p>간편결제 충전</p>\n",
+        "description": "간편결제 충전",
         "type": "object",
         "required": [
           "type"
@@ -41982,7 +41988,7 @@
       },
       "ReconciliationPaymentMethodEasyPay": {
         "title": "간편 결제",
-        "description": "<p>간편 결제</p>\n",
+        "description": "간편 결제",
         "type": "object",
         "required": [
           "type"
@@ -42005,7 +42011,7 @@
       },
       "ReconciliationPaymentMethodEtc": {
         "title": "기타 결제",
-        "description": "<p>기타 결제</p>\n",
+        "description": "기타 결제",
         "type": "object",
         "required": [
           "type",
@@ -42025,7 +42031,7 @@
       },
       "ReconciliationPaymentMethodGiftCertificate": {
         "title": "상품권 결제",
-        "description": "<p>상품권 결제</p>\n",
+        "description": "상품권 결제",
         "type": "object",
         "required": [
           "type"
@@ -42048,7 +42054,7 @@
       },
       "ReconciliationPaymentMethodMobile": {
         "title": "모바일 결제",
-        "description": "<p>모바일 결제</p>\n",
+        "description": "모바일 결제",
         "type": "object",
         "required": [
           "type"
@@ -42067,7 +42073,7 @@
       },
       "ReconciliationPaymentMethodTransfer": {
         "title": "계좌이체",
-        "description": "<p>계좌이체</p>\n",
+        "description": "계좌이체",
         "type": "object",
         "required": [
           "type"
@@ -42090,7 +42096,7 @@
       },
       "ReconciliationPaymentMethodType": {
         "title": "대사용 결제수단 목록",
-        "description": "<p>대사용 결제수단 목록</p>\n",
+        "description": "대사용 결제수단 목록",
         "type": "string",
         "enum": [
           "CARD",
@@ -42212,7 +42218,7 @@
       },
       "ReconciliationPaymentMethodVirtualAccount": {
         "title": "가상계좌 결제",
-        "description": "<p>가상계좌 결제</p>\n",
+        "description": "가상계좌 결제",
         "type": "object",
         "required": [
           "type"
@@ -42267,7 +42273,7 @@
       },
       "ReconciliationPgSpecifier": {
         "title": "대사용 PG사 가맹점 식별자",
-        "description": "<p>대사용 PG사 가맹점 식별자</p>\n",
+        "description": "대사용 PG사 가맹점 식별자",
         "type": "object",
         "required": [
           "pgMerchantId",
@@ -42317,7 +42323,7 @@
       },
       "RecoverPlatformAdditionalFeePolicyResponse": {
         "title": "추가 수수료 정책 복원 성공 응답",
-        "description": "<p>추가 수수료 정책 복원 성공 응답</p>\n",
+        "description": "추가 수수료 정책 복원 성공 응답",
         "type": "object",
         "required": [
           "additionalFeePolicy"
@@ -42362,7 +42368,7 @@
       },
       "RecoverPlatformContractResponse": {
         "title": "계약 복원 성공 응답",
-        "description": "<p>계약 복원 성공 응답</p>\n",
+        "description": "계약 복원 성공 응답",
         "type": "object",
         "required": [
           "contract"
@@ -42407,7 +42413,7 @@
       },
       "RecoverPlatformDiscountSharePolicyResponse": {
         "title": "할인 분담 복원 성공 응답",
-        "description": "<p>할인 분담 복원 성공 응답</p>\n",
+        "description": "할인 분담 복원 성공 응답",
         "type": "object",
         "required": [
           "discountSharePolicy"
@@ -42452,7 +42458,7 @@
       },
       "RecoverPlatformPartnerResponse": {
         "title": "파트너 복원 성공 응답",
-        "description": "<p>파트너 복원 성공 응답</p>\n",
+        "description": "파트너 복원 성공 응답",
         "type": "object",
         "required": [
           "partner"
@@ -42467,7 +42473,7 @@
       },
       "RefreshTokenBody": {
         "title": "토큰 재발급을 위한 입력 정보",
-        "description": "<p>토큰 재발급을 위한 입력 정보</p>\n",
+        "description": "토큰 재발급을 위한 입력 정보",
         "type": "object",
         "required": [
           "refreshToken"
@@ -42500,7 +42506,7 @@
       },
       "RefreshTokenResponse": {
         "title": "토큰 재발급 성공 응답",
-        "description": "<p>토큰 재발급 성공 응답</p>\n",
+        "description": "토큰 재발급 성공 응답",
         "type": "object",
         "required": [
           "accessToken",
@@ -42510,19 +42516,19 @@
           "accessToken": {
             "type": "string",
             "title": "인증에 사용하는 엑세스 토큰",
-            "description": "<p>하루의 유효기간을 가지고 있습니다.</p>\n"
+            "description": "하루의 유효기간을 가지고 있습니다."
           },
           "refreshToken": {
             "type": "string",
             "title": "토큰 재발급 및 유효기간 연장을 위해 사용하는 리프레시 토큰",
-            "description": "<p>일주일의 유효기간을 가지고 있으며, 리프레시 토큰을 통해 유효기간이 연장된 새로운 엑세스 토큰을 발급받을 수 있습니다.</p>\n"
+            "description": "일주일의 유효기간을 가지고 있으며, 리프레시 토큰을 통해 유효기간이 연장된 새로운 엑세스 토큰을 발급받을 수 있습니다."
           }
         },
         "x-portone-title": "토큰 재발급 성공 응답"
       },
       "RefuseB2bTaxInvoiceRequestBody": {
         "title": "세금계산서 역발행 요청 거부 정보",
-        "description": "<p>세금계산서 역발행 요청 거부 정보</p>\n",
+        "description": "세금계산서 역발행 요청 거부 정보",
         "type": "object",
         "required": [
           "brn",
@@ -42540,7 +42546,7 @@
           "documentKeyType": {
             "$ref": "#/components/schemas/B2bTaxInvoiceDocumentKeyType",
             "title": "문서 번호 유형",
-            "description": "<p>기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.</p>\n"
+            "description": "기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다."
           },
           "memo": {
             "type": "string",
@@ -42589,7 +42595,7 @@
       },
       "RegisterB2bMemberCompanyBody": {
         "title": "사업자 연동 요청 정보",
-        "description": "<p>사업자 연동 요청 정보</p>\n",
+        "description": "사업자 연동 요청 정보",
         "type": "object",
         "required": [
           "company",
@@ -42643,7 +42649,7 @@
       },
       "RegisterB2bMemberCompanyResponse": {
         "title": "사업자 연동 응답 정보",
-        "description": "<p>사업자 연동 응답 정보</p>\n",
+        "description": "사업자 연동 응답 정보",
         "type": "object",
         "required": [
           "company",
@@ -42663,7 +42669,7 @@
       },
       "RegisterEscrowLogisticsBody": {
         "title": "에스크로 배송 정보 등록 입력 정보",
-        "description": "<p>에스크로 배송 정보 등록 입력 정보</p>\n",
+        "description": "에스크로 배송 정보 등록 입력 정보",
         "type": "object",
         "required": [
           "logistics"
@@ -42672,7 +42678,7 @@
           "storeId": {
             "type": "string",
             "title": "상점 아이디",
-            "description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다."
           },
           "sender": {
             "$ref": "#/components/schemas/PaymentEscrowSenderInput",
@@ -42689,7 +42695,7 @@
           "sendEmail": {
             "type": "boolean",
             "title": "이메일 알림 전송 여부",
-            "description": "<p>에스크로 구매 확정 시 이메일로 알림을 보낼지 여부입니다.</p>\n"
+            "description": "에스크로 구매 확정 시 이메일로 알림을 보낼지 여부입니다."
           },
           "products": {
             "title": "상품 정보",
@@ -42703,7 +42709,7 @@
       },
       "RegisterStoreReceiptBody": {
         "title": "영수증 내 하위 상점 거래 등록 정보",
-        "description": "<p>영수증 내 하위 상점 거래 등록 정보</p>\n",
+        "description": "영수증 내 하위 상점 거래 등록 정보",
         "type": "object",
         "required": [
           "items"
@@ -42725,7 +42731,7 @@
       },
       "RegisterStoreReceiptBodyItem": {
         "title": "하위 상점 거래 정보",
-        "description": "<p>하위 상점 거래 정보</p>\n",
+        "description": "하위 상점 거래 정보",
         "type": "object",
         "required": [
           "storeBusinessRegistrationNumber",
@@ -42805,7 +42811,7 @@
       },
       "RegisterStoreReceiptResponse": {
         "title": "영수증 내 하위 상점 거래 등록 응답",
-        "description": "<p>영수증 내 하위 상점 거래 등록 응답</p>\n",
+        "description": "영수증 내 하위 상점 거래 등록 응답",
         "type": "object",
         "properties": {
           "receiptUrl": {
@@ -42817,7 +42823,7 @@
       },
       "RegisteredPaymentEscrow": {
         "title": "배송 정보 등록 완료",
-        "description": "<p>배송 정보 등록 완료</p>\n",
+        "description": "배송 정보 등록 완료",
         "type": "object",
         "required": [
           "status",
@@ -42852,7 +42858,7 @@
       },
       "RejectConfirmedPaymentEscrow": {
         "title": "구매 거절 확정",
-        "description": "<p>구매 거절 확정</p>\n",
+        "description": "구매 거절 확정",
         "type": "object",
         "required": [
           "status",
@@ -42887,7 +42893,7 @@
       },
       "RejectPlatformPartnerBody": {
         "title": "파트너 상태를 승인 거절로 변경하기 위한 입력 정보",
-        "description": "<p>파트너 상태를 승인 거절로 변경하기 위한 입력 정보</p>\n",
+        "description": "파트너 상태를 승인 거절로 변경하기 위한 입력 정보",
         "type": "object",
         "properties": {
           "memo": {
@@ -42933,7 +42939,7 @@
       },
       "RejectPlatformPartnerResponse": {
         "title": "파트너 거절 성공 응답",
-        "description": "<p>파트너 거절 성공 응답</p>\n",
+        "description": "파트너 거절 성공 응답",
         "type": "object",
         "required": [
           "partner"
@@ -42948,7 +42954,7 @@
       },
       "RejectedPaymentEscrow": {
         "title": "구매 거절",
-        "description": "<p>구매 거절</p>\n",
+        "description": "구매 거절",
         "type": "object",
         "required": [
           "status",
@@ -42983,7 +42989,7 @@
       },
       "RemainedAmountLessThanPromotionMinPaymentAmountError": {
         "title": "부분 취소 시, 취소하게 될 경우 남은 금액이 프로모션의 최소 결제 금액보다 작아지는 경우",
-        "description": "<p>부분 취소 시, 취소하게 될 경우 남은 금액이 프로모션의 최소 결제 금액보다 작아지는 경우</p>\n",
+        "description": "부분 취소 시, 취소하게 될 경우 남은 금액이 프로모션의 최소 결제 금액보다 작아지는 경우",
         "type": "object",
         "required": [
           "type"
@@ -43001,7 +43007,7 @@
       },
       "RequestB2bTaxInvoiceRegisterBody": {
         "title": "세금계산서 임시 저장 정보",
-        "description": "<p>세금계산서 임시 저장 정보</p>\n",
+        "description": "세금계산서 임시 저장 정보",
         "type": "object",
         "required": [
           "taxInvoice"
@@ -43050,7 +43056,7 @@
       },
       "RequestB2bTaxInvoiceRequestBody": {
         "title": "세금계산서 역발행 요청 정보",
-        "description": "<p>세금계산서 역발행 요청 정보</p>\n",
+        "description": "세금계산서 역발행 요청 정보",
         "type": "object",
         "required": [
           "brn",
@@ -43068,7 +43074,7 @@
           "documentKeyType": {
             "$ref": "#/components/schemas/B2bTaxInvoiceDocumentKeyType",
             "title": "문서 번호 유형",
-            "description": "<p>기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다.</p>\n"
+            "description": "기본 값은 RECIPIENT이며 SUPPLIER, RECIPIENT을 지원합니다."
           },
           "memo": {
             "type": "string",
@@ -43113,7 +43119,7 @@
       },
       "RequestB2bTaxInvoiceReverseIssuanceRequestBody": {
         "title": "세금계산서 역발행 요청 정보",
-        "description": "<p>세금계산서 역발행 요청 정보</p>\n",
+        "description": "세금계산서 역발행 요청 정보",
         "type": "object",
         "required": [
           "taxInvoice"
@@ -43132,7 +43138,7 @@
       },
       "RequestedPaymentCancellation": {
         "title": "취소 요청 상태",
-        "description": "<p>취소 요청 상태</p>\n",
+        "description": "취소 요청 상태",
         "type": "object",
         "required": [
           "status",
@@ -43315,7 +43321,7 @@
       },
       "ReschedulePlatformAdditionalFeePolicyBody": {
         "title": "추가 수수료 정책 예약 업데이트 재설정을 위한 입력 정보",
-        "description": "<p>추가 수수료 정책 예약 업데이트 재설정을 위한 입력 정보</p>\n",
+        "description": "추가 수수료 정책 예약 업데이트 재설정을 위한 입력 정보",
         "type": "object",
         "required": [
           "update",
@@ -43336,7 +43342,7 @@
       },
       "ReschedulePlatformAdditionalFeePolicyResponse": {
         "title": "추가 수수료 정책 예약 업데이트 재설정 성공 응답",
-        "description": "<p>추가 수수료 정책 예약 업데이트 재설정 성공 응답</p>\n",
+        "description": "추가 수수료 정책 예약 업데이트 재설정 성공 응답",
         "type": "object",
         "required": [
           "scheduledAdditionalFeePolicy"
@@ -43351,7 +43357,7 @@
       },
       "ReschedulePlatformContractBody": {
         "title": "계약 예약 업데이트 재설정을 위한 입력 정보",
-        "description": "<p>계약 예약 업데이트 재설정을 위한 입력 정보</p>\n",
+        "description": "계약 예약 업데이트 재설정을 위한 입력 정보",
         "type": "object",
         "required": [
           "update",
@@ -43372,7 +43378,7 @@
       },
       "ReschedulePlatformContractResponse": {
         "title": "계약 예약 업데이트 재설정 성공 응답",
-        "description": "<p>계약 예약 업데이트 재설정 성공 응답</p>\n",
+        "description": "계약 예약 업데이트 재설정 성공 응답",
         "type": "object",
         "required": [
           "scheduledContract"
@@ -43387,7 +43393,7 @@
       },
       "ReschedulePlatformDiscountSharePolicyBody": {
         "title": "할인 분담 정책 예약 업데이트 재설정을 위한 입력 정보",
-        "description": "<p>할인 분담 정책 예약 업데이트 재설정을 위한 입력 정보</p>\n",
+        "description": "할인 분담 정책 예약 업데이트 재설정을 위한 입력 정보",
         "type": "object",
         "required": [
           "update",
@@ -43408,7 +43414,7 @@
       },
       "ReschedulePlatformDiscountSharePolicyResponse": {
         "title": "할인 분담 정책 예약 업데이트 재설정 성공 응답",
-        "description": "<p>할인 분담 정책 예약 업데이트 재설정 성공 응답</p>\n",
+        "description": "할인 분담 정책 예약 업데이트 재설정 성공 응답",
         "type": "object",
         "required": [
           "scheduledDiscountSharePolicy"
@@ -43423,7 +43429,7 @@
       },
       "ReschedulePlatformPartnerBody": {
         "title": "파트너 예약 업데이트 재설정을 위한 입력 정보",
-        "description": "<p>파트너 예약 업데이트 재설정을 위한 입력 정보</p>\n",
+        "description": "파트너 예약 업데이트 재설정을 위한 입력 정보",
         "type": "object",
         "required": [
           "update",
@@ -43444,7 +43450,7 @@
       },
       "ReschedulePlatformPartnerResponse": {
         "title": "파트너 예약 업데이트 재설정 성공 응답",
-        "description": "<p>파트너 예약 업데이트 재설정 성공 응답</p>\n",
+        "description": "파트너 예약 업데이트 재설정 성공 응답",
         "type": "object",
         "required": [
           "scheduledPartner"
@@ -43497,27 +43503,27 @@
       },
       "ResendIdentityVerificationResponse": {
         "title": "본인인증 요청 재전송 성공 응답",
-        "description": "<p>본인인증 요청 재전송 성공 응답</p>\n",
+        "description": "본인인증 요청 재전송 성공 응답",
         "type": "object",
         "x-portone-title": "본인인증 요청 재전송 성공 응답"
       },
       "ResendWebhookBody": {
         "title": "ResendWebhookBody",
-        "description": "<p>웹훅 재발송을 위한 입력 정보</p>\n",
+        "description": "웹훅 재발송을 위한 입력 정보",
         "type": "object",
         "properties": {
           "storeId": {
             "type": "string",
             "title": "상점 아이디",
-            "description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다."
           },
           "webhookId": {
             "type": "string",
             "title": "웹훅 아이디",
-            "description": "<p>입력하지 않으면 결제 건의 가장 최근 웹훅 아이디가 기본 적용됩니다</p>\n"
+            "description": "입력하지 않으면 결제 건의 가장 최근 웹훅 아이디가 기본 적용됩니다"
           }
         },
-        "x-portone-description": "<p>웹훅 재발송을 위한 입력 정보</p>\n"
+        "x-portone-description": "웹훅 재발송을 위한 입력 정보"
       },
       "ResendWebhookError": {
         "title": "ResendWebhookError",
@@ -43551,7 +43557,7 @@
       },
       "ResendWebhookResponse": {
         "title": "웹훅 재발송 응답 정보",
-        "description": "<p>웹훅 재발송 응답 정보</p>\n",
+        "description": "웹훅 재발송 응답 정보",
         "type": "object",
         "required": [
           "webhook"
@@ -43566,13 +43572,13 @@
       },
       "RevokePaymentSchedulesBody": {
         "title": "결제 예약 건 취소 요청 입력 정보",
-        "description": "<p>결제 예약 건 취소 요청 입력 정보</p>\n<p>billingKey, scheduleIds 중 하나 이상은 필수로 입력합니다.\nbillingKey 만 입력된 경우 -&gt; 해당 빌링키로 예약된 모든 결제 예약 건들이 취소됩니다.\nscheduleIds 만 입력된 경우 -&gt; 입력된 결제 예약 건 아이디에 해당하는 예약 건들이 취소됩니다.\nbillingKey, scheduleIds 모두 입력된 경우 -&gt; 입력된 결제 예약 건 아이디에 해당하는 예약 건들이 취소됩니다. 그리고 예약한 빌링키가 입력된 빌링키와 일치하는지 검증합니다.\n위 정책에 따라 선택된 결제 예약 건들 중 하나라도 취소에 실패할 경우, 모든 취소 요청이 실패합니다.</p>\n",
+        "description": "결제 예약 건 취소 요청 입력 정보\n\nbillingKey, scheduleIds 중 하나 이상은 필수로 입력합니다.\nbillingKey 만 입력된 경우 -> 해당 빌링키로 예약된 모든 결제 예약 건들이 취소됩니다.\nscheduleIds 만 입력된 경우 -> 입력된 결제 예약 건 아이디에 해당하는 예약 건들이 취소됩니다.\nbillingKey, scheduleIds 모두 입력된 경우 -> 입력된 결제 예약 건 아이디에 해당하는 예약 건들이 취소됩니다. 그리고 예약한 빌링키가 입력된 빌링키와 일치하는지 검증합니다.\n위 정책에 따라 선택된 결제 예약 건들 중 하나라도 취소에 실패할 경우, 모든 취소 요청이 실패합니다.",
         "type": "object",
         "properties": {
           "storeId": {
             "type": "string",
             "title": "상점 아이디",
-            "description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다."
           },
           "billingKey": {
             "type": "string",
@@ -43587,7 +43593,7 @@
           }
         },
         "x-portone-title": "결제 예약 건 취소 요청 입력 정보",
-        "x-portone-description": "<p>billingKey, scheduleIds 중 하나 이상은 필수로 입력합니다.\nbillingKey 만 입력된 경우 -&gt; 해당 빌링키로 예약된 모든 결제 예약 건들이 취소됩니다.\nscheduleIds 만 입력된 경우 -&gt; 입력된 결제 예약 건 아이디에 해당하는 예약 건들이 취소됩니다.\nbillingKey, scheduleIds 모두 입력된 경우 -&gt; 입력된 결제 예약 건 아이디에 해당하는 예약 건들이 취소됩니다. 그리고 예약한 빌링키가 입력된 빌링키와 일치하는지 검증합니다.\n위 정책에 따라 선택된 결제 예약 건들 중 하나라도 취소에 실패할 경우, 모든 취소 요청이 실패합니다.</p>\n"
+        "x-portone-description": "billingKey, scheduleIds 중 하나 이상은 필수로 입력합니다.\nbillingKey 만 입력된 경우 -> 해당 빌링키로 예약된 모든 결제 예약 건들이 취소됩니다.\nscheduleIds 만 입력된 경우 -> 입력된 결제 예약 건 아이디에 해당하는 예약 건들이 취소됩니다.\nbillingKey, scheduleIds 모두 입력된 경우 -> 입력된 결제 예약 건 아이디에 해당하는 예약 건들이 취소됩니다. 그리고 예약한 빌링키가 입력된 빌링키와 일치하는지 검증합니다.\n위 정책에 따라 선택된 결제 예약 건들 중 하나라도 취소에 실패할 경우, 모든 취소 요청이 실패합니다."
       },
       "RevokePaymentSchedulesError": {
         "title": "RevokePaymentSchedulesError",
@@ -43633,7 +43639,7 @@
       },
       "RevokePaymentSchedulesResponse": {
         "title": "결제 예약 건 취소 성공 응답",
-        "description": "<p>결제 예약 건 취소 성공 응답</p>\n",
+        "description": "결제 예약 건 취소 성공 응답",
         "type": "object",
         "required": [
           "revokedScheduleIds"
@@ -43656,7 +43662,7 @@
       },
       "RevokedPaymentSchedule": {
         "title": "결제 예약 취소 상태",
-        "description": "<p>결제 예약 취소 상태</p>\n",
+        "description": "결제 예약 취소 상태",
         "type": "object",
         "required": [
           "status",
@@ -43947,7 +43953,7 @@
       },
       "SchedulePlatformAdditionalFeePolicyBody": {
         "title": "추가 수수료 정책 업데이트 예약을 위한 입력 정보",
-        "description": "<p>추가 수수료 정책 업데이트 예약을 위한 입력 정보</p>\n",
+        "description": "추가 수수료 정책 업데이트 예약을 위한 입력 정보",
         "type": "object",
         "required": [
           "update",
@@ -43968,7 +43974,7 @@
       },
       "SchedulePlatformAdditionalFeePolicyResponse": {
         "title": "추가 수수료 정책 업데이트 예약 성공 응답",
-        "description": "<p>추가 수수료 정책 업데이트 예약 성공 응답</p>\n",
+        "description": "추가 수수료 정책 업데이트 예약 성공 응답",
         "type": "object",
         "required": [
           "scheduledAdditionalFeePolicy"
@@ -43983,7 +43989,7 @@
       },
       "SchedulePlatformContractBody": {
         "title": "계약 업데이트 예약을 위한 입력 정보",
-        "description": "<p>계약 업데이트 예약을 위한 입력 정보</p>\n",
+        "description": "계약 업데이트 예약을 위한 입력 정보",
         "type": "object",
         "required": [
           "update",
@@ -44004,7 +44010,7 @@
       },
       "SchedulePlatformContractResponse": {
         "title": "계약 업데이트 예약 성공 응답",
-        "description": "<p>계약 업데이트 예약 성공 응답</p>\n",
+        "description": "계약 업데이트 예약 성공 응답",
         "type": "object",
         "required": [
           "scheduledContract"
@@ -44019,7 +44025,7 @@
       },
       "SchedulePlatformDiscountSharePolicyBody": {
         "title": "할인 분담 정책 업데이트 예약을 위한 입력 정보",
-        "description": "<p>할인 분담 정책 업데이트 예약을 위한 입력 정보</p>\n",
+        "description": "할인 분담 정책 업데이트 예약을 위한 입력 정보",
         "type": "object",
         "required": [
           "update",
@@ -44040,7 +44046,7 @@
       },
       "SchedulePlatformDiscountSharePolicyResponse": {
         "title": "할인 분담 정책 업데이트 예약 성공 응답",
-        "description": "<p>할인 분담 정책 업데이트 예약 성공 응답</p>\n",
+        "description": "할인 분담 정책 업데이트 예약 성공 응답",
         "type": "object",
         "required": [
           "scheduledDiscountSharePolicy"
@@ -44055,7 +44061,7 @@
       },
       "SchedulePlatformPartnerBody": {
         "title": "파트너 업데이트 예약을 위한 입력 정보",
-        "description": "<p>파트너 업데이트 예약을 위한 입력 정보</p>\n",
+        "description": "파트너 업데이트 예약을 위한 입력 정보",
         "type": "object",
         "required": [
           "update",
@@ -44076,7 +44082,7 @@
       },
       "SchedulePlatformPartnerResponse": {
         "title": "파트너 업데이트 예약 성공 응답",
-        "description": "<p>파트너 업데이트 예약 성공 응답</p>\n",
+        "description": "파트너 업데이트 예약 성공 응답",
         "type": "object",
         "required": [
           "scheduledPartner"
@@ -44144,7 +44150,7 @@
       },
       "SchedulePlatformPartnersBodyUpdateAccount": {
         "title": "파트너 계좌 업데이트를 위한 입력 정보",
-        "description": "<p>파트너 계좌 업데이트를 위한 입력 정보</p>\n",
+        "description": "파트너 계좌 업데이트를 위한 입력 정보",
         "type": "object",
         "required": [
           "bank",
@@ -44178,7 +44184,7 @@
       },
       "SchedulePlatformPartnersBodyUpdateContact": {
         "title": "파트너 업데이트를 위한 유형별 추가 정보",
-        "description": "<p>파트너 업데이트를 위한 유형별 추가 정보</p>\n",
+        "description": "파트너 업데이트를 위한 유형별 추가 정보",
         "type": "object",
         "properties": {
           "name": {
@@ -44198,7 +44204,7 @@
       },
       "SchedulePlatformPartnersBodyUpdateType": {
         "title": "파트너 유형별 정보 업데이트를 위한 입력 정보",
-        "description": "<p>파트너 유형별 정보 업데이트를 위한 입력 정보</p>\n<p>파트너 유형별 추가 정보를 수정합니다.\n최초 생성된 유형 내에서 세부 정보만 수정할 수 있고 파트너의 유형 자체를 수정할 수는 없습니다.</p>\n",
+        "description": "파트너 유형별 정보 업데이트를 위한 입력 정보\n\n파트너 유형별 추가 정보를 수정합니다.\n최초 생성된 유형 내에서 세부 정보만 수정할 수 있고 파트너의 유형 자체를 수정할 수는 없습니다.",
         "type": "object",
         "properties": {
           "business": {
@@ -44215,7 +44221,7 @@
           }
         },
         "x-portone-title": "파트너 유형별 정보 업데이트를 위한 입력 정보",
-        "x-portone-description": "<p>파트너 유형별 추가 정보를 수정합니다.\n최초 생성된 유형 내에서 세부 정보만 수정할 수 있고 파트너의 유형 자체를 수정할 수는 없습니다.</p>\n"
+        "x-portone-description": "파트너 유형별 추가 정보를 수정합니다.\n최초 생성된 유형 내에서 세부 정보만 수정할 수 있고 파트너의 유형 자체를 수정할 수는 없습니다."
       },
       "SchedulePlatformPartnersBodyUpdateTypeBusiness": {
         "title": "SchedulePlatformPartnersBodyUpdateTypeBusiness",
@@ -44256,9 +44262,9 @@
         "type": "object",
         "properties": {
           "birthdate": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "생년월일"
           }
         }
@@ -44268,9 +44274,9 @@
         "type": "object",
         "properties": {
           "birthdate": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "생년월일"
           }
         }
@@ -44323,7 +44329,7 @@
       },
       "ScheduledPaymentSchedule": {
         "title": "결제 예약 완료 상태",
-        "description": "<p>결제 예약 완료 상태</p>\n",
+        "description": "결제 예약 완료 상태",
         "type": "object",
         "required": [
           "status",
@@ -44440,7 +44446,7 @@
       },
       "SelectedChannel": {
         "title": "(결제, 본인인증 등에) 선택된 채널 정보",
-        "description": "<p>(결제, 본인인증 등에) 선택된 채널 정보</p>\n",
+        "description": "(결제, 본인인증 등에) 선택된 채널 정보",
         "type": "object",
         "required": [
           "type",
@@ -44477,7 +44483,7 @@
       },
       "SelectedChannelType": {
         "title": "채널 타입",
-        "description": "<p>채널 타입</p>\n",
+        "description": "채널 타입",
         "type": "string",
         "enum": [
           "LIVE",
@@ -44495,7 +44501,7 @@
       },
       "SendIdentityVerificationBody": {
         "title": "본인인증 요청을 위한 입력 정보",
-        "description": "<p>본인인증 요청을 위한 입력 정보</p>\n",
+        "description": "본인인증 요청을 위한 입력 정보",
         "type": "object",
         "required": [
           "channelKey",
@@ -44507,7 +44513,7 @@
           "storeId": {
             "type": "string",
             "title": "상점 아이디",
-            "description": "<p>접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다.</p>\n"
+            "description": "접근 권한이 있는 상점 아이디만 입력 가능하며, 미입력시 토큰에 담긴 상점 아이디를 사용합니다."
           },
           "channelKey": {
             "type": "string",
@@ -44538,7 +44544,7 @@
       },
       "SendIdentityVerificationBodyCustomer": {
         "title": "본인인증 요청을 위한 고객 정보",
-        "description": "<p>본인인증 요청을 위한 고객 정보</p>\n",
+        "description": "본인인증 요청을 위한 고객 정보",
         "type": "object",
         "required": [
           "name",
@@ -44557,17 +44563,17 @@
           "phoneNumber": {
             "type": "string",
             "title": "전화번호",
-            "description": "<p>특수 문자(-) 없이 숫자만 입력합니다.</p>\n"
+            "description": "특수 문자(-) 없이 숫자만 입력합니다."
           },
           "identityNumber": {
             "type": "string",
             "title": "주민등록번호 앞 7자리",
-            "description": "<p>SMS 방식의 경우 필수로 입력합니다.</p>\n"
+            "description": "SMS 방식의 경우 필수로 입력합니다."
           },
           "ipAddress": {
             "type": "string",
             "title": "IP 주소",
-            "description": "<p>고객의 요청 속도 제한에 사용됩니다.</p>\n"
+            "description": "고객의 요청 속도 제한에 사용됩니다."
           }
         },
         "x-portone-title": "본인인증 요청을 위한 고객 정보"
@@ -44616,13 +44622,13 @@
       },
       "SendIdentityVerificationResponse": {
         "title": "본인인증 요청 전송 성공 응답",
-        "description": "<p>본인인증 요청 전송 성공 응답</p>\n",
+        "description": "본인인증 요청 전송 성공 응답",
         "type": "object",
         "x-portone-title": "본인인증 요청 전송 성공 응답"
       },
       "SeparatedAddress": {
         "title": "분리 형식 주소",
-        "description": "<p>분리 형식 주소</p>\n<p>한 줄 형식 주소와 분리 형식 주소 모두 존재합니다.\n한 줄 형식 주소는 분리 형식 주소를 이어 붙인 형태로 생성됩니다.</p>\n",
+        "description": "분리 형식 주소\n\n한 줄 형식 주소와 분리 형식 주소 모두 존재합니다.\n한 줄 형식 주소는 분리 형식 주소를 이어 붙인 형태로 생성됩니다.",
         "type": "object",
         "required": [
           "type",
@@ -44660,11 +44666,11 @@
           }
         },
         "x-portone-title": "분리 형식 주소",
-        "x-portone-description": "<p>한 줄 형식 주소와 분리 형식 주소 모두 존재합니다.\n한 줄 형식 주소는 분리 형식 주소를 이어 붙인 형태로 생성됩니다.</p>\n"
+        "x-portone-description": "한 줄 형식 주소와 분리 형식 주소 모두 존재합니다.\n한 줄 형식 주소는 분리 형식 주소를 이어 붙인 형태로 생성됩니다."
       },
       "SeparatedAddressInput": {
         "title": "분리 형식 주소 입력 정보",
-        "description": "<p>분리 형식 주소 입력 정보</p>\n",
+        "description": "분리 형식 주소 입력 정보",
         "type": "object",
         "required": [
           "addressLine1",
@@ -44696,7 +44702,7 @@
       },
       "Settlement": {
         "title": "정산 정보",
-        "description": "<p>정산 정보</p>\n",
+        "description": "정산 정보",
         "type": "object",
         "required": [
           "feeAmount",
@@ -44726,9 +44732,9 @@
             "title": "정산 통화"
           },
           "settlementDate": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "정산일"
           }
         },
@@ -44736,7 +44742,7 @@
       },
       "SortOrder": {
         "title": "정렬 방식",
-        "description": "<p>정렬 방식</p>\n",
+        "description": "정렬 방식",
         "type": "string",
         "enum": [
           "DESC",
@@ -44754,7 +44760,7 @@
       },
       "StartedPaymentSchedule": {
         "title": "결제 시작 상태",
-        "description": "<p>결제 시작 상태</p>\n",
+        "description": "결제 시작 상태",
         "type": "object",
         "required": [
           "status",
@@ -44877,7 +44883,7 @@
       },
       "SucceededPaymentCancellation": {
         "title": "취소 완료 상태",
-        "description": "<p>취소 완료 상태</p>\n",
+        "description": "취소 완료 상태",
         "type": "object",
         "required": [
           "status",
@@ -44944,7 +44950,7 @@
       },
       "SucceededPaymentSchedule": {
         "title": "결제 성공 상태",
-        "description": "<p>결제 성공 상태</p>\n",
+        "description": "결제 성공 상태",
         "type": "object",
         "required": [
           "status",
@@ -45073,7 +45079,7 @@
       },
       "SumOfPartsExceedsCancelAmountError": {
         "title": "면세 금액 등 하위 항목들의 합이 전체 취소 금액을 초과한 경우",
-        "description": "<p>면세 금액 등 하위 항목들의 합이 전체 취소 금액을 초과한 경우</p>\n",
+        "description": "면세 금액 등 하위 항목들의 합이 전체 취소 금액을 초과한 경우",
         "type": "object",
         "required": [
           "type"
@@ -45091,7 +45097,7 @@
       },
       "SumOfPartsExceedsTotalAmountError": {
         "title": "면세 금액 등 하위 항목들의 합이 전체 결제 금액을 초과한 경우",
-        "description": "<p>면세 금액 등 하위 항목들의 합이 전체 결제 금액을 초과한 경우</p>\n",
+        "description": "면세 금액 등 하위 항목들의 합이 전체 결제 금액을 초과한 경우",
         "type": "object",
         "required": [
           "type"
@@ -45116,7 +45122,7 @@
       },
       "UnauthorizedError": {
         "title": "인증 정보가 올바르지 않은 경우",
-        "description": "<p>인증 정보가 올바르지 않은 경우</p>\n",
+        "description": "인증 정보가 올바르지 않은 경우",
         "type": "object",
         "required": [
           "type"
@@ -45134,7 +45140,7 @@
       },
       "UpdateB2bMemberCompanyBody": {
         "title": "연동 사업자 정보 수정 요청",
-        "description": "<p>연동 사업자 정보 수정 요청</p>\n",
+        "description": "연동 사업자 정보 수정 요청",
         "type": "object",
         "properties": {
           "name": {
@@ -45162,7 +45168,7 @@
       },
       "UpdateB2bMemberCompanyContactBody": {
         "title": "담당자 정보 수정 요청",
-        "description": "<p>담당자 정보 수정 요청</p>\n",
+        "description": "담당자 정보 수정 요청",
         "type": "object",
         "properties": {
           "password": {
@@ -45220,7 +45226,7 @@
       },
       "UpdateB2bMemberCompanyContactResponse": {
         "title": "담당자 정보 수정 응답",
-        "description": "<p>담당자 정보 수정 응답</p>\n",
+        "description": "담당자 정보 수정 응답",
         "type": "object",
         "required": [
           "contact"
@@ -45261,7 +45267,7 @@
       },
       "UpdateB2bMemberCompanyResponse": {
         "title": "연동 사업자 정보 수정 응답",
-        "description": "<p>연동 사업자 정보 수정 응답</p>\n",
+        "description": "연동 사업자 정보 수정 응답",
         "type": "object",
         "required": [
           "memberCompany"
@@ -45276,7 +45282,7 @@
       },
       "UpdatePlatformAdditionalFeePolicyBody": {
         "title": "추가 수수료 정책 업데이트를 위한 입력 정보",
-        "description": "<p>추가 수수료 정책 업데이트를 위한 입력 정보</p>\n<p>값이 명시하지 않은 필드는 업데이트되지 않습니다.</p>\n",
+        "description": "추가 수수료 정책 업데이트를 위한 입력 정보\n\n값이 명시하지 않은 필드는 업데이트되지 않습니다.",
         "type": "object",
         "properties": {
           "fee": {
@@ -45297,7 +45303,7 @@
           }
         },
         "x-portone-title": "추가 수수료 정책 업데이트를 위한 입력 정보",
-        "x-portone-description": "<p>값이 명시하지 않은 필드는 업데이트되지 않습니다.</p>\n"
+        "x-portone-description": "값이 명시하지 않은 필드는 업데이트되지 않습니다."
       },
       "UpdatePlatformAdditionalFeePolicyError": {
         "title": "UpdatePlatformAdditionalFeePolicyError",
@@ -45335,7 +45341,7 @@
       },
       "UpdatePlatformAdditionalFeePolicyResponse": {
         "title": "추가 수수료 정책 업데이트 성공 응답",
-        "description": "<p>추가 수수료 정책 업데이트 성공 응답</p>\n",
+        "description": "추가 수수료 정책 업데이트 성공 응답",
         "type": "object",
         "required": [
           "additionalFeePolicy"
@@ -45350,7 +45356,7 @@
       },
       "UpdatePlatformBody": {
         "title": "플랫폼 업데이트를 위한 입력 정보",
-        "description": "<p>플랫폼 업데이트를 위한 입력 정보</p>\n<p>값이 명시되지 않은 필드는 업데이트하지 않습니다.</p>\n",
+        "description": "플랫폼 업데이트를 위한 입력 정보\n\n값이 명시되지 않은 필드는 업데이트하지 않습니다.",
         "type": "object",
         "properties": {
           "roundType": {
@@ -45367,11 +45373,11 @@
           }
         },
         "x-portone-title": "플랫폼 업데이트를 위한 입력 정보",
-        "x-portone-description": "<p>값이 명시되지 않은 필드는 업데이트하지 않습니다.</p>\n"
+        "x-portone-description": "값이 명시되지 않은 필드는 업데이트하지 않습니다."
       },
       "UpdatePlatformBodySettlementFormula": {
         "title": "플랫폼 업데이트 시 변경할 계산식 정보",
-        "description": "<p>플랫폼 업데이트 시 변경할 계산식 정보</p>\n<p>값이 명시되지 않은 필드는 업데이트하지 않습니다.</p>\n",
+        "description": "플랫폼 업데이트 시 변경할 계산식 정보\n\n값이 명시되지 않은 필드는 업데이트하지 않습니다.",
         "type": "object",
         "properties": {
           "platformFee": {
@@ -45388,11 +45394,11 @@
           }
         },
         "x-portone-title": "플랫폼 업데이트 시 변경할 계산식 정보",
-        "x-portone-description": "<p>값이 명시되지 않은 필드는 업데이트하지 않습니다.</p>\n"
+        "x-portone-description": "값이 명시되지 않은 필드는 업데이트하지 않습니다."
       },
       "UpdatePlatformBodySettlementRule": {
         "title": "플랫폼 업데이트 시 변경할 정산 규칙 정보",
-        "description": "<p>플랫폼 업데이트 시 변경할 정산 규칙 정보</p>\n<p>값이 명시되지 않은 필드는 업데이트하지 않습니다.</p>\n",
+        "description": "플랫폼 업데이트 시 변경할 정산 규칙 정보\n\n값이 명시되지 않은 필드는 업데이트하지 않습니다.",
         "type": "object",
         "properties": {
           "supportsMultipleOrderTransfersPerPartner": {
@@ -45409,11 +45415,11 @@
           }
         },
         "x-portone-title": "플랫폼 업데이트 시 변경할 정산 규칙 정보",
-        "x-portone-description": "<p>값이 명시되지 않은 필드는 업데이트하지 않습니다.</p>\n"
+        "x-portone-description": "값이 명시되지 않은 필드는 업데이트하지 않습니다."
       },
       "UpdatePlatformContractBody": {
         "title": "계약 업데이트를 위한 입력 정보. 값이 명시되지 않은 필드는 업데이트되지 않습니다.",
-        "description": "<p>계약 업데이트를 위한 입력 정보. 값이 명시되지 않은 필드는 업데이트되지 않습니다.</p>\n<p>값이 명시되지 않은 필드는 업데이트되지 않습니다.</p>\n",
+        "description": "계약 업데이트를 위한 입력 정보. 값이 명시되지 않은 필드는 업데이트되지 않습니다.\n\n값이 명시되지 않은 필드는 업데이트되지 않습니다.",
         "type": "object",
         "properties": {
           "name": {
@@ -45442,7 +45448,7 @@
           }
         },
         "x-portone-title": "계약 업데이트를 위한 입력 정보. 값이 명시되지 않은 필드는 업데이트되지 않습니다.",
-        "x-portone-description": "<p>값이 명시되지 않은 필드는 업데이트되지 않습니다.</p>\n"
+        "x-portone-description": "값이 명시되지 않은 필드는 업데이트되지 않습니다."
       },
       "UpdatePlatformContractError": {
         "title": "UpdatePlatformContractError",
@@ -45480,7 +45486,7 @@
       },
       "UpdatePlatformContractResponse": {
         "title": "계약 객체 업데이트 성공 응답",
-        "description": "<p>계약 객체 업데이트 성공 응답</p>\n",
+        "description": "계약 객체 업데이트 성공 응답",
         "type": "object",
         "required": [
           "contract"
@@ -45495,7 +45501,7 @@
       },
       "UpdatePlatformDiscountSharePolicyBody": {
         "title": "할인 분담 정책 업데이트를 위한 입력 정보",
-        "description": "<p>할인 분담 정책 업데이트를 위한 입력 정보</p>\n<p>값이 명시되지 않은 필드는 업데이트하지 않습니다.</p>\n",
+        "description": "할인 분담 정책 업데이트를 위한 입력 정보\n\n값이 명시되지 않은 필드는 업데이트하지 않습니다.",
         "type": "object",
         "properties": {
           "name": {
@@ -45506,7 +45512,7 @@
             "type": "integer",
             "format": "int32",
             "title": "할인 분담율",
-            "description": "<p>파트너가 분담할 할인금액의 비율을 의미하는 밀리 퍼센트 단위 (10^-5) 의 음이 아닌 정수이며, 파트너가 부담할 금액은 <code>할인금액 * partnerShareRate * 10^5</code> 로 책정합니다.</p>\n"
+            "description": "파트너가 분담할 할인금액의 비율을 의미하는 밀리 퍼센트 단위 (10^-5) 의 음이 아닌 정수이며, 파트너가 부담할 금액은 `할인금액 * partnerShareRate * 10^5` 로 책정합니다."
           },
           "memo": {
             "type": "string",
@@ -45514,7 +45520,7 @@
           }
         },
         "x-portone-title": "할인 분담 정책 업데이트를 위한 입력 정보",
-        "x-portone-description": "<p>값이 명시되지 않은 필드는 업데이트하지 않습니다.</p>\n"
+        "x-portone-description": "값이 명시되지 않은 필드는 업데이트하지 않습니다."
       },
       "UpdatePlatformDiscountSharePolicyError": {
         "title": "UpdatePlatformDiscountSharePolicyError",
@@ -45552,7 +45558,7 @@
       },
       "UpdatePlatformDiscountSharePolicyResponse": {
         "title": "할인 분담 정책 업데이트 성공 응답",
-        "description": "<p>할인 분담 정책 업데이트 성공 응답</p>\n",
+        "description": "할인 분담 정책 업데이트 성공 응답",
         "type": "object",
         "required": [
           "discountSharePolicy"
@@ -45597,7 +45603,7 @@
       },
       "UpdatePlatformPartnerBody": {
         "title": "파트너 업데이트를 위한 입력 정보",
-        "description": "<p>파트너 업데이트를 위한 입력 정보</p>\n<p>값이 명시되지 않은 필드는 업데이트되지 않습니다.</p>\n",
+        "description": "파트너 업데이트를 위한 입력 정보\n\n값이 명시되지 않은 필드는 업데이트되지 않습니다.",
         "type": "object",
         "properties": {
           "name": {
@@ -45637,11 +45643,11 @@
           }
         },
         "x-portone-title": "파트너 업데이트를 위한 입력 정보",
-        "x-portone-description": "<p>값이 명시되지 않은 필드는 업데이트되지 않습니다.</p>\n"
+        "x-portone-description": "값이 명시되지 않은 필드는 업데이트되지 않습니다."
       },
       "UpdatePlatformPartnerBodyAccount": {
         "title": "파트너 계좌 업데이트를 위한 입력 정보",
-        "description": "<p>파트너 계좌 업데이트를 위한 입력 정보</p>\n",
+        "description": "파트너 계좌 업데이트를 위한 입력 정보",
         "type": "object",
         "required": [
           "bank",
@@ -45675,7 +45681,7 @@
       },
       "UpdatePlatformPartnerBodyContact": {
         "title": "파트너 담당자 업데이트를 위한 정보",
-        "description": "<p>파트너 담당자 업데이트를 위한 정보</p>\n",
+        "description": "파트너 담당자 업데이트를 위한 정보",
         "type": "object",
         "properties": {
           "name": {
@@ -45695,7 +45701,7 @@
       },
       "UpdatePlatformPartnerBodyType": {
         "title": "파트너 업데이트를 위한 유형별 추가 정보",
-        "description": "<p>파트너 업데이트를 위한 유형별 추가 정보</p>\n<p>파트너 유형별 추가 정보를 수정합니다.\n기존과 다른 파트너 유형 정보가 입력된 경우, 파트너의 유형 자체가 변경됩니다.</p>\n",
+        "description": "파트너 업데이트를 위한 유형별 추가 정보\n\n파트너 유형별 추가 정보를 수정합니다.\n기존과 다른 파트너 유형 정보가 입력된 경우, 파트너의 유형 자체가 변경됩니다.",
         "type": "object",
         "properties": {
           "business": {
@@ -45712,7 +45718,7 @@
           }
         },
         "x-portone-title": "파트너 업데이트를 위한 유형별 추가 정보",
-        "x-portone-description": "<p>파트너 유형별 추가 정보를 수정합니다.\n기존과 다른 파트너 유형 정보가 입력된 경우, 파트너의 유형 자체가 변경됩니다.</p>\n"
+        "x-portone-description": "파트너 유형별 추가 정보를 수정합니다.\n기존과 다른 파트너 유형 정보가 입력된 경우, 파트너의 유형 자체가 변경됩니다."
       },
       "UpdatePlatformPartnerBodyTypeBusiness": {
         "title": "UpdatePlatformPartnerBodyTypeBusiness",
@@ -45753,9 +45759,9 @@
         "type": "object",
         "properties": {
           "birthdate": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "생년월일"
           }
         }
@@ -45765,9 +45771,9 @@
         "type": "object",
         "properties": {
           "birthdate": {
-            "description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "type": "string",
-            "x-portone-description": "<p>날짜를 나타내는 문자열로, <code>yyyy-MM-dd</code> 형식을 따릅니다.</p>\n",
+            "x-portone-description": "날짜를 나타내는 문자열로, `yyyy-MM-dd` 형식을 따릅니다.",
             "title": "생년월일"
           }
         }
@@ -45832,7 +45838,7 @@
       },
       "UpdatePlatformPartnerResponse": {
         "title": "파트너 업데이트 성공 응답",
-        "description": "<p>파트너 업데이트 성공 응답</p>\n",
+        "description": "파트너 업데이트 성공 응답",
         "type": "object",
         "required": [
           "partner"
@@ -45866,7 +45872,7 @@
       },
       "UpdatePlatformPartnerSettlementStatusResponse": {
         "title": "정산내역 상태 업데이트 결과",
-        "description": "<p>정산내역 상태 업데이트 결과</p>\n",
+        "description": "정산내역 상태 업데이트 결과",
         "type": "object",
         "required": [
           "partnerSettlement"
@@ -45880,7 +45886,7 @@
       },
       "UpdatePlatformResponse": {
         "title": "플랫폼 업데이트 결과 정보",
-        "description": "<p>플랫폼 업데이트 결과 정보</p>\n",
+        "description": "플랫폼 업데이트 결과 정보",
         "type": "object",
         "required": [
           "platform"
@@ -45895,7 +45901,7 @@
       },
       "VerifiedIdentityVerification": {
         "title": "완료된 본인인증 내역",
-        "description": "<p>완료된 본인인증 내역</p>\n",
+        "description": "완료된 본인인증 내역",
         "type": "object",
         "required": [
           "status",
@@ -45962,7 +45968,7 @@
       },
       "VirtualAccountIssuedPayment": {
         "title": "가상계좌 발급 완료 상태 건",
-        "description": "<p>가상계좌 발급 완료 상태 건</p>\n",
+        "description": "가상계좌 발급 완료 상태 건",
         "type": "object",
         "required": [
           "status",
@@ -45992,7 +45998,7 @@
           "transactionId": {
             "type": "string",
             "title": "결제 건 포트원 채번 아이디",
-            "description": "<p>V1 결제 건의 경우 imp_uid에 해당합니다.</p>\n"
+            "description": "V1 결제 건의 경우 imp_uid에 해당합니다."
           },
           "merchantId": {
             "type": "string",
@@ -46021,12 +46027,12 @@
           "scheduleId": {
             "type": "string",
             "title": "결제 예약 건 아이디",
-            "description": "<p>결제 예약을 이용한 경우에만 존재</p>\n"
+            "description": "결제 예약을 이용한 경우에만 존재"
           },
           "billingKey": {
             "type": "string",
             "title": "결제 시 사용된 빌링키",
-            "description": "<p>빌링키 결제인 경우에만 존재</p>\n"
+            "description": "빌링키 결제인 경우에만 존재"
           },
           "webhooks": {
             "title": "웹훅 발송 내역",
@@ -46077,7 +46083,7 @@
           "escrow": {
             "$ref": "#/components/schemas/PaymentEscrow",
             "title": "에스크로 결제 정보",
-            "description": "<p>에스크로 결제인 경우 존재합니다.</p>\n"
+            "description": "에스크로 결제인 경우 존재합니다."
           },
           "products": {
             "title": "상품 정보",
@@ -46108,7 +46114,7 @@
       },
       "WebhookNotFoundError": {
         "title": "웹훅 내역이 존재하지 않는 경우",
-        "description": "<p>웹훅 내역이 존재하지 않는 경우</p>\n",
+        "description": "웹훅 내역이 존재하지 않는 경우",
         "type": "object",
         "required": [
           "type"
@@ -46192,12 +46198,12 @@
     "securitySchemes": {
       "bearerJwt": {
         "type": "http",
-        "description": "<p>Authorization: Bearer <code>엑세스 토큰</code></p>\n",
+        "description": "Authorization: Bearer `엑세스 토큰`",
         "scheme": "bearer"
       },
       "portOne": {
         "type": "http",
-        "description": "<p>Authorization: PortOne <code>발급된 API 시크릿</code></p>\n",
+        "description": "Authorization: PortOne `발급된 API 시크릿`",
         "scheme": "portone"
       }
     }
@@ -46206,99 +46212,99 @@
     {
       "id": "auth",
       "title": "인증 관련 API",
-      "description": "<p>인증과 관련된 API 기능을 제공합니다.</p>\n"
+      "description": "인증과 관련된 API 기능을 제공합니다."
     },
     {
       "id": "payment",
       "title": "결제 관련 API",
-      "description": "<p>결제와 관련된 API 기능을 제공합니다.</p>\n"
+      "description": "결제와 관련된 API 기능을 제공합니다."
     },
     {
       "id": "paymentSchedule",
       "title": "결제 예약 관련 API",
-      "description": "<p>결제 예약과 관련된 API 기능을 제공합니다.</p>\n"
+      "description": "결제 예약과 관련된 API 기능을 제공합니다."
     },
     {
       "id": "billingKey",
       "title": "빌링키 관련 API",
-      "description": "<p>빌링키와 관련된 API 기능을 제공합니다.</p>\n"
+      "description": "빌링키와 관련된 API 기능을 제공합니다."
     },
     {
       "id": "cashReceipt",
       "title": "현금 영수증 관련 API",
-      "description": "<p>현금 영수증과 관련된 API 기능을 제공합니다.</p>\n"
+      "description": "현금 영수증과 관련된 API 기능을 제공합니다."
     },
     {
       "id": "identityVerification",
       "title": "본인인증 관련 API",
-      "description": "<p>본인인증과 관련된 API 기능을 제공합니다.</p>\n"
+      "description": "본인인증과 관련된 API 기능을 제공합니다."
     },
     {
       "id": "b2b",
       "title": "B2B 서비스 API",
-      "description": "<p>B2B 관련 API 기능을 제공합니다. alpha 버전의 API 로서, 사용을 원하실 경우 관리자콘솔 및 홈페이지를 통해 문의해주세요.</p>\n"
+      "description": "B2B 관련 API 기능을 제공합니다. alpha 버전의 API 로서, 사용을 원하실 경우 관리자콘솔 및 홈페이지를 통해 문의해주세요."
     },
     {
       "id": "platform",
       "title": "파트너 정산 관련 API",
-      "description": "<p>파트너 정산 서비스 API 기능을 제공합니다.</p>\n",
+      "description": "파트너 정산 서비스 API 기능을 제공합니다.",
       "children": [
         {
           "id": "platform.policy",
           "title": "정책 관련 API",
-          "description": "<p>파트너 정산에 적용할 정책에 관한 API 입니다.</p>\n"
+          "description": "파트너 정산에 적용할 정책에 관한 API 입니다."
         },
         {
           "id": "platform.partner",
           "title": "파트너 관련 API",
-          "description": "<p>파트너 정산에 적용할 파트너에 관한 API 입니다.</p>\n"
+          "description": "파트너 정산에 적용할 파트너에 관한 API 입니다."
         },
         {
           "id": "platform.transfer",
           "title": "정산 상세내역 관련 API",
-          "description": "<p>파트너 정산 서비스의 정산 상세내역과 관련된 API 입니다.</p>\n"
+          "description": "파트너 정산 서비스의 정산 상세내역과 관련된 API 입니다."
         },
         {
           "id": "platform.account",
           "title": "계좌 관련 API",
-          "description": "<p>파트너 정산 서비스의 계좌와 관련된 API 입니다.</p>\n"
+          "description": "파트너 정산 서비스의 계좌와 관련된 API 입니다."
         },
         {
           "id": "platform.partnerSettlement",
           "title": "정산 내역 관련 API",
-          "description": "<p>파트너 정산 서비스의 정산 내역과 관련된 API 입니다.</p>\n"
+          "description": "파트너 정산 서비스의 정산 내역과 관련된 API 입니다."
         },
         {
           "id": "platform.payout",
           "title": "지급 내역 관련 API",
-          "description": "<p>파트너 정산 서비스의 지급 내역과 관련된 API 입니다.</p>\n"
+          "description": "파트너 정산 서비스의 지급 내역과 관련된 API 입니다."
         },
         {
           "id": "platform.bulkPayout",
           "title": "일괄 지급 내역 관련 API",
-          "description": "<p>파트너 정산 서비스의 일괄 지급 내역과 관련된 API 입니다.</p>\n"
+          "description": "파트너 정산 서비스의 일괄 지급 내역과 관련된 API 입니다."
         },
         {
           "id": "platform.accountTransfer",
           "title": "이체 내역 관련 API",
-          "description": "<p>파트너 정산 서비스의 이체 내역과 관련된 API 입니다.</p>\n"
+          "description": "파트너 정산 서비스의 이체 내역과 관련된 API 입니다."
         }
       ]
     },
     {
       "id": "pgSpecific",
       "title": "특정 PG사 관련 API",
-      "description": "<p>특정 PG사에 국한된 API 기능을 제공합니다.</p>\n"
+      "description": "특정 PG사에 국한된 API 기능을 제공합니다."
     },
     {
       "id": "reconciliation",
       "title": "대사 서비스 API",
-      "description": "<p>거래 대사 및 정산 대사 관련 API 기능을 제공합니다.</p>\n"
+      "description": "거래 대사 및 정산 대사 관련 API 기능을 제공합니다."
     },
     {
       "id": "promotion",
       "title": "프로모션 관련 API",
-      "description": "<p>프로모션과 관련된 API 기능을 제공합니다.</p>\n"
+      "description": "프로모션과 관련된 API 기능을 제공합니다."
     }
   ]
 }

--- a/src/schema/v2.openapi.json
+++ b/src/schema/v2.openapi.json
@@ -5309,7 +5309,6 @@
                     "gender": "FEMALE",
                     "isForeigner": false,
                     "ci": "ci-value",
-                    "ci2": "ci2-value",
                     "di": "di-value"
                   },
                   "customData": "your-custom-data-string",
@@ -7125,7 +7124,7 @@
       "post": {
         "summary": "빌링키 결제",
         "description": "빌링키 결제\n\n빌링키로 결제를 진행합니다.",
-        "operationId": "PayWithBillingKey",
+        "operationId": "payWithBillingKey",
         "parameters": [
           {
             "name": "paymentId",
@@ -7241,7 +7240,7 @@
       "post": {
         "summary": "수기 결제",
         "description": "수기 결제\n\n수기 결제를 진행합니다.",
-        "operationId": "PayInstantly",
+        "operationId": "payInstantly",
         "parameters": [
           {
             "name": "paymentId",
@@ -12476,7 +12475,7 @@
       "get": {
         "summary": "카카오페이 주문 조회 API",
         "description": "카카오페이 주문 조회 API\n\n주어진 아이디에 대응되는 카카오페이 주문 건을 조회합니다.\n해당 API 사용이 필요한 경우 포트원 기술지원팀으로 문의 주시길 바랍니다.",
-        "operationId": "GetKakaopayPaymentOrder",
+        "operationId": "getKakaopayPaymentOrder",
         "parameters": [
           {
             "name": "pgTxId",
@@ -14261,7 +14260,7 @@
           "brn": {
             "type": "string",
             "title": "사업자등록번호",
-            "description": "- 없이 숫자 10자리로 구성됩니다."
+            "description": "`-` 없이 숫자 10자리로 구성됩니다."
           },
           "documentKey": {
             "type": "string",
@@ -14798,7 +14797,7 @@
           "brn": {
             "type": "string",
             "title": "사업자등록번호",
-            "description": "- 없이 숫자로만 구성됩니다."
+            "description": "`-` 없이 숫자로만 구성됩니다."
           },
           "name": {
             "type": "string",
@@ -15291,7 +15290,7 @@
           "brn": {
             "type": "string",
             "title": "사업자등록번호",
-            "description": "- 를 제외한 10자리"
+            "description": "`-`를 제외한 10자리"
           },
           "taxRegistrationId": {
             "type": "string",
@@ -24735,7 +24734,8 @@
           "requestedCustomer",
           "requestedAt",
           "updatedAt",
-          "statusChangedAt"
+          "statusChangedAt",
+          "failure"
         ],
         "properties": {
           "status": {
@@ -24772,6 +24772,10 @@
             "type": "string",
             "format": "date-time",
             "title": "상태 업데이트 시점"
+          },
+          "failure": {
+            "$ref": "#/components/schemas/IdentityVerificationFailure",
+            "title": "본인인증 실패 정보"
           }
         },
         "x-portone-title": "실패한 본인인증 내역"
@@ -24794,7 +24798,8 @@
           "amount",
           "currency",
           "customer",
-          "failedAt"
+          "failedAt",
+          "failure"
         ],
         "properties": {
           "status": {
@@ -24919,6 +24924,10 @@
             "type": "string",
             "format": "date-time",
             "title": "결제 실패 시점"
+          },
+          "failure": {
+            "$ref": "#/components/schemas/PaymentFailure",
+            "title": "결제 실패 정보"
           }
         },
         "x-portone-title": "결제 실패 상태 건"
@@ -29114,6 +29123,26 @@
         "x-portone-title": "본인인증 건이 이미 인증 완료된 상태인 경우",
         "x-portone-status-code": 409
       },
+      "IdentityVerificationFailure": {
+        "title": "본인인증 실패 정보",
+        "description": "본인인증 실패 정보",
+        "type": "object",
+        "properties": {
+          "reason": {
+            "type": "string",
+            "title": "실패 사유"
+          },
+          "pgCode": {
+            "type": "string",
+            "title": "PG사 실패 코드"
+          },
+          "pgMessage": {
+            "type": "string",
+            "title": "PG사 실패 메시지"
+          }
+        },
+        "x-portone-title": "본인인증 실패 정보"
+      },
       "IdentityVerificationMethod": {
         "title": "본인인증 방식",
         "description": "본인인증 방식",
@@ -29255,27 +29284,22 @@
           "gender": {
             "$ref": "#/components/schemas/Gender",
             "title": "성별",
-            "description": "다날: 항상 제공합니다.\nKG이니시스: 본인확인에서 제공합니다."
+            "description": "다날: 항상 제공합니다.\nKG이니시스: 항상 제공합니다."
           },
           "isForeigner": {
             "type": "boolean",
             "title": "외국인 여부",
-            "description": "다날: 별도 계약이 필요합니다.\nKG이니시스: 본인확인에서만 제공합니다."
+            "description": "다날: 별도 계약이 필요합니다.\nKG이니시스: 항상 제공합니다."
           },
           "ci": {
             "type": "string",
             "title": "CI (개인 고유 식별키)",
             "description": "개인을 식별하기 위한 고유 정보입니다.\n다날: 항상 제공합니다.\nKG이니시스: 카카오를 제외한 인증사에서 제공합니다."
           },
-          "ci2": {
-            "type": "string",
-            "title": "CI2 (개인 고유 백업 식별키)",
-            "description": "기존 CI가 유출 등의 이유로 사용할 수 없는 경우에 사용됩니다. 평상시에는 제공되지 않습니다.\n다날: 제공하지 않습니다.\nKG이니시스: 본인확인에서 제공합니다."
-          },
           "di": {
             "type": "string",
             "title": "DI (사이트별 개인 고유 식별키)",
-            "description": "중복 가입을 방지하기 위해 개인을 식별하는 사이트별 고유 정보입니다.\n다날: 항상 제공합니다.\nKG이니시스: 본인확인에서 제공합니다."
+            "description": "중복 가입을 방지하기 위해 개인을 식별하는 사이트별 고유 정보입니다.\n다날: 항상 제공합니다.\nKG이니시스: 제공하지 않습니다."
           }
         },
         "x-portone-title": "인증된 고객 정보"
@@ -31538,6 +31562,26 @@
           }
         },
         "x-portone-title": "에스크로 발송자 정보"
+      },
+      "PaymentFailure": {
+        "title": "결제 실패 정보",
+        "description": "결제 실패 정보",
+        "type": "object",
+        "properties": {
+          "reason": {
+            "type": "string",
+            "title": "실패 사유"
+          },
+          "pgCode": {
+            "type": "string",
+            "title": "PG사 실패 코드"
+          },
+          "pgMessage": {
+            "type": "string",
+            "title": "PG사 실패 메시지"
+          }
+        },
+        "x-portone-title": "결제 실패 정보"
       },
       "PaymentFilterInput": {
         "title": "결제 건 다건 조회를 위한 입력 정보",


### PR DESCRIPTION
OpenAPI 표준에서는 description 필드에 HTML을 허용하지 않고, CommonMark를 허용하고 있습니다. 스키마 JSON 파일에서 설명을 HTML로 변환하지 않고 그대로 사용하되, 필요한 경우 HTML로 변환하도록 수정했습니다.

- `-`로 시작하는 일부 설명이 markdown 문법으로 처리되고 있는 부분의 문서 수정이 필요합니다.