### PR TITLE
fix: paymentId 오표기

### DIFF
--- a/src/routes/(root)/opi/ko/integration/start/v2/checkout.mdx
+++ b/src/routes/(root)/opi/ko/integration/start/v2/checkout.mdx
@@ -118,12 +118,12 @@ PortOne.requestPayment({
 
 |키         |설명      |비고   |
 |-----------|----------|-------|
-|payment\_id|결제 건 ID|공통   |
+|paymentId|결제 건 ID|공통   |
 |code       |오류 코드 |실패 시|
 |message    |오류 문구 |실패 시|
 
 예를 들어 paymentId가 `payment-39ecfa97`, redirectUrl이 `https://example.com/payment-redirect`인 경우,
-결제 성공 시에 `https://example.com/payment-redirect?payment_id=payment-39ecfa97`로 리다이렉트됩니다.
+결제 성공 시에 `https://example.com/payment-redirect?paymentId=payment-39ecfa97`로 리다이렉트됩니다.
 
 ## 4. 결제 완료 처리 (서버)
 


### PR DESCRIPTION
문서에 기재된 'payment_Id'가 아닌 카멜표기 'paymentId'로 전달되는 것으로 확인. 다른사람들은 연동에 시간이 낭비되지 않았으면함.