### PR TITLE
잘못 작성된 링크 수정

### DIFF
--- a/src/routes/(root)/opi/ko/console/guide/billing-payments.mdx
+++ b/src/routes/(root)/opi/ko/console/guide/billing-payments.mdx
@@ -28,14 +28,14 @@ import Image4 from "../_assets/schedule.png";
 <Figure src={Image1} caption="[결제] - [빌링결제 내역 조회] 예시 화면" />
 
 <VersionGate v="v1">
-  발급한 빌링키를 이용하여 [비 인증 결제(빌링키) API](https://developers.portone.io/api/rest-v1/nonAuthPayment#post%20%2Fsubscribe%2Fpayments%2Fagain)
-  혹은 [결제 예약 API](https://developers.portone.io/api/rest-v1/nonAuthPayment.subscribe#post%20%2Fsubscribe%2Fpayments%2Fschedule)로
+  발급한 빌링키를 이용하여 [비 인증 결제(빌링키) API](/api/rest-v1/nonAuthPayment#post%20%2Fsubscribe%2Fpayments%2Fagain)
+  혹은 [결제 예약 API](/api/rest-v1/nonAuthPayment.subscribe#post%20%2Fsubscribe%2Fpayments%2Fschedule)로
   시도된 거래 건을 상태별로 조회할 수 있습니다.
 </VersionGate>
 
 <VersionGate v="v2">
-  발급한 빌링키를 이용하여 [빌링키 결제 API](https://developers.portone.io/api/rest-v2/payment#post%20%2Fpayments%2F%7BpaymentId%7D%2Fbilling-key)
-  혹은 [결제 예약 API](https://developers.portone.io/api/rest-v2/paymentSchedule#post%20%2Fpayments%2F%7BpaymentId%7D%2Fschedule)로
+  발급한 빌링키를 이용하여 [빌링키 결제 API](/api/rest-v2/payment#post%20%2Fpayments%2F%7BpaymentId%7D%2Fbilling-key)
+  혹은 [결제 예약 API](/api/rest-v2/paymentSchedule#post%20%2Fpayments%2F%7BpaymentId%7D%2Fschedule)로
   시도된 거래 건을 상태별로 조회할 수 있습니다.
 </VersionGate>
 

--- a/src/routes/(root)/opi/ko/console/guide/billing-payments.mdx
+++ b/src/routes/(root)/opi/ko/console/guide/billing-payments.mdx
@@ -35,7 +35,7 @@ import Image4 from "../_assets/schedule.png";
 
 <VersionGate v="v2">
   발급한 빌링키를 이용하여 [빌링키 결제 API](/api/rest-v2/payment#post%20%2Fpayments%2F%7BpaymentId%7D%2Fbilling-key)
-  혹은 [결제 예약 API](/api/rest-v2/paymentSchedule#post%20%2Fpayments%2F%7BpaymentId%7D%2Fschedule)로
+  혹은 [결제 예약 API](/api/rest-v2/payment.paymentSchedule#post%20%2Fpayments%2F%7BpaymentId%7D%2Fschedule)로
   시도된 거래 건을 상태별로 조회할 수 있습니다.
 </VersionGate>
 

--- a/src/routes/(root)/opi/ko/console/guide/channel-manage.mdx
+++ b/src/routes/(root)/opi/ko/console/guide/channel-manage.mdx
@@ -60,7 +60,7 @@ import image12 from "../_assets/whitelist.png";
     10. `저장`버튼을 눌러 채널을 추가를 완료합니다.
 
     <Hint Style="info">
-      채널 등록 시 결제대행사별 저장하는 파라미터가 다릅니다. 파라미터 정보 확인은 하단의 \[결제대행사별 연동 정보 확인하기]를 확인해주세요.
+      채널 등록 시 결제대행사별 저장하는 파라미터가 다릅니다. 파라미터 정보 확인은 하단의 \[결제대행사 선택하여 연동하기]를 확인해주세요.
     </Hint>
   </Tabs.Tab>
 
@@ -86,16 +86,26 @@ import image12 from "../_assets/whitelist.png";
     9. `저장`버튼을 눌러 채널을 추가를 완료합니다.
 
     <Hint Style="info">
-      채널 등록 시 결제대행사별 저장하는 파라미터가 다릅니다. 파라미터 정보 확인은 하단의 \[결제대행사별 연동 정보 확인하기]를 확인해주세요.
+      채널 등록 시 결제대행사별 저장하는 파라미터가 다릅니다. 파라미터 정보 확인은 하단의 \[결제대행사 선택하여 연동하기]를 확인해주세요.
     </Hint>
   </Tabs.Tab>
 </Tabs>
 
-<Hint style="info">
-  채널 추가 시 입력해야 하는 값은 결제대행사별로 다르므로
-  [결제대행사별 연동 정보 확인하기](https://developers.portone.io/docs/ko/ready/readme#integration-info)
-  를 참고하여 확인 후 입력 및 저장해야합니다.
-</Hint>
+<VersionGate v="v2">
+  <Hint style="info">
+    채널 추가 시 입력해야 하는 값은 결제대행사별로 다르므로
+    [결제대행사 선택하여 연동하기](/opi/ko/integration/pg/v2/readme)
+    를 참고하여 확인 후 입력 및 저장해야합니다.
+  </Hint>
+</VersionGate>
+
+<VersionGate v="v1">
+  <Hint style="info">
+    채널 추가 시 입력해야 하는 값은 결제대행사별로 다르므로
+    [결제대행사 선택하여 연동하기](/opi/ko/integration/pg/v1/readme)
+    를 참고하여 확인 후 입력 및 저장해야합니다.
+  </Hint>
+</VersionGate>
 
 ## 식별코드 및 API Keys
 
@@ -178,11 +188,11 @@ import image12 from "../_assets/whitelist.png";
 최신 상태의 결제 결과 처리를 위해서 결제 연동 시 웹훅 연동을 함께 구현하시길 권장드립니다.
 
 <VersionGate v="v1">
-  웹훅에 대한 자세한 설명은 [웹훅 연동하기](https://developers.portone.io/docs/ko/result/webhook?v=v1)를 참고하세요.
+  웹훅에 대한 자세한 설명은 [웹훅 연동하기](/opi/ko/integration/webhook/readme-v1?v=v1)를 참고하세요.
 </VersionGate>
 
 <VersionGate v="v2">
-  웹훅에 대한 자세한 설명은 [웹훅 연동하기](https://developers.portone.io/docs/ko/v2-payment/webhook?v=v2)를 참고하세요.
+  웹훅에 대한 자세한 설명은 [웹훅 연동하기](/opi/ko/integration/webhook/readme-v2?v=v2)를 참고하세요.
 </VersionGate>
 
 ### 웹훅 URL 관리자 콘솔 설정

--- a/src/routes/(root)/opi/ko/console/guide/reg.mdx
+++ b/src/routes/(root)/opi/ko/console/guide/reg.mdx
@@ -165,9 +165,9 @@ import image11 from "./_assets/reg/console_011.png";
 
 - 결제대행사(PG사)와 계약을 위해서는 신청하신 PG사의 모듈 연동이 필요합니다.
 
-- [V1 연동 매뉴얼 바로가기](https://developers.portone.io/docs/ko/readme?v=v1)
+- [V1 연동 매뉴얼 바로가기](/opi/ko/integration/ready/readme?v=v1)
 
-- [V2 연동 매뉴얼 바로가기](https://developers.portone.io/docs/ko/readme?v=v2)
+- [V2 연동 매뉴얼 바로가기](/opi/ko/integration/ready/readme?v=v2)
 
 - 연동과 관련하여 궁금하신 사항은 **포트원 기술지원 이메일 [support@portone.io](mailto:support@portone.io)**
   또는 채널톡으로 문의 주시기 바랍니다.

--- a/src/routes/(root)/opi/ko/console/guide/smartrouting.mdx
+++ b/src/routes/(root)/opi/ko/console/guide/smartrouting.mdx
@@ -41,7 +41,7 @@ import Image5 from "./_assets/sr_console_5.png";
 6. \[+채널 추가]를 클릭하세요.
 
 7. <Figure src={Image3} />
-   <div class="body">그룹에 사용할 채널을 선택하세요. [지원 PG사 확인 바로가기](/docs/ko/console/guide/smartrouting?v=v2#available-pg)</div>
+   <div class="body">그룹에 사용할 채널을 선택하세요. [지원 PG사 확인 바로가기](/opi/ko/extra/smart-routing/intro?v=v2)</div>
 
 8. 채널은 최소 1개부터 최대 10개까지 설정이 가능합니다.
 

--- a/src/routes/(root)/opi/ko/console/guide/smartrouting.mdx
+++ b/src/routes/(root)/opi/ko/console/guide/smartrouting.mdx
@@ -41,7 +41,7 @@ import Image5 from "./_assets/sr_console_5.png";
 6. \[+채널 추가]를 클릭하세요.
 
 7. <Figure src={Image3} />
-   <div class="body">그룹에 사용할 채널을 선택하세요. [지원 PG사 확인 바로가기](https://developers.portone.io/docs/ko/console/guide/smartrouting?v=v2#available-pg)</div>
+   <div class="body">그룹에 사용할 채널을 선택하세요. [지원 PG사 확인 바로가기](/docs/ko/console/guide/smartrouting?v=v2#available-pg)</div>
 
 8. 채널은 최소 1개부터 최대 10개까지 설정이 가능합니다.
 

--- a/src/routes/(root)/opi/ko/extra/smart-routing/console-guide.mdx
+++ b/src/routes/(root)/opi/ko/extra/smart-routing/console-guide.mdx
@@ -41,7 +41,7 @@ import Image5 from "./_assets/sr_console_5.png";
 6. \[+채널 추가]를 클릭하세요.
 
 7. <Figure src={Image3} />
-   <div class="body">그룹에 사용할 채널을 선택하세요. [지원 PG사 확인 바로가기](http://developers.portone.io/docs/ko/console/guide/smartrouting?v=v2#available-pg)</div>
+   <div class="body">그룹에 사용할 채널을 선택하세요. [지원 PG사 확인 바로가기](/opi/ko/extra/smart-routing/intro?v=v2#사용-가능한-pg사-및-결제수단-)</div>
 
 8. 채널은 최소 1개부터 최대 10개까지 설정이 가능합니다.
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/danal.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/danal.mdx
@@ -314,7 +314,7 @@ import Hint from "~/components/Hint";
 
     **파라미터 설명**
 
-    - **code** : 카드사 금융결제원 표준 코드. [<mark style="color:red;">**링크**</mark>](http://faq.portone.io/6503bcb4-4a61-4cf3-afd8-5d913b1385a6) 참조 (**string**)
+    - **code** : 카드사 금융결제원 표준 코드. [<mark style="color:red;">**링크**</mark>](/opi/ko/support/code-info/card-code) 참조 (**string**)
     - **quota** : 할부 개월 수. 일시불일 시 0 으로 지정. (**integer**)
     - **usePoint** : 해당 파라미터 설정시 카드사 포인트가 후취방식으로 결제됩니다.
 
@@ -337,7 +337,7 @@ import Hint from "~/components/Hint";
 
     **파라미터 설명**
 
-    - **card\_code :** 금결원 카드사코드 [<mark style="color:red;">**링크**</mark>](http://faq.portone.io/6503bcb4-4a61-4cf3-afd8-5d913b1385a6) 참조 (<mark style="color:green;">**string)**</mark>
+    - **card\_code :** 금결원 카드사코드 [<mark style="color:red;">**링크**</mark>](/opi/ko/support/code-info/card-code) 참조 (<mark style="color:green;">**string)**</mark>
     - **enabled :** 해당카드 활성화 여부 (<mark style="color:orange;">**boolean)**</mark>
 
     <mark style="color:red;">**신한카드**</mark>**만 결제창 노출 처리 예제**

--- a/src/routes/(root)/opi/ko/integration/pg/v1/daou/readme.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/daou/readme.mdx
@@ -222,7 +222,7 @@ import Hint from "~/components/Hint";
 
     **파라미터 설명**
 
-    - **`code`** : 카드사 금융결제원 표준 코드. [<mark style="color:red;">**링크**</mark>](http://faq.portone.io/6503bcb4-4a61-4cf3-afd8-5d913b1385a6) 참조 (**string**)
+    - **`code`** : 카드사 금융결제원 표준 코드. [<mark style="color:red;">**링크**</mark>](/opi/ko/support/code-info/card-code) 참조 (**string**)
     - **`quota`** : 할부 개월 수. 일시불일 시 0으로 지정 (**number**)
   </Tabs.Tab>
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/inicis.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/inicis.mdx
@@ -316,7 +316,7 @@ KG이니시스 결제창을 호출할 수 있습니다.
 
     **파라미터 설명**
 
-    - **code** : 카드사 금융결제원 표준 코드. [<mark style="color:red;">**링크**</mark>](http://faq.portone.io/6503bcb4-4a61-4cf3-afd8-5d913b1385a6) 참조 (**string**)
+    - **code** : 카드사 금융결제원 표준 코드. [<mark style="color:red;">**링크**</mark>](/opi/ko/support/code-info/card-code) 참조 (**string**)
     - **quota** : 할부 개월 수. 일시불일 시 0 으로 지정. (**integer**)
   </Tabs.Tab>
 
@@ -334,7 +334,7 @@ KG이니시스 결제창을 호출할 수 있습니다.
 
     **파라미터 설명**
 
-    - **card\_code :** 금결원 카드사코드 [<mark style="color:red;">**링크**</mark>](http://chaifinance.notion.site/53589280bbc94fab938d93257d452216?v=eb405baf52134b3f90d438e3bf763630) 참조 (<mark style="color:green;">**string)**</mark>
+    - **card\_code :** 금결원 카드사코드 [<mark style="color:red;">**링크**</mark>](/opi/ko/support/code-info/card-code) 참조 (<mark style="color:green;">**string)**</mark>
     - **enabled :** 해당카드 활성화 여부 (<mark style="color:orange;">**boolean)**</mark>
   </Tabs.Tab>
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/kicc.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/kicc.mdx
@@ -250,7 +250,7 @@ import Hint from "~/components/Hint";
 
     **파라미터 설명**
 
-    - **`code`** : 카드사 금융결제원 표준 코드. [<mark style="color:red;">**링크**</mark>](http://faq.portone.io/6503bcb4-4a61-4cf3-afd8-5d913b1385a6) 참조 (**string**)
+    - **`code`** : 카드사 금융결제원 표준 코드. [<mark style="color:red;">**링크**</mark>](/opi/ko/support/code-info/card-code) 참조 (**string**)
     - **`quota`** : 할부 개월 수. 일시불일 시 0 으로 지정. (**number**)
 
     <Hint style="danger">
@@ -274,7 +274,7 @@ import Hint from "~/components/Hint";
 
     **파라미터 설명**
 
-    - **`card_code` :** 금융결제원 카드사 코드. [<mark style="color:red;">**링크**</mark>](http://faq.portone.io/6503bcb4-4a61-4cf3-afd8-5d913b1385a6) 참조 (<mark style="color:green;">**string)**</mark>
+    - **`card_code` :** 금융결제원 카드사 코드. [<mark style="color:red;">**링크**</mark>](/opi/ko/support/code-info/card-code) 참조 (<mark style="color:green;">**string)**</mark>
     - **`enabled` :** 해당카드 활성화 여부 (<mark style="color:orange;">**boolean)**</mark>
   </Tabs.Tab>
 </Tabs>

--- a/src/routes/(root)/opi/ko/integration/pg/v1/ksnet/readme.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/ksnet/readme.mdx
@@ -249,7 +249,7 @@ KSNET 결제창을 호출할 수 있습니다. **결제결과**는 PC의 경우 
   <Tabs.Tab title="API 결제">
     ### 일회성 결제 요청하기
 
-    REST [**API POST /subscribe/payments/onetime**](http://developers.portone.io/api/rest-v1/nonAuthPayment#post%20%2Fsubscribe%2Fpayments%2Fonetime)을 호출하여 일회성 결제를 요청합니다.
+    REST [**API POST /subscribe/payments/onetime**](/api/rest-v1/nonAuthPayment#post%20%2Fsubscribe%2Fpayments%2Fonetime)을 호출하여 일회성 결제를 요청합니다.
     요청 시 전달된 카드 정보는 포트원에 등록되지 않습니다.
 
     ```sh
@@ -260,7 +260,7 @@ KSNET 결제창을 호출할 수 있습니다. **결제결과**는 PC의 경우 
 
     ### 빌링키 발급 요청하기
 
-    REST [**API POST /subscribe/customers/\{customer\_uid}**](http://developers.portone.io/api/rest-v1/billingkey#post%20%2Fsubscribe%2Fcustomers%2F%7Bcustomer_uid%7D)를 호출하여 빌링키 발급을 요청합니다.
+    REST [**API POST /subscribe/customers/\{customer\_uid}**](/api/rest-v1/billingkey#post%20%2Fsubscribe%2Fcustomers%2F%7Bcustomer_uid%7D)를 호출하여 빌링키 발급을 요청합니다.
 
     ```sh
     curl -H "Content-Type: application/json" \
@@ -272,7 +272,7 @@ KSNET 결제창을 호출할 수 있습니다. **결제결과**는 PC의 경우 
 
     빌링키 발급과 최초 결제가 성공하면 빌링키는 전달된 `customer_uid` 와 1:1 매칭되어 포트원에 저장됩니다.
     보안상의 이유로 서버는 빌링키에 직접 접근할 수 없기 때문에 `customer_uid`를 이용해서
-    재결제([**POST /subscribe/payments/again**](http://developers.portone.io/api/rest-v1/nonAuthPayment#post%20%2Fsubscribe%2Fpayments%2Fagain)) REST API를 다음과 같이 호출합니다.
+    재결제([**POST /subscribe/payments/again**](/api/rest-v1/nonAuthPayment#post%20%2Fsubscribe%2Fpayments%2Fagain)) REST API를 다음과 같이 호출합니다.
 
     ```sh
     curl -H "Content-Type: application/json" \
@@ -287,13 +287,13 @@ KSNET 결제창을 호출할 수 있습니다. **결제결과**는 PC의 경우 
 ### 승인 취소(환불)
 
 결제 승인 완료 건에 대해 승인 취소(환불)를 할 수 있는 API입니다.\
-REST [**API POST /payments/cancel**](http://developers.portone.io/api/rest-v1/payment#post%20%2Fpayments%2Fcancel)를
+REST [**API POST /payments/cancel**](/api/rest-v1/payment#post%20%2Fpayments%2Fcancel)를
 호출하여 승인 취소(환불)을 요청합니다.
 
 ### 현금영수증 등록
 
 포트원을 통한 거래건이지만 결제창에서 현금영수증 등록을 하지 못한 경우 API를 통해 현금영수증을 등록할 수 있습니다.\
-REST [**API POST /receipts/\{imp\_uid}**](http://developers.portone.io/api/rest-v1/receipt#post%20%2Freceipts%2F%7Bimp_uid%7D)를
+REST [**API POST /receipts/\{imp\_uid}**](/api/rest-v1/receipt#post%20%2Freceipts%2F%7Bimp_uid%7D)를
 호출하여 현금영수증을 요청합니다.
 
 - `product_type`(디지털: `"digital"`, 실물: `"real"`), `buyer_name` 파라미터는 KSNET 필수 입력 대상입니다.
@@ -307,7 +307,7 @@ curl -H "Content-Type: application/json" \
 ### 외부 현금영수증 등록
 
 포트원을 통한 거래건이 아닌 현금성 거래의 경우에도 API를 통해 현금영수증을 등록할 수 있습니다.\
-REST [**API POST /receipts/external/\{merchant\_uid}**](http://developers.portone.io/api/rest-v1/receipt#post%20%2Freceipts%2Fexternal%2F%7Bmerchant_uid%7D)를
+REST [**API POST /receipts/external/\{merchant\_uid}**](/api/rest-v1/receipt#post%20%2Freceipts%2Fexternal%2F%7Bmerchant_uid%7D)를
 호출하여 현금영수증을 요청합니다.
 
 - `product_type`, `pg`, `buyer_name` 파라미터는 KSNET 필수 입력 대상입니다.
@@ -386,7 +386,7 @@ curl -H "Content-Type: application/json" \
 
           **카드사 코드**
 
-          [카드사 코드 바로가기](http://developers.portone.io/docs/ko/tip/card-code?v=v1)
+          [카드사 코드 바로가기](/opi/ko/support/code-info/card-code?v=v1)
       </ParamTree>
   </ParamTree>
 </ParamTree>

--- a/src/routes/(root)/opi/ko/integration/pg/v1/newtoss/readme.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/newtoss/readme.mdx
@@ -377,7 +377,7 @@ import image4 from "../_assets/tosspayments/tosspayments4.png";
 
     **파라미터 설명**
 
-    - **`code`** : 카드사 금융결제원 표준 코드. [<mark style="color:red;">**링크**</mark>](http://faq.portone.io/6503bcb4-4a61-4cf3-afd8-5d913b1385a6) 참조 (**string**)
+    - **`code`** : 카드사 금융결제원 표준 코드. [<mark style="color:red;">**링크**</mark>](/opi/ko/support/code-info/card-code) 참조 (**string**)
     - **`quota`** : 할부 개월 수. 일시불일 시 0 으로 지정. (**number**)
   </Tabs.Tab>
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/nice.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/nice.mdx
@@ -220,7 +220,7 @@ NICE페이먼츠 결제창을 호출할 수 있습니다.
 
     **파라미터 설명**
 
-    - **`code`** : 카드사 금융결제원 표준 코드. [<mark style="color:red;">**링크**</mark>](http://faq.portone.io/6503bcb4-4a61-4cf3-afd8-5d913b1385a6) 참조 (**string**)
+    - **`code`** : 카드사 금융결제원 표준 코드. [<mark style="color:red;">**링크**</mark>](/opi/ko/support/code-info/card-code) 참조 (**string**)
     - **`quota`** : 할부 개월 수. 일시불일 시 0으로 지정. (**number**)
 
     <Hint style="danger">
@@ -244,7 +244,7 @@ NICE페이먼츠 결제창을 호출할 수 있습니다.
 
     **파라미터 설명**
 
-    - **`card_code` :** 금융결제원 카드사 코드. [<mark style="color:red;">**링크**</mark>](http://faq.portone.io/6503bcb4-4a61-4cf3-afd8-5d913b1385a6) 참조 (<mark style="color:green;">**string)**</mark>
+    - **`card_code` :** 금융결제원 카드사 코드. [<mark style="color:red;">**링크**</mark>](/opi/ko/support/code-info/card-code) 참조 (<mark style="color:green;">**string)**</mark>
     - **`enabled` :** 해당 카드 활성화 여부 (<mark style="color:orange;">**boolean)**</mark>
   </Tabs.Tab>
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/paymentwall.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/paymentwall.mdx
@@ -253,7 +253,7 @@ import Hint from "~/components/Hint";
 
   페이먼트월을 통한 이커머스(실물상품) 결제인 경우 아래 배송정보등록 API를 반드시 연동해야 합니다. 해당 API를 연동하지 않을 경우 정산 시 문제가 발생할 수 있습니다.
 
-  [→ 페이먼트월 배송등록 API 바로가기](http://developers.portone.io/api/rest-v1/pg.paymentwall)
+  [→ 페이먼트월 배송등록 API 바로가기](/api/rest-v1/pg.paymentwall)
 </Hint>
 
 <Hint style="danger">

--- a/src/routes/(root)/opi/ko/integration/pg/v1/settle/mybank.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/settle/mybank.mdx
@@ -256,7 +256,7 @@ callback) 호출 후 <mark style="color:red;">**callback**</mark> 으로 수신�
     #### 빌링키(customer\_uid)로 결제 요청하기
 
     빌링키 발급이 성공하면 실 빌링키는 customer\_uid 와 1:1 매칭되어 **포트원 서버에 저장**됩니다.
-    customer\_uid를 고객사 내부서버에 저장하시고 [**비 인증 결제요청 REST API**](http://developers.portone.io/api/rest-v1/nonAuthPayment#post%20%2Fsubscribe%2Fpayments%2Fagain)
+    customer\_uid를 고객사 내부서버에 저장하시고 [**비 인증 결제요청 REST API**](/api/rest-v1/nonAuthPayment#post%20%2Fsubscribe%2Fpayments%2Fagain)
     호출 시 해당 값을 지정하신 후 호출해야 합니다.
 
     ```sh title="server-side"

--- a/src/routes/(root)/opi/ko/integration/pg/v2/inicis-v2.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v2/inicis-v2.mdx
@@ -848,7 +848,7 @@ import Tabs from "~/components/gitbook/Tabs";
             **발급 은행**
 
             - 은행코드는 ENUM으로 정의되어 있습니다.
-            - [BANK ENUM 바로가기](http://developers.portone.io/api/rest-v2/type-def#Bank)
+            - [BANK ENUM 바로가기](/api/rest-v2/type-def#Bank)
 
           - `expiry` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
 

--- a/src/routes/(root)/opi/ko/integration/pg/v2/kcp-v2.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v2/kcp-v2.mdx
@@ -786,7 +786,7 @@ KCP 기준으로 작성한 예시 코드는 아래와 같습니다.
             **발급 은행**
 
             - 은행코드는 ENUM으로 정의되어 있습니다.
-            - [BANK ENUM 바로가기](http://developers.portone.io/api/rest-v2/type-def#Bank)
+            - [BANK ENUM 바로가기](/api/rest-v2/type-def#Bank)
 
           - `expiry` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
 

--- a/src/routes/(root)/opi/ko/integration/pg/v2/kpn.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v2/kpn.mdx
@@ -375,7 +375,7 @@ function requestPayment() {
   <Details.Content>
     한국결제네트웍스(KPN)에서 가상계좌 발급이 가능한 은행은 아래와 같습니다.
 
-    은행코드는 [BANK ENUM](http://developers.portone.io/api/rest-v2/type-def#Bank)으로 정의되어 있으며
+    은행코드는 [BANK ENUM](/api/rest-v2/type-def#Bank)으로 정의되어 있으며
     아래 목록에 대한 ENUM 코드를 매핑하여 API에 사용하실 수 있습니다.
 
     - 기업은행
@@ -641,7 +641,7 @@ const issueResponse = await axios({
             **발급 은행**
 
             - 은행코드는 ENUM으로 정의되어 있습니다.
-            - [BANK ENUM 바로가기](http://developers.portone.io/api/rest-v2/type-def#Bank)
+            - [BANK ENUM 바로가기](/api/rest-v2/type-def#Bank)
 
           - `expiry` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
 

--- a/src/routes/(root)/opi/ko/integration/pg/v2/paypal-v2.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v2/paypal-v2.mdx
@@ -212,7 +212,7 @@ function updateLoadIssueBillingKeyUIRequest() {
 
 1. 결제 요청 후 대기 상태
    페이팔 결제 건은 결제 승인 요청 시 바로 승인 되지 않고 일정 시간이후 처리되는 "승인 대기(pending)" 상태가 존재합니다.
-   때문에 트랜잭션 종료 시 콜백 함수로 전달되는 결제 아이디(paymentId)로 결제 내역을 조회하여 status 응답에 따라 후처리 로직을 구현해야 합니다. \[[→ 결제내역 단건조회 API 바로가기](http://developers.portone.io/api/rest-v2/payment#get%20%2Fpayments%2F%7BpaymentId%7D)]
+   때문에 트랜잭션 종료 시 콜백 함수로 전달되는 결제 아이디(paymentId)로 결제 내역을 조회하여 status 응답에 따라 후처리 로직을 구현해야 합니다. \[[→ 결제내역 단건조회 API 바로가기](/api/rest-v2/payment#get%20%2Fpayments%2F%7BpaymentId%7D)]
 
 2. 결제 취소 후 대기 상태
    결제 취소 시 취소 승인이 바로 되지 않고 일정 시간이후 취소 승인이 처리되는 경우가 존재합니다.

--- a/src/routes/(root)/opi/ko/integration/pg/v2/smartro-v2.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v2/smartro-v2.mdx
@@ -676,7 +676,7 @@ import Tabs from "~/components/gitbook/Tabs";
             **발급 은행**
 
             - 은행코드는 ENUM으로 정의되어 있습니다.
-            - [BANK ENUM 바로가기](http://developers.portone.io/api/rest-v2/type-def#Bank)
+            - [BANK ENUM 바로가기](/api/rest-v2/type-def#Bank)
 
           - `expiry` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
 

--- a/src/routes/(root)/opi/ko/integration/ready/_components/integration-guide/inicis.mdx
+++ b/src/routes/(root)/opi/ko/integration/ready/_components/integration-guide/inicis.mdx
@@ -8,7 +8,7 @@ import image23 from "./assets/inicis2.png";
 <VersionGate v="v1">
   <Hint style="info">
     - **INILite Key**는 정기결제 시 필수로 입력해야 합니다.
-    - **INIAPI Key**, **INIAPI IV** 하위 상점 관련 API 사용시 필수로 입력해야 합니다. [영수증 내 하위 상점 거래 등록 API 바로가기](http://developers.portone.io/api/rest-v1/partner#post%20%2Fpartners%2Freceipts%2F%7Bimp_uid%7D)
+    - **INIAPI Key**, **INIAPI IV** 하위 상점 관련 API 사용시 필수로 입력해야 합니다. [영수증 내 하위 상점 거래 등록 API 바로가기](/api/rest-v1/partner#post%20%2Fpartners%2Freceipts%2F%7Bimp_uid%7D)
   </Hint>
 </VersionGate>
 

--- a/src/routes/(root)/opi/ko/integration/sdk/javascript-sdk/payrq.mdx
+++ b/src/routes/(root)/opi/ko/integration/sdk/javascript-sdk/payrq.mdx
@@ -410,5 +410,5 @@ const param = {
 
 **파라미터 설명**
 
-- **card\_code :** 금결원 카드사 코드 [<mark style="color:red;">**링크**</mark>](https://chaifinance.notion.site/53589280bbc94fab938d93257d452216?v=eb405baf52134b3f90d438e3bf763630) 참조 (<mark style="color:green;">**string)**</mark>
+- **card\_code :** 금결원 카드사 코드 [<mark style="color:red;">**링크**</mark>](/opi/ko/support/code-info/card-code) 참조 (<mark style="color:green;">**string)**</mark>
 - **enabled :** 해당 카드 활성화 여부 (<mark style="color:orange;">**boolean)**</mark>

--- a/src/routes/(root)/opi/ko/integration/start/v1/non-auth.mdx
+++ b/src/routes/(root)/opi/ko/integration/start/v1/non-auth.mdx
@@ -32,7 +32,7 @@ import Image1 from "../_assets/subscription.png";
   매번 카드정보를 기입해야 하는 번거로움 때문에 많이 사용되지 않은 방식입니다.
 </Hint>
 
-카드 정보를 바탕으로 [비 인증 결제(일회성) API](http://developers.portone.io/api/rest-v1/nonAuthPayment#post%20%2Fsubscribe%2Fpayments%2Fonetime)
+카드 정보를 바탕으로 [비 인증 결제(일회성) API](/api/rest-v1/nonAuthPayment#post%20%2Fsubscribe%2Fpayments%2Fonetime)
 를 이용하여 결제를 진행하는 방식입니다.
 
 - 지원 결제대행사
@@ -87,7 +87,7 @@ const onetimeResponse = await fetch(
 
 #### REST API 방식
 
-고객 결제 정보를 이용하여 [빌링키 발급 API](http://developers.portone.io/api/rest-v1/billingkey#post%20%2Fsubscribe%2Fcustomers%2F%7Bcustomer_uid%7D)를
+고객 결제 정보를 이용하여 [빌링키 발급 API](/api/rest-v1/billingkey#post%20%2Fsubscribe%2Fcustomers%2F%7Bcustomer_uid%7D)를
 호출하면 포트원 서버가 결제대행사를 통해 빌링키를 발급받습니다.
 
 이 과정에서 고객의 카드 정보는 포트원 서버에 기록되지 않습니다.
@@ -153,7 +153,7 @@ const {
 결제창을 이용해 빌링키를 발급할 때는 포트원 SDK를 이용합니다.
 
 포트원 SDK를 설치하는 방법은
-[포트원 SDK 설치하기](http://developers.portone.io/docs/ko/authpay/guide?v=v1#1-포트원-sdk-설치하기) 문서를 참고하세요.
+[포트원 SDK 설치하기](/opi/ko/integration/start/v1/auth?v=v1#1-포트원-sdk-설치하기-) 문서를 참고하세요.
 
 `IMP.request_pay()` 함수를 호출 시 `customer_uid` 파라미터를 포함하는 경우 빌링키를 발급하기 위한
 결제창을 열 수 있습니다.
@@ -221,8 +221,8 @@ IMP.request_pay(
 
 ### 빌링키 결제 요청하기
 
-발급 받은 포트원 빌링키를 이용하여 [비 인증 결제(빌링키) API](http://developers.portone.io/api/rest-v1/nonAuthPayment#post%20%2Fsubscribe%2Fpayments%2Fagain)
-또는 [결제 예약 API](http://developers.portone.io/api/rest-v1/nonAuthPayment.subscribe#post%20%2Fsubscribe%2Fpayments%2Fschedule)
+발급 받은 포트원 빌링키를 이용하여 [비 인증 결제(빌링키) API](/api/rest-v1/nonAuthPayment#post%20%2Fsubscribe%2Fpayments%2Fagain)
+또는 [결제 예약 API](/api/rest-v1/nonAuthPayment.subscribe#post%20%2Fsubscribe%2Fpayments%2Fschedule)
 를 호출하여 즉시 결제 및 결제 예약을 진행합니다.
 
 #### 즉시 결제
@@ -230,11 +230,11 @@ IMP.request_pay(
 <Hint style="info">
   **빌링키 발급과 결제 요청을 한번에 하기**
 
-  [결제 예약 API](http://developers.portone.io/api/rest-v1/nonAuthPayment.subscribe#post%20%2Fsubscribe%2Fpayments%2Fschedule)를
+  [결제 예약 API](/api/rest-v1/nonAuthPayment.subscribe#post%20%2Fsubscribe%2Fpayments%2Fschedule)를
   사용하면 등록된 customer\_uid가 없는 경우 빌링키 신규 발급을 먼저 진행한 후 schedule정보를 예약합니다.(카드정보 필수사항)
 </Hint>
 
-[비 인증 결제(빌링키) API](http://developers.portone.io/api/rest-v1/nonAuthPayment#post%20%2Fsubscribe%2Fpayments%2Fagain)
+[비 인증 결제(빌링키) API](/api/rest-v1/nonAuthPayment#post%20%2Fsubscribe%2Fpayments%2Fagain)
 를 참고하여 파라미터를 입력한 후 결제 요청해야 합니다.
 
 ```ts title="server-side"
@@ -268,7 +268,7 @@ if (!paymentResponse.ok)
 **1. 결제 예약하기**
 
 미래 특정 시점에 결제가 진행되도록 결제를 예약할 수 있습니다.
-포트원 [결제 예약 API](http://developers.portone.io/api/rest-v1/nonAuthPayment.subscribe#post%20%2Fsubscribe%2Fpayments%2Fschedule)
+포트원 [결제 예약 API](/api/rest-v1/nonAuthPayment.subscribe#post%20%2Fsubscribe%2Fpayments%2Fschedule)
 를 이용하여 원하시는 시점에 결제 예약을 손쉽게 등록할 수 있습니다.
 
 ```ts title="server-side"

--- a/src/routes/(root)/opi/ko/support/code-info/pg.mdx
+++ b/src/routes/(root)/opi/ko/support/code-info/pg.mdx
@@ -8,8 +8,8 @@ import Hint from "~/components/Hint";
 
 <Hint style="info">
   발급과 동시에 결제 기능은 포트원 결제모듈 V1에서만 지원되며, 지원 여부는 결제창 방식 기준으로 작성되었습니다.
-  API방식으로 연동하실 때는 [비인증 결제(일회성) API](https://developers.portone.io/api/rest-v1/nonAuthPayment#post%20%2Fsubscribe%2Fpayments%2Fonetime)
-  를 사용하시거나 [빌링키 발급 API](https://developers.portone.io/api/rest-v1/billingkey#post%20%2Fsubscribe%2Fcustomers%2F%7Bcustomer_uid%7D)
+  API방식으로 연동하실 때는 [비인증 결제(일회성) API](/api/rest-v1/nonAuthPayment#post%20%2Fsubscribe%2Fpayments%2Fonetime)
+  를 사용하시거나 [빌링키 발급 API](/api/rest-v1/billingkey#post%20%2Fsubscribe%2Fcustomers%2F%7Bcustomer_uid%7D)
   로 발급 후 결제 로직을 직접 구현하실 수 있습니다.
 </Hint>
 

--- a/src/routes/(root)/platform/(doc)/usages/order.mdx
+++ b/src/routes/(root)/platform/(doc)/usages/order.mdx
@@ -24,7 +24,7 @@ import Tabs from "~/components/gitbook/Tabs";
   <Tabs.Tab title="Python">
     ```py
     import requests
-    # ... 결제 요청 및 결제 완료 로직 생략. 포트원 결제일경우 /docs/ko/authpay/guide?v=v2를 참고하세요
+    # ... 결제 요청 및 결제 완료 로직 생략. 포트원 결제일경우 https://developers.portone.io/opi/ko/authpay/guide?v=v2 를 참고하세요
 
     # 주문 정산 요청
 
@@ -670,7 +670,7 @@ import Tabs from "~/components/gitbook/Tabs";
 <Tabs>
   <Tabs.Tab title="Python">
     ```py
-    # ... 결제 요청 및 결제 완료 로직 생략. 포트원 결제일경우 /docs/ko/authpay/guide?v=v2를 참고하세요
+    # ... 결제 요청 및 결제 완료 로직 생략. 포트원 결제일경우 https://developers.portone.io/opi/ko/authpay/guide?v=v2 를 참고하세요
 
     # 주문건에 대해서 주문금액 기준으로 직접 파트너별로 분리하여 정산건을 생성합니다.
 
@@ -708,7 +708,7 @@ import Tabs from "~/components/gitbook/Tabs";
   <Tabs.Tab title="Node">
     ```js
     const axios = require("axios");
-    // ... 결제 요청 및 결제 완료 로직 생략. 포트원 결제일경우 /docs/ko/authpay/guide?v=v2를 참고하세요
+    // ... 결제 요청 및 결제 완료 로직 생략. 포트원 결제일경우 https://developers.portone.io/opi/ko/authpay/guide?v=v2 를 참고하세요
     // 주문건에 대해서 주문금액 기준으로 직접 파트너별로 분리하여 정산건을 생성합니다.
 
     const orderTransferData_A = {

--- a/src/routes/(root)/platform/(doc)/usages/order.mdx
+++ b/src/routes/(root)/platform/(doc)/usages/order.mdx
@@ -24,7 +24,7 @@ import Tabs from "~/components/gitbook/Tabs";
   <Tabs.Tab title="Python">
     ```py
     import requests
-    # ... 결제 요청 및 결제 완료 로직 생략. 포트원 결제일경우 https://developers.portone.io/docs/ko/authpay/guide?v=v2를 참고하세요
+    # ... 결제 요청 및 결제 완료 로직 생략. 포트원 결제일경우 /docs/ko/authpay/guide?v=v2를 참고하세요
 
     # 주문 정산 요청
 
@@ -670,7 +670,7 @@ import Tabs from "~/components/gitbook/Tabs";
 <Tabs>
   <Tabs.Tab title="Python">
     ```py
-    # ... 결제 요청 및 결제 완료 로직 생략. 포트원 결제일경우 https://developers.portone.io/docs/ko/authpay/guide?v=v2를 참고하세요
+    # ... 결제 요청 및 결제 완료 로직 생략. 포트원 결제일경우 /docs/ko/authpay/guide?v=v2를 참고하세요
 
     # 주문건에 대해서 주문금액 기준으로 직접 파트너별로 분리하여 정산건을 생성합니다.
 
@@ -708,7 +708,7 @@ import Tabs from "~/components/gitbook/Tabs";
   <Tabs.Tab title="Node">
     ```js
     const axios = require("axios");
-    // ... 결제 요청 및 결제 완료 로직 생략. 포트원 결제일경우 https://developers.portone.io/docs/ko/authpay/guide?v=v2를 참고하세요
+    // ... 결제 요청 및 결제 완료 로직 생략. 포트원 결제일경우 /docs/ko/authpay/guide?v=v2를 참고하세요
     // 주문건에 대해서 주문금액 기준으로 직접 파트너별로 분리하여 정산건을 생성합니다.
 
     const orderTransferData_A = {

--- a/src/routes/(root)/release-notes/(note)/api-sdk/2023-05-12.mdx
+++ b/src/routes/(root)/release-notes/(note)/api-sdk/2023-05-12.mdx
@@ -21,4 +21,4 @@ writtenAt: 2023-05-15
 - 면세 금액을 직접 설정할 수 있습니다
 - 회전식/고정식 가상계좌를 발급할 수 있습니다
 
-본 기능 설정을 위한 자세한 내용은 관련 API 문서를 확인 바랍니다. [→ 스마트로 PG 설정하기](https://developers.portone.io/docs/ko/pg/payment-gateway/smartro-v2/readme)
+본 기능 설정을 위한 자세한 내용은 관련 API 문서를 확인 바랍니다. [→ 스마트로 PG 설정하기](/docs/ko/pg/payment-gateway/smartro-v2/readme)

--- a/src/routes/(root)/release-notes/(note)/api-sdk/2023-07-17.mdx
+++ b/src/routes/(root)/release-notes/(note)/api-sdk/2023-07-17.mdx
@@ -27,7 +27,7 @@ import { PaymentV1 } from "~/components/release-note/badges";
 API를 통해 PG 설정 정보 호출시 channel\_name과 channel\_key 응답을 받아볼 수 있습니다.
 
 본 기능 설정을 위한 자세한 내용은 관련 API 문서를 확인 바랍니다.
-[→ PG MID 복수조회 API 호출하기](https://developers.portone.io/docs/ko/api/miscellaneous-api/pg/pg-mid-api)
+[→ PG MID 복수조회 API 호출하기](/docs/ko/api/miscellaneous-api/pg/pg-mid-api)
 
 <br />
 

--- a/src/routes/(root)/release-notes/(note)/api-sdk/2023-07-31.mdx
+++ b/src/routes/(root)/release-notes/(note)/api-sdk/2023-07-31.mdx
@@ -18,4 +18,4 @@ KCP 인증결제창에서 할인쿠폰 적용 여부를 컨트롤 할수 있는 
 할인쿠폰기능을 사용하기 위해서는 KCP와 협의가 먼저 선행되어야 하는점 유의하세요
 
 본 기능 설정을 위한 자세한 내용은 SDK 가이드 문서를 확인 해주세요
-[→ KCP SDK 연동가이드 확인하기](https://developers.portone.io/docs/ko/pg/payment-gateway/nhn-kcp#4-%EA%B8%B0%ED%83%80-%ED%8C%8C%EB%9D%BC%EB%AF%B8%ED%84%B0)
+[→ KCP SDK 연동가이드 확인하기](/docs/ko/pg/payment-gateway/nhn-kcp#4-%EA%B8%B0%ED%83%80-%ED%8C%8C%EB%9D%BC%EB%AF%B8%ED%84%B0)

--- a/src/routes/(root)/release-notes/(note)/api-sdk/2023-08-31.mdx
+++ b/src/routes/(root)/release-notes/(note)/api-sdk/2023-08-31.mdx
@@ -27,7 +27,7 @@ NHN KCP결제창을 통한 빌링키 발급시 파라미터를 통해 빌링키 
 선택할수 있도록 하였습니다.
 
 본 기능 설정을 위한 자세한 내용은 SDK 가이드 문서를 확인 해주세요
-[→ KCP SDK 연동가이드 확인하기](https://developers.portone.io/docs/ko/pg/payment-gateway/nhn-kcp#4-%EA%B8%B0%ED%83%80-%ED%8C%8C%EB%9D%BC%EB%AF%B8%ED%84%B0)
+[→ KCP SDK 연동가이드 확인하기](/docs/ko/pg/payment-gateway/nhn-kcp#4-%EA%B8%B0%ED%83%80-%ED%8C%8C%EB%9D%BC%EB%AF%B8%ED%84%B0)
 
 <prose.h3>
   <PaymentV1 />

--- a/src/routes/(root)/release-notes/(note)/api-sdk/2024-05-14.mdx
+++ b/src/routes/(root)/release-notes/(note)/api-sdk/2024-05-14.mdx
@@ -18,7 +18,7 @@ import { PaymentV1 } from "~/components/release-note/badges";
 바로 호출하여 사용하세요.
 
 KSNET 카드사 다이렉트 연동에 대해 자세히 알고 싶다면
-[→ KSNET 연동가이드](https://developers.portone.io/docs/ko/pg/payment-gateway/ksnet/readme?v=v1#%EC%B9%B4%EB%93%9C%EC%82%AC-%EB%8B%A4%EC%9D%B4%EB%A0%89%ED%8A%B8-%ED%98%B8%EC%B6%9C)
+[→ KSNET 연동가이드](/docs/ko/pg/payment-gateway/ksnet/readme?v=v1#%EC%B9%B4%EB%93%9C%EC%82%AC-%EB%8B%A4%EC%9D%B4%EB%A0%89%ED%8A%B8-%ED%98%B8%EC%B6%9C)
 에서 확인하실 수 있습니다.
 
 (\* 포트원 V2 결제 모듈의 경우 추후에 KSNET을 통한 카드사 다이렉트 기능이 지원될 예정입니다.)

--- a/src/routes/(root)/release-notes/(note)/api-sdk/2024-06-03.mdx
+++ b/src/routes/(root)/release-notes/(note)/api-sdk/2024-06-03.mdx
@@ -53,6 +53,6 @@ import Image1 from "./_assets/2024-06-03/screenshot.png";
 이번 업데이트를 통해 스마트 라우팅 그룹을 생성하고 자동화된 결제 트래픽 분산 서비스를 경험해보세요.
 
 스마트 라우팅에 대해 자세히 알고 싶다면
-[→ 스마트 라우팅 소개](https://developers.portone.io/docs/ko/smartrouting/intro-sr) 및
-[→ 스마트 라우팅 연동하기](https://developers.portone.io/docs/ko/smartrouting/smartrouting)
+[→ 스마트 라우팅 소개](/opi/ko/extra/smart-routing/intro) 및
+[→ 스마트 라우팅 연동하기](/opi/ko/extra/smart-routing/integration)
 문서에서 확인하실 수 있습니다.

--- a/src/routes/(root)/release-notes/(note)/platform/2023-08-31.mdx
+++ b/src/routes/(root)/release-notes/(note)/platform/2023-08-31.mdx
@@ -20,4 +20,4 @@ import { Partner } from "~/components/release-note/badges";
 영업일 2일안에 연락드리겠습니다.
 
 [→ 파트너 정산 자동화 서비스 소개](https://portone.io/korea/ko/service/platform)
-[→ 파트너 정산 자동화 연동가이드 확인하기](https://developers.portone.io/platform/guide)
+[→ 파트너 정산 자동화 연동가이드 확인하기](/platform/guides/intro)

--- a/src/routes/(root)/release-notes/(note)/platform/2023-11-14.mdx
+++ b/src/routes/(root)/release-notes/(note)/platform/2023-11-14.mdx
@@ -30,7 +30,7 @@ import * as prose from "~/components/prose";
 - graphql 중 `loginViaApiKey` mutation이 `loginViaApiSecret` 로 변경됩니다.
 
 - 따라서 rest api 중 `/login/api-key` api는 **deprecate**되고
-[API secret 를 사용한 토큰 발급 api](https://developers.portone.io/api/rest-v2/auth#post%20%2Flogin%2Fapi-secret)가
+[API secret 를 사용한 토큰 발급 api](/api/rest-v2/auth#post%20%2Flogin%2Fapi-secret)가
 추가됩니다.
 
 - `/login/api-key`의 경우, 하위 호환성 보장을 위해 24년 3월까지 사용이 가능하나, 가급적 변경해주시길 바랍니다.


### PR DESCRIPTION
- `developers.portone.io` 링크를 상대 경로로 변경
- `/docs` 경로를 `/opi` 경로로 이동