### PR TITLE
SDK 메뉴 명칭 변경 & 브라우저 SDK 링크 추가

### DIFF
--- a/src/layouts/gnb/Gnb.tsx
+++ b/src/layouts/gnb/Gnb.tsx
@@ -128,14 +128,21 @@ export default function Gnb(props: Props) {
                     systemVersion: "v2",
                   },
                   {
-                    label: "Client SDKs",
+                    label: "브라우저 SDK",
+                    link: {
+                      v1: "/sdk/ko/v1-sdk/javascript-sdk/readme",
+                      v2: "/sdk/ko/v2-sdk/readme",
+                    },
+                  },
+                  {
+                    label: "모바일 SDK",
                     link: {
                       v1: "/sdk/ko/v1-mobile-sdk/readme",
                       v2: "/sdk/ko/v2-mobile-sdk/readme",
                     },
                   },
                   {
-                    label: "Server SDKs",
+                    label: "서버 SDK",
                     link: "/sdk/ko/v2-server-sdk/readme",
                   },
                   {

--- a/src/routes/(root)/sdk/ko/_nav.yaml
+++ b/src/routes/(root)/sdk/ko/_nav.yaml
@@ -2,7 +2,7 @@
   items:
     - /ko/readme
 
-- label: JS SDK
+- label: 브라우저 SDK
   systemVersion: v1
   items:
     - /ko/v1-sdk/javascript-sdk/readme
@@ -13,7 +13,7 @@
     - /ko/v1-sdk/javascript-sdk/load-module
     - /ko/v1-sdk/javascript-sdk/load-module-rt
 
-- label: JS SDK
+- label: 브라우저 SDK
   systemVersion: v2
   items:
     - /ko/v2-sdk/readme

--- a/src/routes/(root)/sdk/ko/readme/index.mdx
+++ b/src/routes/(root)/sdk/ko/readme/index.mdx
@@ -9,7 +9,7 @@ import VersionGate from "~/components/gitbook/VersionGate";
 
 포트원은 고객사에서 보다 쉽게 서비스를 이용하실 수 있도록 프로그래밍 언어 / 플랫폼 별 SDK를 제공하고 있습니다.
 
-## JS SDK
+## 브라우저 SDK
 
 브라우저 환경에서 포트원 서비스를 연동할 때 사용하는 자바스크립트 SDK입니다. 브라우저에서 포트원 SDK를 호출하여 결제, 본인인증 등을 진행하게 됩니다.
 


### PR DESCRIPTION
- Client SDKs -> 모바일 SDK
- Server SDKs -> 서버 SDK
- JS SDK -> 브라우저 SDK

JS SDK는 상단 메뉴 링크와 SDK 문서 title만 변경하고 문서 내 표현은 유지했습니다.