### PR TITLE
결제창 호출 시 PG 파라미터를 모두 channelKey 파라미터로 대체

### DIFF
--- a/src/routes/(root)/opi/ko/console/pg.mdx
+++ b/src/routes/(root)/opi/ko/console/pg.mdx
@@ -78,6 +78,8 @@ import image1 from "./_assets/multi-pg-guide-1.png";
   </Tabs.Tab>
 </Tabs>
 
-<Hint style="info">
-  `channelKey` 파라미터는 최신 JS SDK 버전에서만 지원됩니다.
+<Hint style="warning">
+  기존에 사용되던 `pg` 파라미터는 지원 중단 예정입니다. 
+  
+  JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 PG사 구분을 대체해주세요.
 </Hint>

--- a/src/routes/(root)/opi/ko/console/pg.mdx
+++ b/src/routes/(root)/opi/ko/console/pg.mdx
@@ -23,30 +23,24 @@ import image1 from "./_assets/multi-pg-guide-1.png";
 
 ## 특정 PG사의 결제창 열기 <a href="#pg" id="pg" />
 
-결제창을 호출하기 위한 [**JavaScript SDK**](/opi/ko/integration/sdk/javascript-sdk-old/readme) `IMP.request_pay`를
-호출할 때 `param.pg` 속성에 미리 등록한 PG사를 지정하여 해당 PG사의 결제창을 호출할 수 있습니다.
-`pg` 속성에는 다음과 같은 형태로 [PG 값](https://docs.iamport.kr/sdk/javascript-sdk?lang=ko#request_pay-pg)을
-지정할 수 있습니다.
-
-- **\{ PG사 코드값 }**
-- **\{ PG사 코드값 }.\{ PG사 상점아이디 }**
+결제창을 호출하기 위한 [**JavaScript SDK**](/opi/ko/integration/sdk/javascript-sdk/readme) `IMP.request_pay`를
+호출할 때 `channelKey` 속성에 PG사의 채널키를 지정하여 해당 PG사의 결제창을 호출할 수 있습니다.
 
 만약 포트원 관리자 콘솔 PG사 등록 현황이 아래와 같이 **3개의 PG설정**을 등록했다고 가정해 보면,
 
-|          PG사         |상점아이디 (예시)|       용도      |
-|:---------------------:|:---------------:|:---------------:|
-|**(신) 나이스페이먼츠**|      MID-a      | **인증 결제용** |
-|**(신) 나이스페이먼츠**|      MID-b      |**비인증 결제용**|
-|       카카오페이      |      MID-c      |   인증 결제용   |
+|          PG사         |상점아이디 (예시)|       용도      |                     채널키                     |
+|:---------------------:|:---------------:|:---------------:|:----------------------------------------------:|
+|**(신) 나이스페이먼츠**|      MID-a      | **인증 결제용** |channel-key-12345678-1234-5678-9012-123456789012|
+|**(신) 나이스페이먼츠**|      MID-b      |**비인증 결제용**|channel-key-abcdefgh-abcd-efgh-ijkl-abcdefghijkl|
+|       카카오페이      |      MID-c      |   인증 결제용   |channel-key-98765432-9876-5432-1098-987654321098|
 
-위에서 등록한 PG 설정 중 **\{ PG사 코드값 }** 으로만 구분할 수 있는 PG사는 **카카오페이**입니다.
-다음과 같이 `pg` 속성에 `kakaopay`를 지정하면 등록한 카카오페이 설정으로 결제창이 호출됩니다
+다음과 같이 `channelKey` 속성에 `channel-key-98765432-9876-5432-1098-987654321098`를 지정하면 등록한 카카오페이 설정으로 결제창이 호출됩니다
 
 <Tabs>
   <Tabs.Tab title="카카오페이 호출">
     ```ts
     IMP.request_pay({
-      pg: "kakaopay", // 카카오페이 결제창 호출
+      channelKey: "channel-key-98765432-9876-5432-1098-987654321098", // 카카오페이 채널키
       amount: 1000,
       name: "테스트 주문",
       buyer_name: "구매자",
@@ -56,13 +50,13 @@ import image1 from "./_assets/multi-pg-guide-1.png";
   </Tabs.Tab>
 </Tabs>
 
-위에서 등록한 PG 설정 중 **(신) 나이스페이먼츠 (인증 결제용)** 와 **(신) 나이스페이먼츠 (비인증 결제용)** 의 경우 <mark style="color:red;">**PG사 코드값이 동일**</mark>하기 때문에 `pg` 속성을 코드값과 상점아이디를 조합한 값 **\{ PG사 코드값 }.\{ PG사 상점아이디 }** 으로 설정해서 구분해야 합니다.
+위에서 등록한 PG 설정 중 **(신) 나이스페이먼츠 (인증 결제용)** 와 **(신) 나이스페이먼츠 (비인증 결제용)** 의 경우 <mark style="color:red;">**PG사 코드값이 동일**</mark>하지만, `channelKey` 파라미터를 통해 구분이 가능합니다.
 
 <Tabs>
   <Tabs.Tab title="(신) 나이스페이먼츠 인증 결제용 호출">
     ```ts
     IMP.request_pay({
-      pg: "nice_v2.MID-a", // (신) 나이스페이먼츠 인증 결제용 호출 (상점아이디 MID-a 적용)
+      channelKey: "channel-key-12345678-1234-5678-9012-123456789012", // (신) 나이스페이먼츠 인증 결제용 채널키
       amount: 1000,
       name: "테스트 주문",
       buyer_name: "구매자",
@@ -74,7 +68,7 @@ import image1 from "./_assets/multi-pg-guide-1.png";
   <Tabs.Tab title="(신) 나이스페이먼츠 비인증 결제용 호출">
     ```ts
     IMP.request_pay({
-      pg: "nice_v2.MID-b", // (신) 나이스페이먼츠 인증 결제용 호출 (상점아이디 MID-b 적용)
+      channelKey: "channel-key-abcdefgh-abcd-efgh-ijkl-abcdefghijkl", // (신) 나이스페이먼츠 비인증 결제용 채널키
       amount: 1000,
       name: "테스트 주문",
       buyer_name: "구매자",
@@ -85,7 +79,5 @@ import image1 from "./_assets/multi-pg-guide-1.png";
 </Tabs>
 
 <Hint style="info">
-  **pg 속성 매칭 우선순위**
-
-  관리자 콘솔에서 PG 설정을 저장한 순서(오래된순)대로 pg 속성의 조건과 일치하는 설정을 찾습니다.
+  `channelKey` 파라미터는 최신 JS SDK 버전에서만 지원됩니다.
 </Hint>

--- a/src/routes/(root)/opi/ko/extra/identity-verification/v1/all/0.mdx
+++ b/src/routes/(root)/opi/ko/extra/identity-verification/v1/all/0.mdx
@@ -4,32 +4,31 @@ description: 통합인증 연동을 시작하기 위한 준비작업을 소개�
 targetVersions: ["v1"]
 ---
 
-import Hint from "~/components/Hint";
+import VersionGate from "~/components/gitbook/VersionGate";
+import Youtube from "~/components/gitbook/Youtube";
 
-## 통합인증을 연동할 페이지에 포트원 라이브러리를 추가합니다.
+## 1. 포트원 SDK 설치하기 <span id="sdk-installation" />
 
-<Hint style="info">
-  신용카드 본인인증 기능은 **포트원 JavaScript v1.1.8**부터 지원합니다.
-</Hint>
+포트원은 다양한 PG의 본인인증창을 통일된 방법으로 호출할 수 있도록 자바스크립트 SDK를 제공합니다.
+브라우저에서 포트원 SDK를 호출하여 본인인증을 진행하게 됩니다.
 
-```html title="client-side"
-<!-- jQuery -->
-<script
-  type="text/javascript"
-  src="https://code.jquery.com/jquery-1.12.4.min.js"
-></script>
-<!-- iamport.payment.js -->
-<script
-  type="text/javascript"
-  src="https://cdn.iamport.kr/js/iamport.payment-{SDK-최신버전}.js"
-></script>
-```
+<VersionGate v="v1">
+  결제창 연동을 진행할 주문 페이지에 아래 JS 라이브러리를 추가합니다.
 
-<Hint style="danger">
-  **jQuery 1.0 이상이 설치**되어 있어야 합니다.
-</Hint>
+  ```html
+  <script src="https://cdn.iamport.kr/v1/iamport.js"></script>
+  ```
 
-## 본인인증 페이지에 [<mark style="color:blue;">`고객사 식별코드`</mark>](/opi/ko/integration/ready/readme#4-포트원-연동정보-확인하기)를 이용하여 `IMP` 객체를 초기화합니다.
+  <Youtube videoId="FLyOmbtnr48" caption="포트원 라이브러리 추가하기" />
+</VersionGate>
+
+## 2. SDK 초기화하기 <span id="sdk-installation" />
+
+포트원 SDK를 사용하여 결제창을 호출하려면, 먼저 포트원 SDK를 초기화하여야 합니다.
+
+먼저, 관리자 콘솔의 결제 연동 페이지에서 **고객사 식별코드**를 확인해 주세요.
+
+그리고 결제창을 호출할 페이지에서 다음과 같이 포트원 SDK를 초기화합니다.
 
 ```ts title="client-side"
 IMP.init("{고객사 식별코드}"); // 예: imp00000000

--- a/src/routes/(root)/opi/ko/extra/identity-verification/v1/all/1.mdx
+++ b/src/routes/(root)/opi/ko/extra/identity-verification/v1/all/1.mdx
@@ -26,7 +26,7 @@ targetVersions: ["v1"]
 IMP.certification(
   {
     // param
-    pg: "inicis_unified.{CPID}", //본인인증 설정이 2개이상 되어 있는 경우 필수
+    channelKey: "{콘솔 내 연동 정보의 채널키}",
     merchant_uid: "ORD20180131-0000011", // 주문 번호
     m_redirect_url: "{리디렉션 될 URL}", // 모바일환경에서 popup:false(기본값) 인 경우 필수, 예: https://www.myservice.com/payments/complete/mobile
     popup: false, // PC환경에서는 popup 파라미터가 무시되고 항상 true 로 적용됨

--- a/src/routes/(root)/opi/ko/extra/identity-verification/v1/credit-auth/1.mdx
+++ b/src/routes/(root)/opi/ko/extra/identity-verification/v1/credit-auth/1.mdx
@@ -4,32 +4,31 @@ description: 신용카드 본인인증을 시작하기 위한 안내입니다.
 targetVersions: ["v1"]
 ---
 
-import Hint from "~/components/Hint";
+import VersionGate from "~/components/gitbook/VersionGate";
+import Youtube from "~/components/gitbook/Youtube";
 
-## 본인인증을 연동할 페이지에 포트원 라이브러리를 추가합니다.
+## 1. 포트원 SDK 설치하기 <span id="sdk-installation" />
 
-<Hint style="info">
-  신용카드 본인인증 기능은 **포트원 JavaScript v1.1.7**부터 지원합니다.
-</Hint>
+포트원은 다양한 PG의 본인인증창을 통일된 방법으로 호출할 수 있도록 자바스크립트 SDK를 제공합니다.
+브라우저에서 포트원 SDK를 호출하여 본인인증을 진행하게 됩니다.
 
-```html title="client-side"
-<!-- jQuery -->
-<script
-  type="text/javascript"
-  src="https://code.jquery.com/jquery-1.12.4.min.js"
-></script>
-<!-- iamport.payment.js -->
-<script
-  type="text/javascript"
-  src="https://cdn.iamport.kr/js/iamport.payment-{SDK-최신버전}.js"
-></script>
-```
+<VersionGate v="v1">
+  결제창 연동을 진행할 주문 페이지에 아래 JS 라이브러리를 추가합니다.
 
-<Hint style="danger">
-  **jQuery 1.0 이상이 설치**되어 있어야 합니다.
-</Hint>
+  ```html
+  <script src="https://cdn.iamport.kr/v1/iamport.js"></script>
+  ```
 
-### 본인인증 페이지에 [<mark style="color:blue;">`고객사 식별코드`</mark>](/opi/ko/integration/ready/readme#4-포트원-연동정보-확인하기)를 이용하여 `IMP` 객체를 초기화합니다.
+  <Youtube videoId="FLyOmbtnr48" caption="포트원 라이브러리 추가하기" />
+</VersionGate>
+
+## 2. SDK 초기화하기 <span id="sdk-installation" />
+
+포트원 SDK를 사용하여 결제창을 호출하려면, 먼저 포트원 SDK를 초기화하여야 합니다.
+
+먼저, 관리자 콘솔의 결제 연동 페이지에서 **고객사 식별코드**를 확인해 주세요.
+
+그리고 결제창을 호출할 페이지에서 다음과 같이 포트원 SDK를 초기화합니다.
 
 ```ts title="client-side"
 IMP.init("{고객사 식별코드}"); // 예: imp00000000

--- a/src/routes/(root)/opi/ko/extra/identity-verification/v1/credit-auth/2.mdx
+++ b/src/routes/(root)/opi/ko/extra/identity-verification/v1/credit-auth/2.mdx
@@ -30,6 +30,7 @@ import Tabs from "~/components/gitbook/Tabs";
     IMP.certification(
       {
         // param
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         merchant_uid: "ORD20180131-0000011", // 주문 번호
         // 모바일환경에서 popup:false(기본값) 인 경우 필수
         m_redirect_url: "{리디렉션 될 URL}",
@@ -53,6 +54,7 @@ import Tabs from "~/components/gitbook/Tabs";
     IMP.certification(
       {
         // param
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         merchant_uid: "ORD20180131-0000011", // 주문 번호
         m_redirect_url: "{리디렉션 될 URL}", // 모바일환경에서 popup:false(기본값) 인 경우 필수
         popup: false, // PC환경에서는 popup 파라미터가 무시되고 항상 true 로 적용됨

--- a/src/routes/(root)/opi/ko/extra/identity-verification/v1/phone/1.mdx
+++ b/src/routes/(root)/opi/ko/extra/identity-verification/v1/phone/1.mdx
@@ -6,7 +6,31 @@ versionVariants:
   v2: /ko/extra/identity-verification/readme-v2
 ---
 
-[**`고객사 식별코드`**](/opi/ko/integration/ready/readme#4-포트원-연동정보-확인하기)를 이용하여 `IMP` 객체를 초기화합니다.
+import VersionGate from "~/components/gitbook/VersionGate";
+import Youtube from "~/components/gitbook/Youtube";
+
+## 1. 포트원 SDK 설치하기 <span id="sdk-installation" />
+
+포트원은 다양한 PG의 본인인증창을 통일된 방법으로 호출할 수 있도록 자바스크립트 SDK를 제공합니다.
+브라우저에서 포트원 SDK를 호출하여 본인인증을 진행하게 됩니다.
+
+<VersionGate v="v1">
+  결제창 연동을 진행할 주문 페이지에 아래 JS 라이브러리를 추가합니다.
+
+  ```html
+  <script src="https://cdn.iamport.kr/v1/iamport.js"></script>
+  ```
+
+  <Youtube videoId="FLyOmbtnr48" caption="포트원 라이브러리 추가하기" />
+</VersionGate>
+
+## 2. SDK 초기화하기 <span id="sdk-installation" />
+
+포트원 SDK를 사용하여 결제창을 호출하려면, 먼저 포트원 SDK를 초기화하여야 합니다.
+
+먼저, 관리자 콘솔의 결제 연동 페이지에서 **고객사 식별코드**를 확인해 주세요.
+
+그리고 결제창을 호출할 페이지에서 다음과 같이 포트원 SDK를 초기화합니다.
 
 ```ts title="client-side"
 IMP.init("{고객사 식별코드}"); // 예: imp00000000

--- a/src/routes/(root)/opi/ko/extra/identity-verification/v1/phone/2.mdx
+++ b/src/routes/(root)/opi/ko/extra/identity-verification/v1/phone/2.mdx
@@ -7,7 +7,6 @@ versionVariants:
 ---
 
 import Tabs from "~/components/gitbook/Tabs";
-import Hint from "~/components/Hint";
 
 휴대폰 본인인증은 아래 두가지 방법으로 호출할 수 있습니다.
 
@@ -23,12 +22,6 @@ import Hint from "~/components/Hint";
 >
 > **WebView 등 팝업이 차단되는 환경**에서는 `popup : false`로 설정하는 것을 권장합니다.
 
-<Hint style="warning">
-  **리디렉션 방식**
-
-  포트원 JavaScript **SDK 1.1.7** 버전 이상 부터 지원합니다.
-</Hint>
-
 아래는 휴대폰 본인인증창을 호출하는 예제입니다.
 
 <Tabs>
@@ -38,8 +31,8 @@ import Hint from "~/components/Hint";
     IMP.certification(
       {
         // param
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         // 주문 번호
-        pg: "PG사코드.{CPID}", //본인인증 설정이 2개이상 되어 있는 경우 필
         merchant_uid: "ORD20180131-0000011",
         // 모바일환경에서 popup:false(기본값) 인 경우 필수
         m_redirect_url: "{리디렉션 될 URL}",
@@ -66,8 +59,8 @@ import Hint from "~/components/Hint";
     IMP.certification(
       {
         // param
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         // 주문 번호
-        pg: "PG사코드.{CPID}", //본인인증 설정이 2개이상 되어 있는 경우 필
         merchant_uid: "ORD20180131-0000011",
         // 모바일환경에서 popup:false(기본값) 인 경우 필수
         m_redirect_url: "{리디렉션 될 URL}",

--- a/src/routes/(root)/opi/ko/extra/promotion/integration.mdx
+++ b/src/routes/(root)/opi/ko/extra/promotion/integration.mdx
@@ -57,7 +57,7 @@ import Hint from "~/components/Hint";
     {
       isPromotion: true, //프로모션 사용 여부
       promotion_id: "promotion-id-86e1ff2a-2c3a-451c-bdd3-e5cd1664bc3e", //적용할 프로모션 아이디 입력 (Ex. 현대카드 프로모션)
-      pg: "kcp", //호출할 PG사 선택
+      channelKey: "{콘솔 내 연동 정보의 채널키}",
       pay_method: "card", //결제수단 선택
       card: {
         direct: {

--- a/src/routes/(root)/opi/ko/integration/pg/v1/blue.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/blue.mdx
@@ -22,7 +22,7 @@ import Tabs from "~/components/gitbook/Tabs";
     ```ts title="Javascript SDK"
     IMP.request_pay(
       {
-        pg: "bluewalnut.{상점 ID}",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "card",
         merchant_uid: "order_no_0001", // 상점에서 관리하는 주문 번호
         name: "주문명:결제테스트",
@@ -42,7 +42,17 @@ import Tabs from "~/components/gitbook/Tabs";
 
     **주요 파라미터 설명**
 
-    **`pg` \***<mark style="color:green;">**string**</mark>
+    **`channelKey` \*** <mark style="color:green;">**string**</mark>
+
+    **채널키**
+
+    결제를 진행할 채널을 지정합니다.
+
+    포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+    (최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+    **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
     **PG사 구분코드**
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/blue.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/blue.mdx
@@ -5,6 +5,7 @@ description: 블루월넛 결제 연동방법을 안내합니다.
 
 import Figure from "~/components/Figure";
 import Tabs from "~/components/gitbook/Tabs";
+import Hint from "~/components/Hint";
 
 ## 1. 블루월넛 PG 설정하기
 
@@ -57,6 +58,12 @@ import Tabs from "~/components/gitbook/Tabs";
     **PG사 구분코드**
 
     **`bluewalnut`** 로 지정하면 됩니다.
+
+    <Hint style="warning">
+      `pg` 파라미터는 지원 중단 예정입니다.
+
+      JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+    </Hint>
 
     **`pay_method`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/danal.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/danal.mdx
@@ -60,6 +60,12 @@ import Hint from "~/components/Hint";
 
     `danal_tpay` 로 지정하면 됩니다.
 
+    <Hint style="warning">
+      `pg` 파라미터는 지원 중단 예정입니다.
+
+      JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+    </Hint>
+
     **`pay_method`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
     **결제수단 구분코드**
@@ -153,6 +159,12 @@ import Hint from "~/components/Hint";
     **PG사 구분코드**
 
     **`danal_tpay`** 로 지정하면 됩니다.
+
+    <Hint style="warning">
+      `pg` 파라미터는 지원 중단 예정입니다.
+
+      JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+    </Hint>
 
     **`customer_uid` \***<mark style="color:green;">**string**</mark>
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/danal.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/danal.mdx
@@ -24,7 +24,7 @@ import Hint from "~/components/Hint";
     ```ts title="Javascript SDK" showLineNumbers
     IMP.request_pay(
       {
-        pg: "danal_tpay.{CPID}",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "card",
         merchant_uid: "order_no_0001", // 상점에서 생성한 고유 주문번호
         name: "주문명:결제테스트",
@@ -44,11 +44,21 @@ import Hint from "~/components/Hint";
 
     ### 주요 파라미터 설명
 
-    **`pg` \***<mark style="color:green;">**string**</mark>
+    **`channelKey` \*** <mark style="color:green;">**string**</mark>
+
+    **채널키**
+
+    결제를 진행할 채널을 지정합니다.
+
+    포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+    (최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+    **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
     **PG사 구분코드**
 
-    **`danal_tpay`** 로 지정하면 됩니다.
+    `danal_tpay` 로 지정하면 됩니다.
 
     **`pay_method`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
@@ -101,7 +111,7 @@ import Hint from "~/components/Hint";
     ```ts
     IMP.request_pay(
       {
-        pg: "danal_tpay.{CPID}",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "card", // 'card'만 지원됩니다.
         merchant_uid: "order_monthly_0001", // 상점에서 관리하는 주문 번호
         name: "최초인증결제",
@@ -128,7 +138,17 @@ import Hint from "~/components/Hint";
 
     ### 주요 파라미터 설명
 
-    **`pg` \***<mark style="color:green;">**string**</mark>
+    **`channelKey` \*** <mark style="color:green;">**string**</mark>
+
+    **채널키**
+
+    결제를 진행할 채널을 지정합니다.
+
+    포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+    (최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+    **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
     **PG사 구분코드**
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/daou/readme.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/daou/readme.mdx
@@ -73,6 +73,12 @@ import Hint from "~/components/Hint";
 
     `daou` 로 지정하면 됩니다.
 
+    <Hint style="warning">
+      `pg` 파라미터는 지원 중단 예정입니다.
+
+      JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+    </Hint>
+
     **`pay_method`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
     **결제수단 구분코드**

--- a/src/routes/(root)/opi/ko/integration/pg/v1/daou/readme.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/daou/readme.mdx
@@ -28,7 +28,7 @@ import Hint from "~/components/Hint";
     ```ts title="Javascript SDK"
     IMP.request_pay(
       {
-        pg: "daou.{상점 ID}",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "card",
         merchant_uid: "mid_1234567890",
         escrow: false,
@@ -57,11 +57,21 @@ import Hint from "~/components/Hint";
 
     **주요 파라미터 설명**
 
-    **`pg` \***<mark style="color:green;">**string**</mark>
+    **`channelKey` \*** <mark style="color:green;">**string**</mark>
+
+    **채널키**
+
+    결제를 진행할 채널을 지정합니다.
+
+    포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+    (최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+    **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
     **PG사 구분코드**
 
-    **`daou`** 로 지정하면 됩니다.
+    `daou` 로 지정하면 됩니다.
 
     **`pay_method`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/eximbay.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/eximbay.mdx
@@ -63,6 +63,12 @@ import Hint from "~/components/Hint";
 
     `eximbay` 로 지정하면 됩니다.
 
+    <Hint style="warning">
+      `pg` 파라미터는 지원 중단 예정입니다.
+
+      JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+    </Hint>
+
     **`pay_method`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
     **결제수단 구분코드**

--- a/src/routes/(root)/opi/ko/integration/pg/v1/eximbay.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/eximbay.mdx
@@ -25,7 +25,7 @@ import Hint from "~/components/Hint";
     ```ts title="Javascript SDK"
     IMP.request_pay(
       {
-        pg: "eximbay.{상점 ID}",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "card",
         merchant_uid: "order_no_0001", // 상점에서 관리하는 주문 번호
         name: "주문명:결제테스트",
@@ -47,11 +47,21 @@ import Hint from "~/components/Hint";
 
     **주요 파라미터 설명**
 
-    **`pg` \***<mark style="color:green;">**string**</mark>
+    **`channelKey` \*** <mark style="color:green;">**string**</mark>
+
+    **채널키**
+
+    결제를 진행할 채널을 지정합니다.
+
+    포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+    (최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+    **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
     **PG사 구분코드**
 
-    **`eximbay`** 로 지정하면 됩니다.
+    `eximbay` 로 지정하면 됩니다.
 
     **`pay_method`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
@@ -195,7 +205,7 @@ import Hint from "~/components/Hint";
 
     ```ts
     IMP.request_pay({
-      pg: "eximbay.{상점 ID}",
+      channelKey: "{콘솔 내 연동 정보의 채널키}",
       pay_method: "card",
       merchant_uid: "order_no_0001",
       name: "주문명:결제테스트",

--- a/src/routes/(root)/opi/ko/integration/pg/v1/hyphen.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/hyphen.mdx
@@ -65,7 +65,7 @@ import Tabs from "~/components/gitbook/Tabs";
     ```ts
     IMP.request_pay(
       {
-        pg: "hyphen.{MID}",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "trans",
         merchant_uid: "orderMonthly0001", // 상점에서 관리하는 주문 번호
         name: "테스트결제",
@@ -91,7 +91,17 @@ import Tabs from "~/components/gitbook/Tabs";
 ### 주요 파라미터
 
 <ParamTree>
-  - `pg` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - **`channelKey` \*** <mark style="color:green;">**string**</mark>
+
+    **채널키**
+
+    결제를 진행할 채널을 지정합니다.
+
+    포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+    (최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+  - **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
     **PG사 구분코드**
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/hyphen.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/hyphen.mdx
@@ -9,6 +9,7 @@ versionVariants:
 import Details from "~/components/gitbook/Details";
 import ParamTree from "~/components/gitbook/ParamTree";
 import Tabs from "~/components/gitbook/Tabs";
+import Hint from "~/components/Hint";
 
 ## 채널 설정하기
 
@@ -91,7 +92,7 @@ import Tabs from "~/components/gitbook/Tabs";
 ### 주요 파라미터
 
 <ParamTree>
-  - **`channelKey` \*** <mark style="color:green;">**string**</mark>
+  - `channelKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
     **채널키**
 
@@ -101,11 +102,17 @@ import Tabs from "~/components/gitbook/Tabs";
 
     (최신 JavaScript SDK 버전부터 사용 가능합니다.)
 
-  - **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
+  - `pg` (deprecated) <mark style="color:green;">**string**</mark>
 
     **PG사 구분코드**
 
     `hyphen.{MID}` 형태로 지정하여 사용해야 합니다.
+
+    <Hint style="warning">
+      `pg` 파라미터는 지원 중단 예정입니다.
+
+      JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+    </Hint>
 
   - `pay_method` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/inicis.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/inicis.mdx
@@ -85,6 +85,12 @@ KG이니시스 결제창을 호출할 수 있습니다.
 
     PG상점아이디는 KG 이니시스와 계약 후 발급받을 수 있습니다.
 
+    <Hint style="warning">
+      `pg` 파라미터는 지원 중단 예정입니다.
+
+      JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+    </Hint>
+
     **`pay_method`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
     **결제수단 구분코드**
@@ -191,6 +197,12 @@ KG이니시스 결제창을 호출할 수 있습니다.
     **`html5_inicis`** 로 설정
 
     > KG이니시스에서 발급받은 상점아이디가 여러개(각각 일반 및 정기)인 경우에는 html5\_inicis.\{상점아이디} 또는 inicis.\{상점아이디}(for ActiveX)로 지정합니다.
+
+    <Hint style="warning">
+      `pg` 파라미터는 지원 중단 예정입니다.
+
+      JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+    </Hint>
 
     **`customer_uid` \***<mark style="color:green;">**string**</mark>
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/inicis.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/inicis.mdx
@@ -31,7 +31,7 @@ KG이니시스 결제창을 호출할 수 있습니다.
     ```ts title="Javascript SDK"
     IMP.request_pay(
       {
-        pg: "html5_inicis.{PG상점아이디}", //테스트 시 html5_inicis.INIpayTest 기재
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "card",
         merchant_uid: "order_no_0001", //상점에서 생성한 고유 주문번호
         name: "주문명:결제테스트",
@@ -67,7 +67,17 @@ KG이니시스 결제창을 호출할 수 있습니다.
 
     ### **주요 파라미터 설명**
 
-    **`pg` \***<mark style="color:green;">**string**</mark>
+    **`channelKey` \*** <mark style="color:green;">**string**</mark>
+
+    **채널키**
+
+    결제를 진행할 채널을 지정합니다.
+
+    포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+    (최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+    **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
     **PG사 구분코드**
 
@@ -141,7 +151,7 @@ KG이니시스 결제창을 호출할 수 있습니다.
     ```ts title="Javascript SDK"
     IMP.request_pay(
       {
-        pg: "html5_inicis.{PG상점아이디}", // 실제 계약 후에는 실제 상점아이디로 변경
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "card", // 'card'만 지원됩니다.
         merchant_uid: "order_monthly_0001", // 상점에서 관리하는 주문 번호
         name: "최초인증결제",
@@ -164,7 +174,17 @@ KG이니시스 결제창을 호출할 수 있습니다.
 
     ### **주요 파라미터 설명**
 
-    **`pg` \***<mark style="color:green;">**string**</mark>
+    **`channelKey` \*** <mark style="color:green;">**string**</mark>
+
+    **채널키**
+
+    결제를 진행할 채널을 지정합니다.
+
+    포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+    (최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+    **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
     **PG사 구분코드**
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/kakaopay.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/kakaopay.mdx
@@ -28,7 +28,7 @@ import Hint from "~/components/Hint";
     ```ts title="Javascript SDK"
     IMP.request_pay(
       {
-        pg: "kakaopay.{CID}",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "card", // 생략가
         merchant_uid: "order_no_0001", // 상점에서 생성한 고유 주문번호
         name: "주문명:결제테스트",
@@ -49,11 +49,21 @@ import Hint from "~/components/Hint";
 
     **주요 파라미터 설명**
 
-    **`pg`** <mark style="color:green;">**string**</mark>
+    **`channelKey` \*** <mark style="color:green;">**string**</mark>
+
+    **채널키**
+
+    결제를 진행할 채널을 지정합니다.
+
+    포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+    (최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+    **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
     **PG사 구분코드**
 
-    **`kakaopay`** 로 지정하면 됩니다.
+    `kakaopay` 로 지정하면 됩니다.
 
     **`pay_method`** <mark style="color:green;">**string**</mark>
 
@@ -90,7 +100,7 @@ import Hint from "~/components/Hint";
     ```ts title="Javascript SDK"
     IMP.request_pay(
       {
-        pg: "kakaopay.{CID}",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         merchant_uid: "order_monthly_0001", // 상점에서 관리하는 주문 번호
         name: "최초인증결제",
         amount: 0, // 결제창에 표시될 금액. 실제 승인이 이뤄지지는 않습니다.
@@ -112,7 +122,17 @@ import Hint from "~/components/Hint";
 
     **주요 파라미터 설명**
 
-    **`pg`** <mark style="color:green;">**string**</mark>
+    **`channelKey` \*** <mark style="color:green;">**string**</mark>
+
+    **채널키**
+
+    결제를 진행할 채널을 지정합니다.
+
+    포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+    (최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+    **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
     **PG사 구분코드**
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/kakaopay.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/kakaopay.mdx
@@ -65,6 +65,12 @@ import Hint from "~/components/Hint";
 
     `kakaopay` 로 지정하면 됩니다.
 
+    <Hint style="warning">
+      `pg` 파라미터는 지원 중단 예정입니다.
+
+      JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+    </Hint>
+
     **`pay_method`** <mark style="color:green;">**string**</mark>
 
     **결제수단 구분코드**
@@ -137,6 +143,12 @@ import Hint from "~/components/Hint";
     **PG사 구분코드**
 
     **`kakaopay`** 로 지정하면 됩니다.
+
+    <Hint style="warning">
+      `pg` 파라미터는 지원 중단 예정입니다.
+
+      JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+    </Hint>
 
     **`customer_uid`** <mark style="color:green;">**string**</mark>
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/kg.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/kg.mdx
@@ -24,7 +24,7 @@ KG 모빌리언스 결제창을 호출할 수 있습니다.
 ```ts title="Javascript SDK"
 IMP.request_pay(
   {
-    pg: "mobilians.{상점 ID}",
+    channelKey: "{콘솔 내 연동 정보의 채널키}",
     pay_method: "phone",
     merchant_uid: "order_no_0001", //상점에서 생성한 고유 주문번호
     name: "주문명:결제테스트",
@@ -45,11 +45,21 @@ IMP.request_pay(
 
 ## 주요 파라미터 설명
 
-**`pg` \***<mark style="color:green;">**string**</mark>
+**`channelKey` \*** <mark style="color:green;">**string**</mark>
+
+**채널키**
+
+결제를 진행할 채널을 지정합니다.
+
+포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+(최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+**`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
 **PG사 구분코드**
 
-**`mobilians`** 로 지정하면 됩니다.
+`mobilians` 로 지정하면 됩니다.
 
 **`pay_method`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
@@ -76,7 +86,7 @@ IMP.request_pay(
 ```ts title="Javascript SDK"
 IMP.request_pay(
   {
-    pg: "mobilians",
+    channelKey: "{콘솔 내 연동 정보의 채널키}",
     pay_method: "phone",
     merchant_uid: "order_monthly_0001", // 상점에서 관리하는 주문 번호
     name: "최초인증결제",
@@ -105,7 +115,17 @@ IMP.request_pay(
 
 ### 주요 파라미터 설명
 
-**`pg` \***<mark style="color:green;">**string**</mark>
+**`channelKey` \*** <mark style="color:green;">**string**</mark>
+
+**채널키**
+
+결제를 진행할 채널을 지정합니다.
+
+포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+(최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+**`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
 **PG사 구분코드**
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/kg.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/kg.mdx
@@ -61,6 +61,12 @@ IMP.request_pay(
 
 `mobilians` 로 지정하면 됩니다.
 
+<Hint style="warning">
+  `pg` 파라미터는 지원 중단 예정입니다.
+
+  JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+</Hint>
+
 **`pay_method`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
 **결제수단 구분 코드**
@@ -130,6 +136,12 @@ IMP.request_pay(
 **PG사 구분코드**
 
 **`mobilians.<KG모빌리언스와 계약이 완료된 MID>`** 로 지정하면 됩니다.
+
+<Hint style="warning">
+  `pg` 파라미터는 지원 중단 예정입니다.
+
+  JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+</Hint>
 
 **`customer_uid` \***<mark style="color:green;">**string**</mark>
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/kicc.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/kicc.mdx
@@ -25,7 +25,7 @@ import Hint from "~/components/Hint";
     ```ts title="Javascript SDK"
     IMP.request_pay(
       {
-        pg: "kicc.{상점 ID}",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "card",
         merchant_uid: "order_no_0001", // 상점에서 생성한 고유 주문번호
         name: "주문명:결제테스트",
@@ -46,11 +46,21 @@ import Hint from "~/components/Hint";
 
     ### 주요 파라미터 설명
 
-    **`pg` \***<mark style="color:green;">**string**</mark>
+    **`channelKey` \*** <mark style="color:green;">**string**</mark>
+
+    **채널키**
+
+    결제를 진행할 채널을 지정합니다.
+
+    포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+    (최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+    **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
     **PG사 구분코드**
 
-    **`kicc`** 로 지정하면 됩니다.
+    `kicc` 로 지정하면 됩니다.
 
     **`pay_method`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
@@ -91,7 +101,7 @@ import Hint from "~/components/Hint";
     ```ts title="Javascript SDK"
     IMP.request_pay(
       {
-        pg: "kicc",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "card", // 'card'만 지원됩니다.
         merchant_uid: "order_monthly_0001", // 상점에서 관리하는 주문 번호
         name: "최초인증결제",
@@ -119,7 +129,17 @@ import Hint from "~/components/Hint";
 
     ### 주요 파라미터 설명
 
-    **`pg` \***<mark style="color:green;">**string**</mark>
+    **`channelKey` \*** <mark style="color:green;">**string**</mark>
+
+    **채널키**
+
+    결제를 진행할 채널을 지정합니다.
+
+    포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+    (최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+    **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
     **PG사 구분코드**
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/kicc.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/kicc.mdx
@@ -62,6 +62,12 @@ import Hint from "~/components/Hint";
 
     `kicc` 로 지정하면 됩니다.
 
+    <Hint style="warning">
+      `pg` 파라미터는 지원 중단 예정입니다.
+
+      JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+    </Hint>
+
     **`pay_method`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
     **결제수단 구분코드**
@@ -144,6 +150,12 @@ import Hint from "~/components/Hint";
     **PG사 구분코드**
 
     **`kicc.<KICC와 협의가 완료된 MID>`** 로 지정하면 됩니다.
+
+    <Hint style="warning">
+      `pg` 파라미터는 지원 중단 예정입니다.
+
+      JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+    </Hint>
 
     **`customer_uid` \***<mark style="color:green;">**string**</mark>
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/ksnet/readme.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/ksnet/readme.mdx
@@ -53,7 +53,7 @@ KSNET 결제창을 호출할 수 있습니다. **결제결과**는 PC의 경우 
     ```ts title="JavaScript SDK"
     IMP.request_pay(
       {
-        pg: "ksnet.{PG 상점 아이디}", // 테스트인 경우 ksnet.2999199999
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "card",
         merchant_uid: "order_id_1667634130160", // 상점에서 채번하는 고유 주문 번호
         name: "나이키 와플 트레이너 2 SD",
@@ -93,7 +93,17 @@ KSNET 결제창을 호출할 수 있습니다. **결제결과**는 PC의 경우 
 
     **주요 파라미터 설명**
 
-    **`pg`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+    **`channelKey` \*** <mark style="color:green;">**string**</mark>
+
+    **채널키**
+
+    결제를 진행할 채널을 지정합니다.
+
+    포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+    (최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+    **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
     **PG사 구분코드**
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/ksnet/readme.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/ksnet/readme.mdx
@@ -109,6 +109,12 @@ KSNET 결제창을 호출할 수 있습니다. **결제결과**는 PC의 경우 
 
     `ksnet.{PG 상점 아이디}`
 
+    <Hint style="warning">
+      `pg` 파라미터는 지원 중단 예정입니다.
+
+      JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+    </Hint>
+
     **`pay_method`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
     **결제수단 구분코드**

--- a/src/routes/(root)/opi/ko/integration/pg/v1/naver.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/naver.mdx
@@ -29,7 +29,7 @@ callback) 호출 후 <mark style="color:red;">**callback**</mark> 으로 수신 
     ```ts title="Javascript SDK"
     IMP.request_pay(
       {
-        pg: "naverpay.{파트너 ID}",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         merchant_uid: "order_no_0001", // 상점에서 관리하는 주문 번호
         name: "주문명:결제테스트",
         amount: 1004,
@@ -87,7 +87,17 @@ callback) 호출 후 <mark style="color:red;">**callback**</mark> 으로 수신 
 
     **주요 파라미터 설명**
 
-    **`pg`** <mark style="color:green;">**string**</mark>
+    **`channelKey` \*** <mark style="color:green;">**string**</mark>
+
+    **채널키**
+
+    결제를 진행할 채널을 지정합니다.
+
+    포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+    (최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+    **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
     **PG사 구분코드**
 
@@ -171,12 +181,13 @@ callback) 호출 후 <mark style="color:red;">**callback**</mark> 으로 수신 
     >   - 고객사의 업종이 통신판매중개업에 해당하여 네이버페이 계약 당시 별도의 안내를 받은 대상 고객사만 필수 입력합니다.
     >   - 비대상 고객사는 입력하지 않습니다.
 
-    **`naverChainId`** <mark style="color:green;">**string**</mark>
+    **`naverChainId` (deprecated)** <mark style="color:green;">**string**</mark>
 
     **네이버페이 그룹형 고객사용 chain id**
 
-    - 같은 파트너 ID로 두개 이상의 서비스를 운영하는 그룹형 고객사의 경우에만 네이버페이로부터 전달받은 값을 필수 입력합니다.
-    - 비 대상 고객사는 입력하지 않습니다.
+    포트원 콘솔에서 채널 등록 시 chain id를 추가하시고 channelKey 파라미터를 이용해 채널을 지정하신다면 설정이 필요 없는 값입니다.
+
+    deprecated된 pg 파라미터를 이용하여 채널을 선택할 경우 설정이 필요합니다.
 
     **`naverCultureBenefit`** <mark style="color:orange;">**boolean**</mark>
 
@@ -199,7 +210,7 @@ callback) 호출 후 <mark style="color:red;">**callback**</mark> 으로 수신 
     ```ts title="JavaScript SDK"
     IMP.request_pay(
       {
-        pg: "naverpay.{파트너 ID}",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         customer_uid: "gildong_0001_1234", // 빌링, 필수 입력.
         merchant_uid: "order_monthly_0001", // 상점에서 생성한 고유 주문번호
         name: "Slim 요금제(1개월 단위)",
@@ -223,7 +234,17 @@ callback) 호출 후 <mark style="color:red;">**callback**</mark> 으로 수신 
 
     **주요 파라미터 설명**
 
-    **`pg`** <mark style="color:green;">**string**</mark>
+    **`channelKey` \*** <mark style="color:green;">**string**</mark>
+
+    **채널키**
+
+    결제를 진행할 채널을 지정합니다.
+
+    포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+    (최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+    **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
     **PG사 구분코드**
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/naver.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/naver.mdx
@@ -103,6 +103,12 @@ callback) 호출 후 <mark style="color:red;">**callback**</mark> 으로 수신 
 
     `naverpay` 로 지정하면 됩니다.
 
+    <Hint style="warning">
+      `pg` 파라미터는 지원 중단 예정입니다.
+
+      JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+    </Hint>
+
     **`merchant_uid`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
     **주문번호**
@@ -249,6 +255,12 @@ callback) 호출 후 <mark style="color:red;">**callback**</mark> 으로 수신 
     **PG사 구분코드**
 
     `naverpay` 로 지정하면 됩니다.
+
+    <Hint style="warning">
+      `pg` 파라미터는 지원 중단 예정입니다.
+
+      JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+    </Hint>
 
     **`customer_uid`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/newtoss/readme.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/newtoss/readme.mdx
@@ -105,6 +105,12 @@ import image4 from "../_assets/tosspayments/tosspayments4.png";
 
         `tosspayments` 로 지정하면 됩니다.
 
+        <Hint style="warning">
+          `pg` 파라미터는 지원 중단 예정입니다.
+
+          JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+        </Hint>
+
         **`pay_method`** <mark style="color:green;">**string**</mark>
 
         - 카드 (card)
@@ -238,6 +244,12 @@ import image4 from "../_assets/tosspayments/tosspayments4.png";
     **PG사 구분코드**
 
     **`tosspayments`** 로 지정하면 됩니다.
+
+    <Hint style="warning">
+      `pg` 파라미터는 지원 중단 예정입니다.
+
+      JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+    </Hint>
 
     **`customer_uid` \***<mark style="color:green;">**string**</mark>
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/newtoss/readme.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/newtoss/readme.mdx
@@ -52,7 +52,7 @@ import image4 from "../_assets/tosspayments/tosspayments4.png";
 
     IMP.request_pay(
       {
-        pg: "tosspayments", // 반드시 "tosspayments"임을 명시해주세요.
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         merchant_uid: "order_id_1667634130160",
         name: "나이키 와플 트레이너 2 SD",
         pay_method: "card",
@@ -89,11 +89,21 @@ import image4 from "../_assets/tosspayments/tosspayments4.png";
       <Details.Summary><strong>주요 파라미터 설명</strong></Details.Summary>
 
       <Details.Content>
-        **`pg` \***<mark style="color:green;">**string**</mark>
+        **`channelKey` \*** <mark style="color:green;">**string**</mark>
+
+        **채널키**
+
+        결제를 진행할 채널을 지정합니다.
+
+        포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+        (최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+        **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
         **PG사 구분코드**
 
-        _tosspayments_ 로 지정하면 됩니다.
+        `tosspayments` 로 지정하면 됩니다.
 
         **`pay_method`** <mark style="color:green;">**string**</mark>
 
@@ -188,7 +198,7 @@ import image4 from "../_assets/tosspayments/tosspayments4.png";
     ```ts title="Javascript SDK"
     IMP.request_pay(
       {
-        pg: "tosspayments.{MID}",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "card", // 'card'만 지원됩니다.
         merchant_uid: "order_monthly_0001", // 상점에서 관리하는 주문 번호
         name: "최초인증결제",
@@ -213,7 +223,17 @@ import image4 from "../_assets/tosspayments/tosspayments4.png";
 
     **주요 파라미터 설명**
 
-    **`pg` \***<mark style="color:green;">**string**</mark>
+    **`channelKey` \*** <mark style="color:green;">**string**</mark>
+
+    **채널키**
+
+    결제를 진행할 채널을 지정합니다.
+
+    포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+    (최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+    **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
     **PG사 구분코드**
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/nhn-kcp.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/nhn-kcp.mdx
@@ -80,7 +80,7 @@ KCP 기준으로 작성한 예시 코드는 아래와 같습니다.
     ```ts
     IMP.request_pay(
       {
-        pg: "kcp.{사이트코드}", //테스트인경우 kcp.T0000
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "card",
         merchant_uid: "order_no_0001", //상점에서 생성한 고유 주문번호
         name: "결제테스트", //주문명
@@ -107,7 +107,17 @@ KCP 기준으로 작성한 예시 코드는 아래와 같습니다.
 #### 주요 파라미터
 
 <ParamTree>
-  - **`pg`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - **`channelKey` \*** <mark style="color:green;">**string**</mark>
+
+    **채널키**
+
+    결제를 진행할 채널을 지정합니다.
+
+    포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+    (최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+  - **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
     **PG사 구분코드**
 
@@ -297,7 +307,7 @@ KCP 기준으로 작성한 예시 코드는 아래와 같습니다.
       <Tabs.Tab title="상품권 결제 호출 예제">
         ```ts
         IMP.request_pay({
-          pg: "kcp.T0000", //kcp.(사이트코드) 형식으로 입력해야 합니다.
+          channelKey: "{콘솔 내 연동 정보의 채널키}",
           pay_method: "cultureland", //컬처랜드 문화상품권
           merchant_uid: "A00021-TEST",
           name: "당근 10kg",
@@ -345,7 +355,7 @@ KCP 기준으로 작성한 예시 코드는 아래와 같습니다.
       <Tabs.Tab>
         ```ts title="JavaScript SDK"
         IMP.request_pay({
-          pg: "kcp",
+          channelKey: "{콘솔 내 연동 정보의 채널키}",
           escrow: true, // 에스크로 결제인 경우 필요
           kcpProducts: [
             {
@@ -396,7 +406,7 @@ KCP 기준으로 작성한 예시 코드는 아래와 같습니다.
     ```ts title="Javascript SDK" showLineNumbers
     IMP.request_pay(
       {
-        pg: "kcp_billing.{사이트코드}",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "card", //'card'만 지원됩니다.
         merchant_uid: "order_monthly_0001", //상점에서 생성한 고유 주문번호
         name: "정기결제",
@@ -422,7 +432,17 @@ KCP 기준으로 작성한 예시 코드는 아래와 같습니다.
 #### 주요 파라미터 설명
 
 <ParamTree>
-  - **`pg`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - **`channelKey` \*** <mark style="color:green;">**string**</mark>
+
+    **채널키**
+
+    결제를 진행할 채널을 지정합니다.
+
+    포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+    (최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+  - **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
     **PG사 구분코드**
 
@@ -579,7 +599,7 @@ KCP 퀵페이 기준으로 작성한 예시 코드는 아래와 같습니다.
     ```ts
     IMP.request_pay(
       {
-        pg: "kcp_quick.{사이트코드}",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "card", //즉시 출금 이용 시 'trans' 입력
         merchant_uid: "order_no_0001", //상점에서 생성한 고유 주문번호
         name: "결제수단 등록테스트", //주문명
@@ -612,7 +632,7 @@ KCP 퀵페이 기준으로 작성한 예시 코드는 아래와 같습니다.
     ```ts
     IMP.request_pay(
       {
-        pg: "kcp_quick.{사이트코드}",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "card", //즉시 출금 이용 시 'trans' 입력
         merchant_uid: "order_no_0001", //상점에서 생성한 고유 주문번호
         name: "결제수단 삭제테스트", //주문명
@@ -647,7 +667,7 @@ KCP 퀵페이 기준으로 작성한 예시 코드는 아래와 같습니다.
     ```ts
     IMP.request_pay(
       {
-        pg: "kcp_quick.{사이트코드}",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "card", //즉시 출금 이용 시 'trans' 입력
         merchant_uid: "order_no_0001", //상점에서 생성한 고유 주문번호
         name: "결제 테스트", //주문명
@@ -682,7 +702,7 @@ KCP 퀵페이 기준으로 작성한 예시 코드는 아래와 같습니다.
     ```ts
     IMP.request_pay(
       {
-        pg: "kcp_quick.{사이트코드}",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "card", //즉시 출금 이용 시 'trans' 입력
         merchant_uid: "order_no_0001", //상점에서 생성한 고유 주문번호
         name: "PIN번호 변경 테스트", //주문명
@@ -715,7 +735,7 @@ KCP 퀵페이 기준으로 작성한 예시 코드는 아래와 같습니다.
     ```ts
     IMP.request_pay(
       {
-        pg: "kcp_quick.{사이트코드}",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "card", //즉시 출금 이용 시 'trans' 입력
         merchant_uid: "order_no_0001", //상점에서 생성한 고유 주문번호
         name: "PIN번호 초기화 테스트", //주문명
@@ -745,82 +765,82 @@ KCP 퀵페이 기준으로 작성한 예시 코드는 아래와 같습니다.
   </Tabs.Tab>
 
   {/*
-    <Tabs.Tab title="PIN번호 확인">
-      ```ts
-      IMP.request_pay(
-        {
-          pg: "kcp_quick.{사이트코드}",
-          pay_method: "card", //즉시 출금 이용 시 'trans' 입력
-          merchant_uid: "order_no_0001", //상점에서 생성한 고유 주문번호
-          name: "PIN번호 확인 테스트", //주문명
-          amount: 0, //pin번호 확인시 0으로 전달
-          buyer_email: "test@portone.io",
-          buyer_name: "구매자이름",
-          buyer_tel: "010-1234-5678",
-          buyer_addr: "서울특별시 강남구 삼성동",
-          buyer_postcode: "123-456",
-          customer_uid: "use_your_unique_id", //memberId와 동일하게 입력
-          bypass: {
-            kcpQuick: {
-              //KCP퀵페이 설정 정보
-              actionType: "PinCheck", //PIN번호 확인
-              memberCI: "djkDFJ45dFndkl", //결제수단 등록시 입력한 CI 값
-              memeberID: "use_your_unique_id", //사용자에 대한 고유 식별값
+        <Tabs.Tab title="PIN번호 확인">
+          ```ts
+          IMP.request_pay(
+            {
+              channelKey: "{콘솔 내 연동 정보의 채널키}",
+              pay_method: "card", //즉시 출금 이용 시 'trans' 입력
+              merchant_uid: "order_no_0001", //상점에서 생성한 고유 주문번호
+              name: "PIN번호 확인 테스트", //주문명
+              amount: 0, //pin번호 확인시 0으로 전달
+              buyer_email: "test@portone.io",
+              buyer_name: "구매자이름",
+              buyer_tel: "010-1234-5678",
+              buyer_addr: "서울특별시 강남구 삼성동",
+              buyer_postcode: "123-456",
+              customer_uid: "use_your_unique_id", //memberId와 동일하게 입력
+              bypass: {
+                kcpQuick: {
+                  //KCP퀵페이 설정 정보
+                  actionType: "PinCheck", //PIN번호 확인
+                  memberCI: "djkDFJ45dFndkl", //결제수단 등록시 입력한 CI 값
+                  memeberID: "use_your_unique_id", //사용자에 대한 고유 식별값
+                },
+              },
+              m_redirect_url: "https://testtest.test", //결제수단 등록 후 리디렉션될 URL
             },
-          },
-          m_redirect_url: "https://testtest.test", //결제수단 등록 후 리디렉션될 URL
-        },
-        function (rsp) {
-          // callback 로직
-          //...중략...
-        },
-      );
-      ```
-    </Tabs.Tab>
-  */}
+            function (rsp) {
+              // callback 로직
+              //...중략...
+            },
+          );
+          ```
+        </Tabs.Tab>
+      */}
 </Tabs>
 
 <Tabs>
   {/*
-    <Tabs.Tab title="사용자만 등록">
-      ```ts
-      IMP.request_pay(
-        {
-          pg: "kcp_quick.{사이트코드}",
-          pay_method: "card", //즉시 출금 이용 시 'trans' 입력
-          merchant_uid: "order_no_0001", //상점에서 생성한 고유 주문번호
-          name: "사용자 등록 테스트", //주문명
-          amount: 0, //사용자만 등록시 0으로 전달
-          buyer_email: "test@portone.io",
-          buyer_name: "구매자이름",
-          buyer_tel: "010-1234-5678",
-          buyer_addr: "서울특별시 강남구 삼성동",
-          buyer_postcode: "123-456",
-          customer_uid: "use_your_unique_id", //memberId와 동일하게 입력
-          bypass: {
-            kcpQuick: {
-              //KCP퀵페이 설정 정보
-              actionType: "UserRegister", //결제수단 등록 없이 사용자만 등록
-              memberCI: "djkDFJ45dFndkl", //본인인증 후 전달된 CI 값
-              memeberID: "use_your_unique_id", //사용자에 대한 고유 식별값
+        <Tabs.Tab title="사용자만 등록">
+          ```ts
+          IMP.request_pay(
+            {
+              channelKey: "{콘솔 내 연동 정보의 채널키}",
+              pay_method: "card", //즉시 출금 이용 시 'trans' 입력
+              merchant_uid: "order_no_0001", //상점에서 생성한 고유 주문번호
+              name: "사용자 등록 테스트", //주문명
+              amount: 0, //사용자만 등록시 0으로 전달
+              buyer_email: "test@portone.io",
+              buyer_name: "구매자이름",
+              buyer_tel: "010-1234-5678",
+              buyer_addr: "서울특별시 강남구 삼성동",
+              buyer_postcode: "123-456",
+              customer_uid: "use_your_unique_id", //memberId와 동일하게 입력
+              bypass: {
+                kcpQuick: {
+                  //KCP퀵페이 설정 정보
+                  actionType: "UserRegister", //결제수단 등록 없이 사용자만 등록
+                  memberCI: "djkDFJ45dFndkl", //본인인증 후 전달된 CI 값
+                  memeberID: "use_your_unique_id", //사용자에 대한 고유 식별값
+                },
+              },
+              m_redirect_url: "https://testtest.test", //결제수단 등록 후 리디렉션될 URL
             },
-          },
-          m_redirect_url: "https://testtest.test", //결제수단 등록 후 리디렉션될 URL
-        },
-        function (rsp) {
-          //callback 로직
-          //...중략...
-        },
-      );
-      ```
-    </Tabs.Tab>
-  */}
+            function (rsp) {
+              //callback 로직
+              //...중략...
+            },
+          );
+          ```
+        </Tabs.Tab>
+      */}
 
   <Tabs.Tab title="등록된 전화번호 변경">
     ```ts
     IMP.request_pay(
       {
-        pg: "kcp_quick.{사이트코드}",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "card", //즉시 출금 이용 시 'trans' 입력
         merchant_uid: "order_no_0001", //상점에서 생성한 고유 주문번호
         name: "전화번호 변경 테스트", //주문명
@@ -855,7 +875,7 @@ KCP 퀵페이 기준으로 작성한 예시 코드는 아래와 같습니다.
     ```ts
     IMP.request_pay(
       {
-        pg: "kcp_quick.{사이트코드}",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "card", //즉시 출금 이용 시 'trans' 입력
         merchant_uid: "order_no_0001", //상점에서 생성한 고유 주문번호
         name: "해지 테스트", //주문명
@@ -899,7 +919,17 @@ KCP 퀵페이 기준으로 작성한 예시 코드는 아래와 같습니다.
 #### 주요 파라미터
 
 <ParamTree>
-  - **`pg`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - **`channelKey` \*** <mark style="color:green;">**string**</mark>
+
+    **채널키**
+
+    결제를 진행할 채널을 지정합니다.
+
+    포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+    (최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+  - **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
     **PG사 구분코드**
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/nhn-kcp.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/nhn-kcp.mdx
@@ -124,6 +124,12 @@ KCP 기준으로 작성한 예시 코드는 아래와 같습니다.
     포트원 콘솔 내 \[연동 관리] > \[연동 정보] > \[채널 관리] 화면에서 채널 추가 후
     `kcp.{mid(사이트코드)}` 형식으로 채널을 지정할 때 사용됩니다.
 
+    <Hint style="warning">
+      `pg` 파라미터는 지원 중단 예정입니다.
+
+      JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+    </Hint>
+
   - **`pay_method`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
     **결제수단 구분코드**
@@ -448,6 +454,12 @@ KCP 기준으로 작성한 예시 코드는 아래와 같습니다.
 
     포트원 콘솔 내 \[연동 관리] > \[연동 정보] > \[채널 관리] 화면에서 채널 추가 후
     `kcp_billing.{mid(사이트코드)}` 형식으로 채널을 지정할 때 사용됩니다.
+
+    <Hint style="warning">
+      `pg` 파라미터는 지원 중단 예정입니다.
+
+      JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+    </Hint>
 
   - **`customer_uid`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
@@ -935,6 +947,12 @@ KCP 퀵페이 기준으로 작성한 예시 코드는 아래와 같습니다.
 
     포트원 콘솔 내 \[연동 관리] > \[연동 정보] > \[채널 관리] 화면에서 채널 추가 후
     `kcp_quick.{mid(사이트코드)}` 형식으로 채널을 지정할 때 사용됩니다.
+
+    <Hint style="warning">
+      `pg` 파라미터는 지원 중단 예정입니다.
+
+      JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+    </Hint>
 
   - **`pay_method`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/nice-v2/payment-caution.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/nice-v2/payment-caution.mdx
@@ -48,7 +48,7 @@ PG사로부터 정확한 사유를 전달받지 못하기 때문에 다음과 �
     IMP.request_pay(
       {
         // ...중략
-        pg: "nice_v2",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "card",
         card: {
           direct: {
@@ -72,7 +72,7 @@ PG사로부터 정확한 사유를 전달받지 못하기 때문에 다음과 �
     IMP.request_pay(
       {
         // ...중략
-        pg: "nice_v2",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "card",
         card: {
           direct: {
@@ -102,7 +102,7 @@ PG사로부터 정확한 사유를 전달받지 못하기 때문에 다음과 �
     IMP.request_pay(
       {
         // ...중략
-        pg: "nice_v2",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "card",
         display: { card_quota: [2, 3, 4, 5, 6] }, // 2 ~ 6 개월 리스트 할부 개월수 적용 시도
       },
@@ -122,7 +122,7 @@ PG사로부터 정확한 사유를 전달받지 못하기 때문에 다음과 �
     // ...중략
     IMP.request_pay(
       {
-        pg: "nice_v2",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "card",
         display: { card_quota: [3] }, // 3개월 고정 할부 개월수 적용 시도
       },
@@ -181,7 +181,7 @@ PG사로부터 정확한 사유를 전달받지 못하기 때문에 다음과 �
     IMP.request_pay(
       {
         // ...중략
-        pg: "nice_v2",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "trans", // 계좌이체 결제
         escrow: true, // 에스크로 결제
       },
@@ -337,7 +337,7 @@ SSGPAY 은행 계좌 거래는 현금성 결제로 현금영수증 발급이 가
     ```ts
     IMP.request_pay({
       // ...중략
-      pg: "nice_v2",
+      channelKey: "{콘솔 내 연동 정보의 채널키}",
       pay_method: "ssgpay_bank",
       bypass: {
         cashReceiptType: "corporate", // 현금영수증 발급 유형(corporate: 지출증빙, personal: 소득공제)
@@ -416,7 +416,7 @@ SSGPAY 은행 계좌 결제 시 현금영수증 발급 정보를 입력하여 �
     IMP.request_pay(
       {
         // ...중략
-        pg: "nice_v2",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "naverpay_point", // 네이버페이 포인트 결제
         bypass: {
           cashReceiptType: "personal", // 소득공제

--- a/src/routes/(root)/opi/ko/integration/pg/v1/nice-v2/readme.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/nice-v2/readme.mdx
@@ -122,6 +122,12 @@ callback)` 호출 후 <mark style="color:red;">**callback**</mark>으로 수신�
 
         `nice_v2` 로 지정하면 됩니다.
 
+        <Hint style="warning">
+          `pg` 파라미터는 지원 중단 예정입니다.
+
+          JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+        </Hint>
+
         **`pay_method`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
         **결제수단 구분코드**

--- a/src/routes/(root)/opi/ko/integration/pg/v1/nice-v2/readme.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/nice-v2/readme.mdx
@@ -84,7 +84,7 @@ callback)` 호출 후 <mark style="color:red;">**callback**</mark>으로 수신�
     ```ts title="Javascript SDK"
     IMP.request_pay(
       {
-        pg: "nice_v2.{상점 ID}",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "card",
         merchant_uid: "orderNo0001",
         name: "주문명:결제테스트",
@@ -106,7 +106,17 @@ callback)` 호출 후 <mark style="color:red;">**callback**</mark>으로 수신�
       <Details.Summary><strong>주요 파라미터 설명</strong></Details.Summary>
 
       <Details.Content>
-        **`pg` \***<mark style="color:green;">**string**</mark>
+        **`channelKey` \*** <mark style="color:green;">**string**</mark>
+
+        **채널키**
+
+        결제를 진행할 채널을 지정합니다.
+
+        포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+        (최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+        **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
         **PG사 구분코드**
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/nice.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/nice.mdx
@@ -75,6 +75,12 @@ NICE페이먼츠 결제창을 호출할 수 있습니다.
 
     `nice` 로 지정하면 됩니다.
 
+    <Hint style="warning">
+      `pg` 파라미터는 지원 중단 예정입니다.
+
+      JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+    </Hint>
+
     **`pay_method`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
     **결제수단 구분코드**

--- a/src/routes/(root)/opi/ko/integration/pg/v1/nice.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/nice.mdx
@@ -34,7 +34,7 @@ NICE페이먼츠 결제창을 호출할 수 있습니다.
     ```ts title="Javascript SDK"
     IMP.request_pay(
       {
-        pg: "nice.{상점 ID}",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "card",
         merchant_uid: "order_no_0001", // 상점에서 생성한 고유 주문번호
         name: "주문명:결제테스트",
@@ -59,11 +59,21 @@ NICE페이먼츠 결제창을 호출할 수 있습니다.
 
     ---
 
-    **`pg` \***<mark style="color:green;">**string**</mark>
+    **`channelKey` \*** <mark style="color:green;">**string**</mark>
+
+    **채널키**
+
+    결제를 진행할 채널을 지정합니다.
+
+    포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+    (최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+    **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
     **PG사 구분코드**
 
-    **`nice`** 로 지정하면 됩니다.
+    `nice` 로 지정하면 됩니다.
 
     **`pay_method`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/payco.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/payco.mdx
@@ -25,7 +25,7 @@ import Hint from "~/components/Hint";
     ```ts title="Javascript SDK"
     IMP.request_pay(
       {
-        pg: "payco.{CPID}",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         merchant_uid: "order_no_0001", // 상점에서 관리하는 주문 번호
         name: "주문명:결제테스트",
         amount: 1004,
@@ -44,11 +44,21 @@ import Hint from "~/components/Hint";
 
     **주요 파라미터 설명**
 
-    **`pg`** <mark style="color:green;">**string**</mark>
+    **`channelKey` \*** <mark style="color:green;">**string**</mark>
+
+    **채널키**
+
+    결제를 진행할 채널을 지정합니다.
+
+    포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+    (최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+    **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
     **PG사 구분코드**
 
-    **`payco`** 로 지정하면 됩니다.
+    `payco` 로 지정하면 됩니다.
 
     **`popup`** <mark style="color:green;">**boolean**</mark>
 
@@ -96,7 +106,7 @@ import Hint from "~/components/Hint";
     ```ts title="JavaScript SDK"
     IMP.request_pay(
       {
-        pg: "payco.{CPID}",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         merchant_uid: "order_monthly_0001", // 상점에서 관리하는 주문 번호
         name: "PAYCO 자동결제 등록",
         amount: 1000, // 결제창에 표시될 금액. 실제 승인이 이뤄지지는 않습니다.
@@ -117,7 +127,17 @@ import Hint from "~/components/Hint";
 
     **주요 파라미터 설명**
 
-    **`pg`** <mark style="color:green;">**string**</mark>
+    **`channelKey` \*** <mark style="color:green;">**string**</mark>
+
+    **채널키**
+
+    결제를 진행할 채널을 지정합니다.
+
+    포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+    (최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+    **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
     **PG사 구분코드**
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/payco.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/payco.mdx
@@ -60,6 +60,12 @@ import Hint from "~/components/Hint";
 
     `payco` 로 지정하면 됩니다.
 
+    <Hint style="warning">
+      `pg` 파라미터는 지원 중단 예정입니다.
+
+      JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+    </Hint>
+
     **`popup`** <mark style="color:green;">**boolean**</mark>
 
     페이코의 경우 모바일 환경에서 기본으로 iframe 방식으로 결제창이 호출됩니다.
@@ -142,6 +148,12 @@ import Hint from "~/components/Hint";
     **PG사 구분코드**
 
     **`payco`** 로 지정하면 됩니다.
+
+    <Hint style="warning">
+      `pg` 파라미터는 지원 중단 예정입니다.
+
+      JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+    </Hint>
 
     **`popup`**  <mark style="color:green;">**boolean**</mark>
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/paymentwall.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/paymentwall.mdx
@@ -26,7 +26,7 @@ import Hint from "~/components/Hint";
     ```ts title="Javascript SDK"
     IMP.request_pay(
       {
-        pg: "paymentwall.{project_key}",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "card", // 페이먼트월은 국가IP에 따라 결제수단이 활성화 됩니다.(생략가능)
         merchant_uid: "order_no_0001", //상점에서 생성한 고유 주문번호
         name: "주문명:결제테스트",
@@ -56,7 +56,17 @@ import Hint from "~/components/Hint";
 
     ### **주요 파라미터 설명**
 
-    `pg` <mark style="color:red;">\*</mark> <mark style="color:green;">**string**</mark>
+    `channelKey` \* <mark style="color:green;">**string**</mark>
+
+    **채널키**
+
+    결제를 진행할 채널을 지정합니다.
+
+    포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+    (최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+    `pg` (deprecated) <mark style="color:green;">**string**</mark>
 
     **PG사 구분코드**
 
@@ -139,7 +149,7 @@ import Hint from "~/components/Hint";
     ```ts title="Javascript SDK"
     IMP.request_pay(
       {
-        pg: "paymentwall.{project_key}",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "card", // 빌링키 결제는 오직 신용카드만 가능합니다.
         merchant_uid: "order_monthly_0001", // 상점에서 관리하는 주문 번호
         name: "최초인증결제",
@@ -163,13 +173,23 @@ import Hint from "~/components/Hint";
 
     **주요 파라미터 설명**
 
-    `pg` <mark style="color:red;">\*</mark> <mark style="color:green;">**string**</mark>
+    `channelKey` \* <mark style="color:green;">**string**</mark>
+
+    **채널키**
+
+    결제를 진행할 채널을 지정합니다.
+
+    포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+    (최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+    `pg` (deprecated) <mark style="color:green;">**string**</mark>
 
     **PG사 구분코드**
 
     `paymentwall`로 지정하면 됩니다. 페이먼트월 채널을 여러개 사용하는 경우 `{pg}.{mid}` 형식으로 요청해야 합니다. (예시-`paymentwall.{projeckey}`)
 
-    `customer_uid` <mark style="color:red;">\*</mark> <mark style="color:green;">**string**</mark>
+    **`customer_uid`** <mark style="color:red;">\*</mark> <mark style="color:green;">**string**</mark>
 
     **빌링키**
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/paymentwall.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/paymentwall.mdx
@@ -72,6 +72,12 @@ import Hint from "~/components/Hint";
 
     `paymentwall`로 지정하면 됩니다. 페이먼트월 채널을 여러개 사용하는 경우 `{pg}.{mid}` 형식으로 요청해야 합니다. (예시-`paymentwall.{projeckey}`)
 
+    <Hint style="warning">
+      `pg` 파라미터는 지원 중단 예정입니다.
+
+      JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+    </Hint>
+
     `pay_method` <mark style="color:green;">**string**</mark>
 
     **결제수단 구분코드**
@@ -188,6 +194,12 @@ import Hint from "~/components/Hint";
     **PG사 구분코드**
 
     `paymentwall`로 지정하면 됩니다. 페이먼트월 채널을 여러개 사용하는 경우 `{pg}.{mid}` 형식으로 요청해야 합니다. (예시-`paymentwall.{projeckey}`)
+
+    <Hint style="warning">
+      `pg` 파라미터는 지원 중단 예정입니다.
+
+      JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+    </Hint>
 
     **`customer_uid`** <mark style="color:red;">\*</mark> <mark style="color:green;">**string**</mark>
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/paypal.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/paypal.mdx
@@ -70,6 +70,12 @@ import Hint from "~/components/Hint";
 
     `paypal` 로 지정하면 됩니다.
 
+    <Hint style="warning">
+      `pg` 파라미터는 지원 중단 예정입니다.
+
+      JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+    </Hint>
+
     **`pay_method`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
     **결제수단 구분코드**

--- a/src/routes/(root)/opi/ko/integration/pg/v1/paypal.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/paypal.mdx
@@ -32,7 +32,7 @@ import Hint from "~/components/Hint";
     ```ts title="Javascript SDK"
     IMP.request_pay(
       {
-        pg: "paypal.{API 사용자 이름}",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "card",
         merchant_uid: "order_no_0001", // 상점에서 관리하는 주문 번호
         name: "주문명:결제테스트",
@@ -54,11 +54,21 @@ import Hint from "~/components/Hint";
 
     **주요 파라미터 설명**
 
-    **`pg` \***<mark style="color:green;">**string**</mark>
+    **`channelKey` \*** <mark style="color:green;">**string**</mark>
+
+    **채널키**
+
+    결제를 진행할 채널을 지정합니다.
+
+    포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+    (최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+    **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
     **PG사 구분코드**
 
-    **`paypal`** 로 지정하면 됩니다.
+    `paypal` 로 지정하면 됩니다.
 
     **`pay_method`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/settle/mybank.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/settle/mybank.mdx
@@ -72,6 +72,12 @@ callback) 호출 후 <mark style="color:red;">**callback**</mark> 으로 수신�
 
       `settle_acc.MID` 형태로 지정해야 합니다.
 
+      <Hint style="warning">
+        `pg` 파라미터는 지원 중단 예정입니다.
+
+        JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+      </Hint>
+
       **`pay_method`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
       **결제수단 구분코드**
@@ -191,6 +197,12 @@ callback) 호출 후 <mark style="color:red;">**callback**</mark> 으로 수신�
       **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
       **PG사 구분코드**
+
+      <Hint style="warning">
+        `pg` 파라미터는 지원 중단 예정입니다.
+
+        JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+      </Hint>
 
       **`customer_uid`** <mark style="color:green;">**string**</mark>
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/settle/mybank.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/settle/mybank.mdx
@@ -28,7 +28,7 @@ callback) 호출 후 <mark style="color:red;">**callback**</mark> 으로 수신�
     IMP.request_pay(
       {
         // param
-        pg: "settle_acc.MID", // 발급받은 고객사아이디
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "trans",
         merchant_uid: "ORD20180131-0000011",
         name: "노르웨이 회전 의자",
@@ -56,7 +56,17 @@ callback) 호출 후 <mark style="color:red;">**callback**</mark> 으로 수신�
     ### 주요 파라미터 설명
 
     <ParamTree>
-      **`pg`** <mark style="color:green;">**string**</mark>
+      **`channelKey` \*** <mark style="color:green;">**string**</mark>
+
+      **채널키**
+
+      결제를 진행할 채널을 지정합니다.
+
+      포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+      (최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+      **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
       **PG사 구분코드**
 
@@ -129,7 +139,7 @@ callback) 호출 후 <mark style="color:red;">**callback**</mark> 으로 수신�
     ```ts title="Javascript SDK"
     IMP.request_pay(
       {
-        pg: "settle_acc.MID", //발급받은 고객사아이디
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "trans",
         merchant_uid: "ORD20180131-0000011",
         name: "노르웨이 회전 의자",
@@ -168,7 +178,17 @@ callback) 호출 후 <mark style="color:red;">**callback**</mark> 으로 수신�
     #### 주요 파라미터 설명
 
     <ParamTree>
-      **`pg`** <mark style="color:green;">**string**</mark>
+      **`channelKey` \*** <mark style="color:green;">**string**</mark>
+
+      **채널키**
+
+      결제를 진행할 채널을 지정합니다.
+
+      포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+      (최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+      **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
       **PG사 구분코드**
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/settle/readme.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/settle/readme.mdx
@@ -27,7 +27,7 @@ import Hint from "~/components/Hint";
     ```ts title="Javascript SDK"
     IMP.request_pay(
       {
-        pg: "settle.{상점 ID}",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "card",
         merchant_uid: "order_no_0001", // 상점에서 생성한 고유 주문번호
         name: "주문명:결제테스트",
@@ -49,11 +49,21 @@ import Hint from "~/components/Hint";
 
     **주요 파라미터 설명**
 
-    **`pg` \***<mark style="color:green;">**string**</mark>
+    **`channelKey` \*** <mark style="color:green;">**string**</mark>
+
+    **채널키**
+
+    결제를 진행할 채널을 지정합니다.
+
+    포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+    (최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+    **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
     **PG사 구분코드**
 
-    **`settle`** 로 지정하면 됩니다.
+    `settle` 로 지정하면 됩니다.
 
     **`pay_method`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/settle/readme.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/settle/readme.mdx
@@ -65,6 +65,12 @@ import Hint from "~/components/Hint";
 
     `settle` 로 지정하면 됩니다.
 
+    <Hint style="warning">
+      `pg` 파라미터는 지원 중단 예정입니다.
+
+      JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+    </Hint>
+
     **`pay_method`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
     **결제수단 구분코드**

--- a/src/routes/(root)/opi/ko/integration/pg/v1/smartro-v2/caution.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/smartro-v2/caution.mdx
@@ -82,7 +82,7 @@ import screenshot2 from "./_assets/caution/screenshot-2.png";
     ```json
     // 예. BC카드 5개월 할부
     {
-      "pg": "smartro_v2",
+      "channelKey": "{콘솔 내 연동 정보의 채널키}",
       "pay_method": "card",
       "card": {
         "direct": {
@@ -97,7 +97,7 @@ import screenshot2 from "./_assets/caution/screenshot-2.png";
     ```json
     // 예. 결제창에서 카드사와 할부개월수 선택
     {
-      "pg": "smartro_v2",
+      "channelKey": "{콘솔 내 연동 정보의 채널키}",
       "pay_method": "card"
     }
 
@@ -207,7 +207,7 @@ V1에서는 가상계좌 다이렉트 호출을 지원하지 않기 때문에 **
   <Details.Content>
     ```tsx {5-11}
     IMP.request_pay({
-      pg: "smartro_v2",
+      channelKey: "{콘솔 내 연동 정보의 채널키}",
       pay_method: "card",
       amount: 50000,
       escrow: true, // 에스크로 결제
@@ -276,7 +276,7 @@ V1에서는 가상계좌 다이렉트 호출을 지원하지 않기 때문에 **
   <Details.Content>
     ```tsx {4-10}
     IMP.request_pay({
-      pg: "smartro_v2",
+      channelKey: "{콘솔 내 연동 정보의 채널키}",
       amount: 50000,
       pay_method: "trans", // 계좌이체 결제
       escrow: true, // 에스크로 결제
@@ -345,7 +345,7 @@ V1에서는 가상계좌 다이렉트 호출을 지원하지 않기 때문에 **
   <Details.Content>
     ```json
     {
-      "pg": "smartro_v2",
+      "channelKey": "{콘솔 내 연동 정보의 채널키}",
       "period": {
         // 서비스 제공 시작 날짜와 종료 날짜를 모두 입력해야 함
         "from": "2023-01-01", // 서비스 제공 시작 날짜

--- a/src/routes/(root)/opi/ko/integration/pg/v1/smartro-v2/readme.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/smartro-v2/readme.mdx
@@ -43,7 +43,7 @@ import Hint from "~/components/Hint";
     ```ts title="Javascript SDK"
     IMP.request_pay(
       {
-        pg: "smartro_v2.{상점 ID}",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "card",
         merchant_uid: "orderNo0001", // 상점에서 생성한 고유 주문번호 주의: 스마트로 일반결제시 주문 번호에 특수문자 사용 불가
         name: "주문명:결제테스트",
@@ -70,7 +70,17 @@ import Hint from "~/components/Hint";
       <Details.Summary><strong>주요 파라미터 설명</strong></Details.Summary>
 
       <Details.Content>
-        **`pg` \***<mark style="color:green;">**string**</mark>
+        **`channelKey` \*** <mark style="color:green;">**string**</mark>
+
+        **채널키**
+
+        결제를 진행할 채널을 지정합니다.
+
+        포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+        (최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+        **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
         **PG사 구분코드**
 
@@ -159,7 +169,7 @@ import Hint from "~/components/Hint";
     ```ts title="Javascript SDK"
     IMP.request_pay(
       {
-        pg: "smartro_v2.{MID}",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "card", // 'card'만 지원됩니다.
         merchant_uid: "orderMonthly0001", // 상점에서 관리하는 주문 번호 주의: 스마트로 일반결제시 주문 번호에 특수문자 사용 불가
         name: "최초인증결제",
@@ -181,7 +191,17 @@ import Hint from "~/components/Hint";
       <Details.Summary><strong>주요 파라미터 설명</strong></Details.Summary>
 
       <Details.Content>
-        **`pg` \***<mark style="color:green;">**string**</mark>
+        **`channelKey` \*** <mark style="color:green;">**string**</mark>
+
+        **채널키**
+
+        결제를 진행할 채널을 지정합니다.
+
+        포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+        (최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+        **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
         **PG사 구분코드**
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/smartro-v2/readme.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/smartro-v2/readme.mdx
@@ -86,6 +86,12 @@ import Hint from "~/components/Hint";
 
         `smartro_v2` 로 지정하면 됩니다.
 
+        <Hint style="warning">
+          `pg` 파라미터는 지원 중단 예정입니다.
+
+          JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+        </Hint>
+
         **`pay_method`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
         **결제수단 구분코드**
@@ -206,6 +212,12 @@ import Hint from "~/components/Hint";
         **PG사 구분코드**
 
         `smartro_v2` 로 지정하면 됩니다.
+
+        <Hint style="warning">
+          `pg` 파라미터는 지원 중단 예정입니다.
+
+          JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+        </Hint>
 
         **`pay_method`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/smartro.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/smartro.mdx
@@ -70,6 +70,12 @@ import Hint from "~/components/Hint";
 
     `smartro` 로 지정하면 됩니다.
 
+    <Hint style="warning">
+      `pg` 파라미터는 지원 중단 예정입니다.
+
+      JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+    </Hint>
+
     **`pay_method`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
     **결제수단 구분코드**

--- a/src/routes/(root)/opi/ko/integration/pg/v1/smartro.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/smartro.mdx
@@ -33,7 +33,7 @@ import Hint from "~/components/Hint";
     ```ts title="Javascript SDK"
     IMP.request_pay(
       {
-        pg: "smartro.{상점 ID}",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "card",
         merchant_uid: "order_no_0001", // 상점에서 생성한 고유 주문번호
         name: "주문명:결제테스트",
@@ -54,11 +54,21 @@ import Hint from "~/components/Hint";
 
     **주요 파라미터 설명**
 
-    **`pg` \***<mark style="color:green;">**string**</mark>
+    **`channelKey` \*** <mark style="color:green;">**string**</mark>
+
+    **채널키**
+
+    결제를 진행할 채널을 지정합니다.
+
+    포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+    (최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+    **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
     **PG사 구분코드**
 
-    **`smartro`** 로 지정하면 됩니다.
+    `smartro` 로 지정하면 됩니다.
 
     **`pay_method`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/smilepay.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/smilepay.mdx
@@ -6,6 +6,7 @@ targetVersions: ["v1"]
 
 import Figure from "~/components/Figure";
 import Tabs from "~/components/gitbook/Tabs";
+import Hint from "~/components/Hint";
 
 import image1 from "./_assets/smilepay.png";
 
@@ -61,6 +62,12 @@ import image1 from "./_assets/smilepay.png";
     **PG사 구분코드**
 
     `smilepay` 로 지정하면 됩니다.
+
+    <Hint style="warning">
+      `pg` 파라미터는 지원 중단 예정입니다.
+
+      JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+    </Hint>
 
     **`pay_method`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/smilepay.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/smilepay.mdx
@@ -27,7 +27,7 @@ import image1 from "./_assets/smilepay.png";
     ```javascript title="Javascript SDK"
     IMP.request_pay(
       {
-        pg: "smilepay.{MID}",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         merchant_uid: "order_no_0001", // 상점에서 관리하는 주문 번호
         name: "주문명:결제테스트",
         amount: 1004,
@@ -46,11 +46,21 @@ import image1 from "./_assets/smilepay.png";
 
     **주요 파라미터 설명**
 
-    **`pg`** <mark style="color:green;">**string**</mark>
+    **`channelKey` \*** <mark style="color:green;">**string**</mark>
+
+    **채널키**
+
+    결제를 진행할 채널을 지정합니다.
+
+    포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+    (최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+    **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
     **PG사 구분코드**
 
-    **`smilepay`** 로 지정하면 됩니다.
+    `smilepay` 로 지정하면 됩니다.
 
     **`pay_method`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/spb/warning.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/spb/warning.mdx
@@ -201,7 +201,7 @@ import image1 from "../_assets/paypal/spb-real.png";
 
     즉, 예를 들어 고객사가 독일, 스페인, 이탈리아 이렇게 3개 나라에 대해 서비스를 제공하고 각 나라별 Pay Later 기능도 함께 제공한다고 가정합니다. 이 경우 고객사는 독일, 스페인, 이탈리아용 **페이팔 머천트 계정을 각각 따로 만들어야** 합니다.
 
-    가입 후 부여 받은 페이팔 Account ID(IMP.loadUI 함수 호출시 pg 파라미터로 전달)가 각각 D, E, I라고 한다면, **고객사는 구매자가 접속한 국가에 따라 올바른 Account ID를 전달해야** 합니다. 즉, 구매자가 독일에서 접속 한 경우엔 pg: “paypal\_v2.D”, 스페인에서 접속 한 경우에는 pg: “paypal\_v2.E” 마지막으로 이탈리아에서 접속 한 경우에는 pg: “paypal\_v2.I”로 입력해줘야합니다.
+    가입 후 부여 받은 페이팔 Account ID(IMP.loadUI 함수 호출시 pg 파라미터로 전달)가 각각 D, E, I라고 한다면, **고객사는 구매자가 접속한 국가에 따라 올바른 Account ID를 전달해야** 합니다. 즉, 구매자가 독일에서 접속 한 경우엔 pg: "paypal\_v2.D", 스페인에서 접속 한 경우에는 pg: "paypal\_v2.E" 마지막으로 이탈리아에서 접속 한 경우에는 pg: "paypal\_v2.I"로 입력해줘야합니다.
   </Details.Content>
 </Details>
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/toss-brandpay/readme.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/toss-brandpay/readme.mdx
@@ -58,7 +58,7 @@ import Hint from "~/components/Hint";
     ```ts title="Javascript SDK"
     IMP.request_pay(
       {
-        pg: "toss_brandpay.{상점 ID}",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "toss_brandpay",
         merchant_uid: "orderNo0001",
         name: "주문명:결제테스트",
@@ -79,7 +79,17 @@ import Hint from "~/components/Hint";
       <Details.Summary><strong>주요 파라미터 설명</strong></Details.Summary>
 
       <Details.Content>
-        **`pg`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+        **`channelKey` \*** <mark style="color:green;">**string**</mark>
+
+        **채널키**
+
+        결제를 진행할 채널을 지정합니다.
+
+        포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+        (최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+        **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
         **PG사 구분코드**
 
@@ -140,7 +150,7 @@ import Hint from "~/components/Hint";
     ```ts title="Javascript SDK"
     IMP.request_pay(
       {
-        pg: "toss_brandpay.{상점 ID}",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "toss_brandpay",
         merchant_uid: "orderNo0001",
         name: "주문명:결제테스트",
@@ -222,7 +232,7 @@ import Hint from "~/components/Hint";
     ```ts title="Javascript SDK"
     IMP.request_pay(
       {
-        pg: "toss_brandpay.{상점 ID}",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "toss_brandpay",
         merchant_uid: "orderNo0001",
         name: "주문명:결제테스트",

--- a/src/routes/(root)/opi/ko/integration/pg/v1/toss-brandpay/readme.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/toss-brandpay/readme.mdx
@@ -95,6 +95,12 @@ import Hint from "~/components/Hint";
 
         `toss_brandpay` 로 지정하면 됩니다.
 
+        <Hint style="warning">
+          `pg` 파라미터는 지원 중단 예정입니다.
+
+          JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+        </Hint>
+
         **`pay_method`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
         **결제수단 구분코드**

--- a/src/routes/(root)/opi/ko/integration/pg/v1/toss.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/toss.mdx
@@ -72,6 +72,12 @@ IMP.request_pay(
 
 `uplus` 로 지정하면 됩니다.
 
+<Hint style="warning">
+  `pg` 파라미터는 지원 중단 예정입니다.
+
+  JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+</Hint>
+
 **`pay_method`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
 **결제수단 구분코드**

--- a/src/routes/(root)/opi/ko/integration/pg/v1/toss.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/toss.mdx
@@ -32,7 +32,7 @@ import Hint from "~/components/Hint";
 ```ts title="Javascript SDK"
 IMP.request_pay(
   {
-    pg: "uplus.{MID}",
+    channelKey: "{콘솔 내 연동 정보의 채널키}",
     pay_method: "card",
     merchant_uid: "order_no_0001", //상점에서 생성한 고유 주문번호
     name: "주문명:결제테스트",
@@ -56,11 +56,21 @@ IMP.request_pay(
 
 **주요 파라미터 설명**
 
-**`pg` \***<mark style="color:green;">**string**</mark>
+**`channelKey` \*** <mark style="color:green;">**string**</mark>
+
+**채널키**
+
+결제를 진행할 채널을 지정합니다.
+
+포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+(최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+**`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
 **PG사 구분코드**
 
-**`uplus`** 로 지정하면 됩니다.
+`uplus` 로 지정하면 됩니다.
 
 **`pay_method`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/tosspay-v2/readme.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/tosspay-v2/readme.mdx
@@ -48,7 +48,7 @@ import Hint from "~/components/Hint";
     ```ts title="Javascript SDK"
     IMP.request_pay(
       {
-        pg: "tosspay_v2.{MID}",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "tosspay", // 'tosspay_card', 'tosspay_money' 도 지원됩니다.
         merchant_uid: "orderMonthly0001", // 상점에서 관리하는 주문 번호
         name: "최초인증결제",
@@ -75,7 +75,17 @@ import Hint from "~/components/Hint";
       <Details.Summary><strong>주요 파라미터 설명</strong></Details.Summary>
 
       <Details.Content>
-        **`pg` \***<mark style="color:green;">**string**</mark>
+        **`channelKey` \*** <mark style="color:green;">**string**</mark>
+
+        **채널키**
+
+        결제를 진행할 채널을 지정합니다.
+
+        포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+        (최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+        **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
         **PG사 구분코드**
 
@@ -133,7 +143,7 @@ import Hint from "~/components/Hint";
     ```ts title="Javascript SDK"
     IMP.request_pay(
       {
-        pg: "tosspay_v2.{MID}",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "tosspay", // 'tosspay'만 지원됩니다.
         merchant_uid: "orderMonthly0001", // 상점에서 관리하는 주문 번호
         name: "최초인증결제",
@@ -155,7 +165,17 @@ import Hint from "~/components/Hint";
       <Details.Summary><strong>주요 파라미터 설명</strong></Details.Summary>
 
       <Details.Content>
-        **`pg` \***<mark style="color:green;">**string**</mark>
+        **`channelKey` \*** <mark style="color:green;">**string**</mark>
+
+        **채널키**
+
+        결제를 진행할 채널을 지정합니다.
+
+        포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+        (최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+        **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
         **PG사 구분코드**
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/tosspay-v2/readme.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/tosspay-v2/readme.mdx
@@ -91,6 +91,12 @@ import Hint from "~/components/Hint";
 
         `tosspay_v2` 로 지정하면 됩니다.
 
+        <Hint style="warning">
+          `pg` 파라미터는 지원 중단 예정입니다.
+
+          JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+        </Hint>
+
         **`pay_method`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
         **결제수단 구분코드**
@@ -180,6 +186,12 @@ import Hint from "~/components/Hint";
         **PG사 구분코드**
 
         `tosspay_v2` 로 지정하면 됩니다.
+
+        <Hint style="warning">
+          `pg` 파라미터는 지원 중단 예정입니다.
+
+          JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+        </Hint>
 
         **`pay_method`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/tosspay.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/tosspay.mdx
@@ -31,7 +31,7 @@ import Hint from "~/components/Hint";
     ```ts title="Javascript SDK"
     IMP.request_pay(
       {
-        pg: "tosspay.{PG 상점아이디}",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "card",
         merchant_uid: "order_no_0001", // 상점에서 생성한 고유 주문번호
         name: "주문명:결제테스트", // 필수 파라미터 입니다.
@@ -52,11 +52,21 @@ import Hint from "~/components/Hint";
 
     **주요 파라미터 설명**
 
-    **`pg`** <mark style="color:green;">**string**</mark>
+    **`channelKey` \*** <mark style="color:green;">**string**</mark>
+
+    **채널키**
+
+    결제를 진행할 채널을 지정합니다.
+
+    포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+    (최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+    **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
     **PG사 구분코드**
 
-    **`tosspay`** 로 지정하면 됩니다.
+    `tosspay` 로 지정하면 됩니다.
 
     **`pay_method`** <mark style="color:green;">**string**</mark>
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/tosspay.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/tosspay.mdx
@@ -68,6 +68,12 @@ import Hint from "~/components/Hint";
 
     `tosspay` 로 지정하면 됩니다.
 
+    <Hint style="warning">
+      `pg` 파라미터는 지원 중단 예정입니다.
+
+      JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+    </Hint>
+
     **`pay_method`** <mark style="color:green;">**string**</mark>
 
     **결제수단 구분코드**

--- a/src/routes/(root)/opi/ko/integration/pg/v1/welcome/caution.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/welcome/caution.mdx
@@ -44,7 +44,7 @@ import Details from "~/components/gitbook/Details";
 
        ```json
        {
-         "pg": "welcome",
+         "channelKey": "{콘솔 내 연동 정보의 채널키}",
          "pay_method": "card",
          "amount": "50000",
          "card": {
@@ -99,7 +99,7 @@ IOS 모바일 웹/인앱 브라우저에서 결제창 호출 후 카드사 앱�
     ```json
     {
       // 현금영수증 자진 발급
-      "pg": "welcome",
+      "channelKey": "{콘솔 내 연동 정보의 채널키}",
       "pay_method": "vbank",
       "bypass": {
         "cashReceiptType": "anonymous"
@@ -116,7 +116,7 @@ IOS 모바일 웹/인앱 브라우저에서 결제창 호출 후 카드사 앱�
     ```json
     // 현금영수증 소득공제
     {
-      "pg": "welcome",
+      "channelKey": "{콘솔 내 연동 정보의 채널키}",
       "pay_method": "trans",
       "bypass": {
         "cashReceiptType": "personal",
@@ -129,7 +129,7 @@ IOS 모바일 웹/인앱 브라우저에서 결제창 호출 후 카드사 앱�
     ```json
     // 현금영수증 지출증빙
     {
-      "pg": "welcome",
+      "channelKey": "{콘솔 내 연동 정보의 채널키}",
       "pay_method": "trans",
       "bypass": {
         "cashReceiptType": "corporate",
@@ -309,7 +309,7 @@ IOS 모바일 웹/인앱 브라우저에서 결제창 호출 후 카드사 앱�
   <Details.Content>
     ```json
     {
-      "pg": "welcome",
+      "channelKey": "{콘솔 내 연동 정보의 채널키}",
       "pay_method": "card",
       "display": {
         "card_quota": [2, 3, 4, 5, 6] // 일시불 + 2개월 ~ 6개월까지 결제창에 표기
@@ -330,7 +330,7 @@ IOS 모바일 웹/인앱 브라우저에서 결제창 호출 후 카드사 앱�
     ```json
     // 일시불만 표기
     {
-      "pg": "welcome",
+      "channelKey": "{콘솔 내 연동 정보의 채널키}",
       "pay_method": "card"
     }
     ```
@@ -338,7 +338,7 @@ IOS 모바일 웹/인앱 브라우저에서 결제창 호출 후 카드사 앱�
     ```json
     // 일시불 + 2개월 ~ 6개월까지 결제창에 표기
     {
-      "pg": "welcome",
+      "channelKey": "{콘솔 내 연동 정보의 채널키}",
       "pay_method": "card",
       "display": {
         "card_quota": [2, 3, 4, 5, 6] // 일시불 + 2개월 ~ 6개월까지 결제창에 표기
@@ -364,7 +364,7 @@ IOS 모바일 웹/인앱 브라우저에서 결제창 호출 후 카드사 앱�
     ```json
     // 예. BC카드 5개월 할부
     {
-      "pg": "welcome",
+      "channelKey": "{콘솔 내 연동 정보의 채널키}",
       "pay_method": "card",
       "card": {
         "direct": {
@@ -379,7 +379,7 @@ IOS 모바일 웹/인앱 브라우저에서 결제창 호출 후 카드사 앱�
     ```json
     // 예. 결제창에서 카드사와 할부 개월수 선택
     {
-      "pg": "welcome",
+      "channelKey": "{콘솔 내 연동 정보의 채널키}",
       "pay_method": "card"
     }
 
@@ -459,7 +459,7 @@ PC 환경에서는 별도 제한이 없습니다.
     ```json
     // 예) 할부 개월수를 3개월까지 렌더링 되도록 설정
     {
-      "pg": "welcome",
+      "channelKey": "{콘솔 내 연동 정보의 채널키}",
       "pay_method": "card",
       "display": {
         "card_quota": [2, 3]

--- a/src/routes/(root)/opi/ko/integration/pg/v1/welcome/readme.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/welcome/readme.mdx
@@ -75,6 +75,12 @@ PC의 경우 <mark style="color:red;">**callback**</mark> 함수로 전달되고
 
         **PG사 구분코드**
 
+        <Hint style="warning">
+          `pg` 파라미터는 지원 중단 예정입니다.
+
+          JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+        </Hint>
+
         **`pay_method`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
         **결제수단 구분코드**

--- a/src/routes/(root)/opi/ko/integration/pg/v1/welcome/readme.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/welcome/readme.mdx
@@ -38,7 +38,7 @@ PC의 경우 <mark style="color:red;">**callback**</mark> 함수로 전달되고
     ```ts title="Javascript SDK"
     IMP.request_pay(
       {
-        pg: "welcome.{상점 ID}",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "card",
         merchant_uid: "orderNo0001", // 고객사에서 채번한 주문 고유 번호입니다.
         name: "주문명:결제테스트",
@@ -61,7 +61,17 @@ PC의 경우 <mark style="color:red;">**callback**</mark> 함수로 전달되고
       <Details.Summary><strong>주요 파라미터 설명</strong></Details.Summary>
 
       <Details.Content>
-        **`pg`** <mark style="color:red;">**\***</mark> <mark style="color:purple;">**`welcome`**</mark>
+        **`channelKey` \*** <mark style="color:green;">**string**</mark>
+
+        **채널키**
+
+        결제를 진행할 채널을 지정합니다.
+
+        포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+        (최신 JavaScript SDK 버전부터 사용 가능합니다.)
+
+        **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
         **PG사 구분코드**
 
@@ -280,7 +290,7 @@ PC의 경우 <mark style="color:red;">**callback**</mark> 함수로 전달되고
 
         ```json
         {
-          "pg": "welcome",
+          "channelKey": "{콘솔 내 연동 정보의 채널키}",
           "bypass": {
             "welcome": {
               "acceptmethod": [
@@ -313,7 +323,7 @@ PC의 경우 <mark style="color:red;">**callback**</mark> 함수로 전달되고
 
         ```json
         {
-          "pg": "welcome",
+          "channelKey": "{콘솔 내 연동 정보의 채널키}",
           "bypass": {
             "welcome": {
               "P_RESERVED": [
@@ -354,7 +364,7 @@ PC의 경우 <mark style="color:red;">**callback**</mark> 함수로 전달되고
     ```ts title="Javascript SDK"
     IMP.request_pay(
       {
-        pg: "welcome.{MID}",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "card", // 빌링키 발급 수단입니다. 웰컴페이먼츠의 경우 'card'만 지원됩니다.
         merchant_uid: "orderMonthly0001", // 고객사에서 채번한 주문 고유 번호입니다.
         name: "빌링키 발급",
@@ -491,7 +501,7 @@ PC의 경우 <mark style="color:red;">**callback**</mark> 함수로 전달되고
     ```ts title="Javascript SDK"
     IMP.request_pay(
       {
-        pg: "welcome.{상점 ID}",
+        channelKey: "{콘솔 내 연동 정보의 채널키}",
         pay_method: "phone", // 빌링키 발급 및 결제 수단입니다. 웰컴페이먼츠의 경우 'phone'만 지원합니다.
         merchant_uid: "orderNo0001", // 고객사에서 채번한 주문 고유 번호입니다.
         name: "주문명:결제테스트",
@@ -631,7 +641,7 @@ PC의 경우 <mark style="color:red;">**callback**</mark> 함수로 전달되고
 
         ```json
         {
-          "pg": "welcome",
+          "channelKey": "{콘솔 내 연동 정보의 채널키}",
           "bypass": {
             "welcome": {
               "acceptmethod": [
@@ -658,7 +668,7 @@ PC의 경우 <mark style="color:red;">**callback**</mark> 함수로 전달되고
 
         ```json
         {
-          "pg": "welcome",
+          "channelKey": "{콘솔 내 연동 정보의 채널키}",
           "bypass": {
             "welcome": {
               "P_RESERVED": [

--- a/src/routes/(root)/opi/ko/integration/sdk/javascript-sdk/cft.mdx
+++ b/src/routes/(root)/opi/ko/integration/sdk/javascript-sdk/cft.mdx
@@ -42,7 +42,9 @@ import Hint from "~/components/Hint";
 </Details>
 
 <Hint style="warning">
-  pg 파라미터는 지원 중단 예정입니다. JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+  pg 파라미터는 지원 중단 예정입니다. 
+  
+  JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
 </Hint>
 
 ### **`merchant_uid`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>

--- a/src/routes/(root)/opi/ko/integration/sdk/javascript-sdk/cft.mdx
+++ b/src/routes/(root)/opi/ko/integration/sdk/javascript-sdk/cft.mdx
@@ -7,10 +7,21 @@ versionVariants:
 ---
 
 import Details from "~/components/gitbook/Details";
+import Hint from "~/components/Hint";
 
 ## certification(param, callback) <a href="#certification" id="certification" />
 
-### **`pg`** <mark style="color:green;">**string**</mark>
+### **`channelKey`** <mark style="color:green;">**string**</mark>
+
+**채널키**
+
+결제를 진행할 채널을 지정합니다.
+
+포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+최신 JavaScript SDK 버전부터 사용 가능합니다.
+
+### **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
 **PG사 구분코드**
 
@@ -29,6 +40,10 @@ import Details from "~/components/gitbook/Details";
     - `inicis`(이니시스 API 수기/정기결제 및 신용카드 본인인증)
   </Details.Content>
 </Details>
+
+<Hint style="warning">
+  pg 파라미터는 지원 중단 예정입니다. JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+</Hint>
 
 ### **`merchant_uid`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
@@ -83,7 +98,7 @@ import Details from "~/components/gitbook/Details";
 - 모바일 환경에서 본인인증 후 리디렉션될 URL
 - 리디렉션될 때 query string 으로 `imp_uid`, `merchant_uid`, `success` 가 전달됩니다.
 
-### **popup** <mark style="color:orange;">**boolean**</mark>
+### **`popup`** <mark style="color:orange;">**boolean**</mark>
 
 **팝업 사용여부**
 

--- a/src/routes/(root)/opi/ko/integration/sdk/javascript-sdk/payrq.mdx
+++ b/src/routes/(root)/opi/ko/integration/sdk/javascript-sdk/payrq.mdx
@@ -78,7 +78,9 @@ import Hint from "~/components/Hint";
 </Details>
 
 <Hint style="warning">
-  pg 파라미터는 지원 중단 예정입니다. JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+  pg 파라미터는 지원 중단 예정입니다. 
+  
+  JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
 </Hint>
 
 ### **`pay_method`** <mark style="color:green;">**string**</mark>

--- a/src/routes/(root)/opi/ko/integration/sdk/javascript-sdk/payrq.mdx
+++ b/src/routes/(root)/opi/ko/integration/sdk/javascript-sdk/payrq.mdx
@@ -12,7 +12,17 @@ import Hint from "~/components/Hint";
 
 ## 결제요청 파라미터 정의
 
-### **`pg`** <mark style="color:green;">**string**</mark>
+### **`channelKey`** <mark style="color:green;">**string**</mark>
+
+**채널키**
+
+결제를 진행할 채널을 지정합니다.
+
+포트원 콘솔 내 \[결제 연동] - \[연동 정보] - \[채널 관리] 에서 확인 가능합니다.
+
+최신 JavaScript SDK 버전부터 사용 가능합니다.
+
+### **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
 **PG사 구분코드**
 
@@ -66,6 +76,10 @@ import Hint from "~/components/Hint";
     - `paymentwall`(페이먼트월 결제창 일반 및 API 수기/정기결제)
   </Details.Content>
 </Details>
+
+<Hint style="warning">
+  pg 파라미터는 지원 중단 예정입니다. JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
+</Hint>
 
 ### **`pay_method`** <mark style="color:green;">**string**</mark>
 

--- a/src/routes/(root)/opi/ko/integration/start/v1/auth.mdx
+++ b/src/routes/(root)/opi/ko/integration/start/v1/auth.mdx
@@ -106,7 +106,7 @@ import imageAuthpayFlow from "../_assets/authpay-flow.png";
   ```ts
   IMP.request_pay(
     {
-      pg: "{PG사 코드}.{상점 ID}",
+      channelKey: "{콘솔 내 연동 정보의 채널키}",
       pay_method: "card",
       merchant_uid: `payment-${crypto.randomUUID()}`, // 주문 고유 번호
       name: "노르웨이 회전 의자",


### PR DESCRIPTION
pg 파라미터를 deprecate 시키기 위해 결제창 호출시 예제에서의 pg 파라미터를 모두 channelKey 파라미터로 대체, 파라미터 설명에 channelKey 파라미터를 추가하고 pg 파라미터는 deprecated됨을 명시하였습니다.