### PR TITLE
모바일 SDK 목차 추가, android v2 sdk 내용 추가

### DIFF
--- a/src/routes/(root)/opi/ko/_nav.yaml
+++ b/src/routes/(root)/opi/ko/_nav.yaml
@@ -55,7 +55,7 @@
     - /ko/integration/v2-sdk/identity-verification-request
     - /ko/integration/v2-sdk/identity-verification-response
     - /ko/integration/v2-sdk/changelog
-    
+
 - label: 모바일 SDK
   systemVersion: v2
   items:

--- a/src/routes/(root)/opi/ko/_nav.yaml
+++ b/src/routes/(root)/opi/ko/_nav.yaml
@@ -55,6 +55,11 @@
     - /ko/integration/v2-sdk/identity-verification-request
     - /ko/integration/v2-sdk/identity-verification-response
     - /ko/integration/v2-sdk/changelog
+    
+- label: 모바일 SDK
+  systemVersion: v2
+  items:
+    - /ko/integration/v2-mobile-sdk/readme
 
 - label: 결제 연동하기
   systemVersion: v1

--- a/src/routes/(root)/opi/ko/integration/v2-mobile-sdk/readme.mdx
+++ b/src/routes/(root)/opi/ko/integration/v2-mobile-sdk/readme.mdx
@@ -3,11 +3,13 @@ title: 모바일 SDK 레퍼런스
 description: 결제창 연동시 사용되는 SDK에 대한 설명 문서입니다.
 targetVersions: ["v2"]
 ---
+
 포트원 모바일 SDK는 Javascript로 작성된 포트원 V2 SDK를 모바일 환경에서 모바일 플랫폼 네이티브 코드(Kotlin, Swift 등) 으로 사용 가능하도록 만들어진 SDK입니다.
 
 현재는 Android SDK만 지원하고 있으며, IOS, React Native, Flutter 등 다른 플랫폼에 대해서도 지원 예정입니다.
 
-### Android SDK
-Android 네이티브 환경에서 사용 가능한 SDK 입니다. 해당 Git 레포지토리의 README.md 파일을 참고하여 사용하실 수 있습니다.
-- [Github 링크](https://github.com/portone-io/android-sdk)
+## Android SDK
 
+Android 네이티브 환경에서 사용 가능한 SDK 입니다. 해당 Git 레포지토리의 README.md 파일을 참고하여 사용하실 수 있습니다.
+
+- [Github 링크](https://github.com/portone-io/android-sdk)

--- a/src/routes/(root)/opi/ko/integration/v2-mobile-sdk/readme.mdx
+++ b/src/routes/(root)/opi/ko/integration/v2-mobile-sdk/readme.mdx
@@ -1,0 +1,13 @@
+---
+title: 모바일 SDK 레퍼런스
+description: 결제창 연동시 사용되는 SDK에 대한 설명 문서입니다.
+targetVersions: ["v2"]
+---
+포트원 모바일 SDK는 Javascript로 작성된 포트원 V2 SDK를 모바일 환경에서 모바일 플랫폼 네이티브 코드(Kotlin, Swift 등) 으로 사용 가능하도록 만들어진 SDK입니다.
+
+현재는 Android SDK만 지원하고 있으며, IOS, React Native, Flutter 등 다른 플랫폼에 대해서도 지원 예정입니다.
+
+### Android SDK
+Android 네이티브 환경에서 사용 가능한 SDK 입니다. 해당 Git 레포지토리의 README.md 파일을 참고하여 사용하실 수 있습니다.
+- [Github 링크](https://github.com/portone-io/android-sdk)
+


### PR DESCRIPTION
모바일 SDK 목차를 추가하고, android v2 sdk 내용을 추가했습니다. 사용법 관련해서는 android sdk 레포 readme에 정리해두어 개발자센터에는 작성하지 않았는데, 너무 허전해보여서 추가로 설치방법이나 사용 방법 기술할지 한번 확인 부탁드립니다.

<img width="1325" alt="image" src="https://github.com/user-attachments/assets/d6584ab4-fd03-4b1b-b8c1-036eb970c585">
