### PR TITLE
파트너정산 자동화 문서 버그 수정

### DIFF
--- a/src/layouts/sidebar/RightSidebar.tsx
+++ b/src/layouts/sidebar/RightSidebar.tsx
@@ -35,6 +35,7 @@ function RightSidebar(_props: RightSidebarProps) {
 
   createEffect(() => {
     void systemVersion();
+    void props.slug;
     setToc(headingsToToc(props.lang));
   });
 

--- a/src/routes/(root)/platform/(doc).tsx
+++ b/src/routes/(root)/platform/(doc).tsx
@@ -36,21 +36,17 @@ export default function PlatformDocLayout(props: { children: JSXElement }) {
   return (
     <Show when={doc()}>
       {(doc) => {
-        const { title } = doc().frontmatter;
+        const title = createMemo(() => doc().frontmatter.title);
 
         return (
           <>
-            <Metadata title={title} ogType="article" />
-            <article class="m-4 mb-40 min-w-0 flex shrink-1 basis-200 flex-col text-slate-700">
-              <prose.h1>{title}</prose.h1>
+            <Metadata title={title()} ogType="article" />
+            <article class="m-4 mb-40 min-w-0 flex shrink-1 basis-200 flex-col text-slate-7">
+              <prose.h1>{title()}</prose.h1>
               {props.children}
             </article>
             <div class="hidden shrink-10 basis-10 lg:block"></div>
-            <RightSidebar
-              lang="ko"
-              slug={doc()?.slug ?? ""}
-              editThisPagePrefix="https://github.com/portone-io/developers.portone.io/blob/main/src/content/platform/"
-            />
+            <RightSidebar lang="ko" file={doc().file} slug={slug()} />
           </>
         );
       }}


### PR DESCRIPTION
- 문서를 이동해도 제목과 ToC 내용이 변경되지 않는 버그 수정
- `이 페이지 수정하기` 버튼 클릭 시 잘못된 링크로 이동하는 버그 수정