### PR TITLE
readme 페이지의 일부 링크 수정

### DIFF
--- a/src/routes/(root)/opi/ko/readme/index.mdx
+++ b/src/routes/(root)/opi/ko/readme/index.mdx
@@ -4,6 +4,8 @@ description: 포트원 결제 연동 가이드입니다. 빠른 시간 안에 �
 targetVersions: ["v1", "v2"]
 ---
 
+import { A } from "@solidjs/router";
+
 import EasyGuideLink from "~/components/EasyGuideLink";
 import ContentRef from "~/components/gitbook/ContentRef";
 import VersionGate from "~/components/gitbook/VersionGate";
@@ -109,18 +111,30 @@ import Hint from "~/components/Hint";
 
 관리자 콘솔 사용 방법을 안내합니다.
 
-<ContentRef slug="/ko/console/pg" />
+<ContentRef slug="/ko/console/guide/readme" />
 
 ## API
 
 포트원에서 제공하는 API 명세를 확인할 수 있습니다.
 
 <VersionGate v="v1">
-  <ContentRef slug="/api/rest-v1" />
+  <A class="m-4" href={`/api/rest-v1`}>
+    <div class="flex items-center justify-between gap-4 border rounded bg-white p-4 transition-transform hover:translate-y-[-2px] hover:text-orange-5 hover:drop-shadow-[0_12px_13px_rgba(0,0,0,0.02)]">
+      <span>API 문서 바로가기</span>
+
+      <i class="i-ic-baseline-chevron-right inline-block text-2xl" />
+    </div>
+  </A>
 </VersionGate>
 
 <VersionGate v="v2">
-  <ContentRef slug="/api/rest-v2" />
+  <A class="m-4" href={`/api/rest-v2`}>
+    <div class="flex items-center justify-between gap-4 border rounded bg-white p-4 transition-transform hover:translate-y-[-2px] hover:text-orange-5 hover:drop-shadow-[0_12px_13px_rgba(0,0,0,0.02)]">
+      <span>API 문서 바로가기</span>
+
+      <i class="i-ic-baseline-chevron-right inline-block text-2xl" />
+    </div>
+  </A>
 </VersionGate>
 
 ## SDK


### PR DESCRIPTION
- 콘솔 가이드로 향하는 링크가 잘못되어 있어 수정합니다.
- 기존에 api 문서 링크를 달아주기 위해 `ContentRef` 를 사용했었는데, `ContentRef`는 opi 하위의 mdx 문서들에 대해서만 사용할 수 있는 컴포넌트여서 api 문서에 대해서는 A 태그를 직접 이용해 링크를 만들어주도록 변경했습니다.