### PR TITLE
[v1] KCP퀵페이, 헥토파이낸셜 결제 연동 파라미터 수정

### DIFF
--- a/src/routes/(root)/opi/ko/integration/pg/v1/nhn-kcp.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/nhn-kcp.mdx
@@ -630,7 +630,7 @@ KCP 퀵페이 기준으로 작성한 예시 코드는 아래와 같습니다.
           kcpQuick: {
             //KCP퀵페이 설정 정보
             actionType: "Register", //결제수단 등록
-            memberCI: "djkDFJ45dFndkl", //본인인증 후 전달된 CI 값
+            encryptedCI: "encrypted_ci" // 본인인증 후 전달받은 CI를 암호화한 값
             memeberID: "use_your_unique_id", //사용자에 대한 고유 식별값
           },
         },
@@ -663,7 +663,7 @@ KCP 퀵페이 기준으로 작성한 예시 코드는 아래와 같습니다.
           kcpQuick: {
             //KCP퀵페이 설정 정보
             actionType: "Deregister", //결제수단 삭제
-            memberCI: "djkDFJ45dFndkl", //결제수단 등록시 입력한 CI 값
+            encryptedCI: "encrypted_ci" // 본인인증 후 전달받은 CI를 암호화한 값
             memeberID: "use_your_unique_id", //사용자에 대한 고유 식별값
           },
         },
@@ -698,7 +698,7 @@ KCP 퀵페이 기준으로 작성한 예시 코드는 아래와 같습니다.
           kcpQuick: {
             //KCP퀵페이 설정 정보
             actionType: "Pay", //결제 요청
-            memberCI: "djkDFJ45dFndkl", //결제수단 등록시 입력한 CI 값
+            encryptedCI: "encrypted_ci" // 본인인증 후 전달받은 CI를 암호화한 값
             memeberID: "use_your_unique_id", //사용자에 대한 고유 식별값
           },
         },
@@ -733,7 +733,7 @@ KCP 퀵페이 기준으로 작성한 예시 코드는 아래와 같습니다.
           kcpQuick: {
             //KCP퀵페이 설정 정보
             actionType: "PinChange", //PIN번호 변경
-            memberCI: "djkDFJ45dFndkl", //결제수단 등록시 입력한 CI 값
+            encryptedCI: "encrypted_ci" // 본인인증 후 전달받은 CI를 암호화한 값
             memeberID: "use_your_unique_id", //사용자에 대한 고유 식별값
           },
         },
@@ -766,7 +766,7 @@ KCP 퀵페이 기준으로 작성한 예시 코드는 아래와 같습니다.
           kcpQuick: {
             //KCP퀵페이 설정 정보
             actionType: "PinReset", //PIN번호 초기화
-            memberCI: "djkDFJ45dFndkl", //결제수단 등록시 입력한 CI 값
+            encryptedCI: "encrypted_ci" // 본인인증 후 전달받은 CI를 암호화한 값
             memeberID: "use_your_unique_id", //사용자에 대한 고유 식별값
           },
         },
@@ -801,7 +801,7 @@ KCP 퀵페이 기준으로 작성한 예시 코드는 아래와 같습니다.
           kcpQuick: {
             //KCP퀵페이 설정 정보
             actionType: "PhoneChange", //등록된 휴대폰 번호 변경
-            memberCI: "djkDFJ45dFndkl", //본인인증 후 전달된 CI 값
+            encryptedCI: "encrypted_ci" // 본인인증 후 전달받은 CI를 암호화한 값
             memeberID: "use_your_unique_id", //사용자에 대한 고유 식별값
           },
         },
@@ -836,7 +836,7 @@ KCP 퀵페이 기준으로 작성한 예시 코드는 아래와 같습니다.
           kcpQuick: {
             //KCP퀵페이 설정 정보
             actionType: "Terminate", //유저 및 결제수단 삭제
-            memberCI: "djkDFJ45dFndkl", //본인인증 후 전달된 CI 값
+            encryptedCI: "encrypted_ci" // 본인인증 후 전달받은 CI를 암호화한 값
             memeberID: "use_your_unique_id", //사용자에 대한 고유 식별값
           },
         },
@@ -937,9 +937,9 @@ KCP 퀵페이 기준으로 작성한 예시 코드는 아래와 같습니다.
             - PhoneChange : 전화번호 변경
             - Terminate : 결제 수단 해지
 
-          - memberCI: string
+          - encryptedCI: string
 
-            **본인인증 CI값**
+            **암호화된 본인인증 CI**
 
           - memberID: string
 
@@ -993,6 +993,33 @@ KCP 퀵페이 기준으로 작성한 예시 코드는 아래와 같습니다.
 </Details>
 
 <Details>
+  <Details.Summary>`encryptedCI` 파라미터 안내</Details.Summary>
+
+  <Details.Content>
+    본인인증 후 전달받은 CI 값을 아래 방법으로 암호화하여 입력해야합니다.
+
+    포트원 계정의 [REST API Secret](https://developers.portone.io/api/rest-v1/auth?v=v1) 을 SHA-256 해시 알고리즘으로 처리하여 암호화 키를 생성한 후, 해당 키를 사용해 CI 데이터를 AES-256-ECB 방식으로 암호화해야 합니다.
+    암호화된 결과는 Base64로 인코딩하여 encryptedCI 파라미터 값으로 전달합니다.
+
+    ```
+    FUNCTION encryptCi(ci, apiSecret):
+    # Step 1: SHA-256으로 API Secret을 해시하여 암호화 키 생성
+    key = SHA256(apiSecret)
+
+    # Step 2: AES-256-ECB 알고리즘으로 CI 데이터를 암호화
+    encryptedData = AES256Encrypt(data = ci, key = key, mode = ECB)
+
+    # Step 3: 암호화된 데이터를 Base64로 인코딩
+    base64EncodedData = Base64Encode(encryptedData)
+
+    # Step 4: Base64 인코딩된 결과 반환
+    RETURN base64EncodedData
+    END FUNCTION
+    ```
+  </Details.Content>
+</Details>
+
+<Details>
   <Details.Summary>결제수단을 여러개 등록할 수 있습니다.</Details.Summary>
 
   <Details.Content>
@@ -1006,7 +1033,7 @@ KCP 퀵페이 기준으로 작성한 예시 코드는 아래와 같습니다.
   <Details.Summary>결제수단 삭제 요청시 등록할 때 입력한 정보를 동일하게 입력해야 합니다.</Details.Summary>
 
   <Details.Content>
-    결제수단 삭제(actionType:Deregister) 요청시 결제수단 등록할 때 사용된 `customer_uid` + `memberCI` + `memberID` + `deviceID` + `noAuth` 조합을
+    결제수단 삭제(actionType:Deregister) 요청시 결제수단 등록할 때 사용된 `customer_uid` + `encryptedCI` + `memberID` + `deviceID` + `noAuth` 조합을
     동일하게 전송해야 합니다.
   </Details.Content>
 </Details>

--- a/src/routes/(root)/opi/ko/integration/pg/v1/nhn-kcp.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/nhn-kcp.mdx
@@ -630,7 +630,7 @@ KCP 퀵페이 기준으로 작성한 예시 코드는 아래와 같습니다.
           kcpQuick: {
             //KCP퀵페이 설정 정보
             actionType: "Register", //결제수단 등록
-            encryptedCI: "encrypted_ci" // 본인인증 후 전달받은 CI를 암호화한 값
+            encryptedCI: "encrypted_ci", // 본인인증 후 전달받은 CI를 암호화한 값
             memeberID: "use_your_unique_id", //사용자에 대한 고유 식별값
           },
         },
@@ -663,7 +663,7 @@ KCP 퀵페이 기준으로 작성한 예시 코드는 아래와 같습니다.
           kcpQuick: {
             //KCP퀵페이 설정 정보
             actionType: "Deregister", //결제수단 삭제
-            encryptedCI: "encrypted_ci" // 본인인증 후 전달받은 CI를 암호화한 값
+            encryptedCI: "encrypted_ci", // 본인인증 후 전달받은 CI를 암호화한 값
             memeberID: "use_your_unique_id", //사용자에 대한 고유 식별값
           },
         },
@@ -698,7 +698,7 @@ KCP 퀵페이 기준으로 작성한 예시 코드는 아래와 같습니다.
           kcpQuick: {
             //KCP퀵페이 설정 정보
             actionType: "Pay", //결제 요청
-            encryptedCI: "encrypted_ci" // 본인인증 후 전달받은 CI를 암호화한 값
+            encryptedCI: "encrypted_ci", // 본인인증 후 전달받은 CI를 암호화한 값
             memeberID: "use_your_unique_id", //사용자에 대한 고유 식별값
           },
         },
@@ -733,7 +733,7 @@ KCP 퀵페이 기준으로 작성한 예시 코드는 아래와 같습니다.
           kcpQuick: {
             //KCP퀵페이 설정 정보
             actionType: "PinChange", //PIN번호 변경
-            encryptedCI: "encrypted_ci" // 본인인증 후 전달받은 CI를 암호화한 값
+            encryptedCI: "encrypted_ci", // 본인인증 후 전달받은 CI를 암호화한 값
             memeberID: "use_your_unique_id", //사용자에 대한 고유 식별값
           },
         },
@@ -766,7 +766,7 @@ KCP 퀵페이 기준으로 작성한 예시 코드는 아래와 같습니다.
           kcpQuick: {
             //KCP퀵페이 설정 정보
             actionType: "PinReset", //PIN번호 초기화
-            encryptedCI: "encrypted_ci" // 본인인증 후 전달받은 CI를 암호화한 값
+            encryptedCI: "encrypted_ci", // 본인인증 후 전달받은 CI를 암호화한 값
             memeberID: "use_your_unique_id", //사용자에 대한 고유 식별값
           },
         },
@@ -801,7 +801,7 @@ KCP 퀵페이 기준으로 작성한 예시 코드는 아래와 같습니다.
           kcpQuick: {
             //KCP퀵페이 설정 정보
             actionType: "PhoneChange", //등록된 휴대폰 번호 변경
-            encryptedCI: "encrypted_ci" // 본인인증 후 전달받은 CI를 암호화한 값
+            encryptedCI: "encrypted_ci", // 본인인증 후 전달받은 CI를 암호화한 값
             memeberID: "use_your_unique_id", //사용자에 대한 고유 식별값
           },
         },
@@ -836,7 +836,7 @@ KCP 퀵페이 기준으로 작성한 예시 코드는 아래와 같습니다.
           kcpQuick: {
             //KCP퀵페이 설정 정보
             actionType: "Terminate", //유저 및 결제수단 삭제
-            encryptedCI: "encrypted_ci" // 본인인증 후 전달받은 CI를 암호화한 값
+            encryptedCI: "encrypted_ci", // 본인인증 후 전달받은 CI를 암호화한 값
             memeberID: "use_your_unique_id", //사용자에 대한 고유 식별값
           },
         },
@@ -1001,7 +1001,7 @@ KCP 퀵페이 기준으로 작성한 예시 코드는 아래와 같습니다.
     포트원 계정의 [REST API Secret](https://developers.portone.io/api/rest-v1/auth?v=v1) 을 SHA-256 해시 알고리즘으로 처리하여 암호화 키를 생성한 후, 해당 키를 사용해 CI 데이터를 AES-256-ECB 방식으로 암호화해야 합니다.
     암호화된 결과는 Base64로 인코딩하여 encryptedCI 파라미터 값으로 전달합니다.
 
-    ```
+    ```pseudo
     FUNCTION encryptCi(ci, apiSecret):
     # Step 1: SHA-256으로 API Secret을 해시하여 암호화 키 생성
     key = SHA256(apiSecret)

--- a/src/routes/(root)/opi/ko/integration/pg/v1/nhn-kcp.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/nhn-kcp.mdx
@@ -998,7 +998,7 @@ KCP 퀵페이 기준으로 작성한 예시 코드는 아래와 같습니다.
   <Details.Content>
     본인인증 후 전달받은 CI 값을 아래 방법으로 암호화하여 입력해야합니다.
 
-    포트원 계정의 [REST API Secret](https://developers.portone.io/api/rest-v1/auth?v=v1) 을 SHA-256 해시 알고리즘으로 처리하여 암호화 키를 생성한 후, 해당 키를 사용해 CI 데이터를 AES-256-ECB 방식으로 암호화해야 합니다.
+    포트원 계정의 [REST API Secret](/api/rest-v1/auth?v=v1) 을 SHA-256 해시 알고리즘으로 처리하여 암호화 키를 생성한 후, 해당 키를 사용해 CI 데이터를 AES-256-ECB 방식으로 암호화해야 합니다.
     암호화된 결과는 Base64로 인코딩하여 encryptedCI 파라미터 값으로 전달합니다.
 
     ```pseudo

--- a/src/routes/(root)/opi/ko/integration/pg/v1/settle/mybank.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/settle/mybank.mdx
@@ -113,7 +113,7 @@ callback) 호출 후 **callback** 으로 수신되며,
               본인인증 후 전달받은 CI 값을 AES-256-ECB 방식을 사용해 암호화하여 16진수로 인코딩한 결과를 입력해야합니다.
               암호화 키(key)는 포트원 관리자콘솔 채널 등록 시 "암호화 키" 항목에 입력한 값을 사용합니다.
 
-              ```
+              ```pseudo
               INPUT: ci (string), key (string)
               OUTPUT: custCI (string)
 
@@ -247,7 +247,7 @@ callback) 호출 후 **callback** 으로 수신되며,
               본인인증 후 전달받은 CI 값을 AES-256-ECB 방식을 사용해 암호화하여 16진수로 인코딩한 결과를 입력해야합니다.
               암호화 키(key)는 포트원 관리자콘솔 채널 등록 시 "암호화 키" 항목에 입력한 값을 사용합니다.
 
-              ```
+              ```pseudo
               INPUT: ci (string), key (string)
               OUTPUT: custCI (string)
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/settle/mybank.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/settle/mybank.mdx
@@ -110,9 +110,24 @@ callback) 호출 후 **callback** 으로 수신되며,
             **주문자 CI**
 
             <Hint style="warning">
-              **2024년 6월부터 필수 파라미터로 변경되었습니다.** (신규 계약 고객의 경우 해당 파라미터를 누락한 채
-              결제 요청하실 경우, 결제가 중단될 수 있습니다. 다만, 기존 고객의 경우 당분간은 해당 파라미터를 제외한 채
-              결제가 가능하오나 자세한 사항은 헥토파이낸셜에 문의해 주시기 바랍니다.)
+              본인인증 후 전달받은 CI 값을 AES-256-ECB 방식을 사용해 암호화하여 16진수로 인코딩한 결과를 입력해야합니다.
+              암호화 키(key)는 포트원 관리자콘솔 채널 등록 시 "암호화 키" 항목에 입력한 값을 사용합니다.
+
+              ```
+              INPUT: ci (string), key (string)
+              OUTPUT: custCI (string)
+
+              BEGIN
+              # Step 1: CI 데이터를 AES-256-ECB 방식으로 암호화
+              binaryData ← AES256ECB(key, ci)
+
+              # Step 2: 암호화된 데이터를 16진수 문자열로 변환
+              custCI ← ConvertToHex(binaryData)
+
+              # Step 3: 결과 반환
+              RETURN custCI
+              END
+              ```
             </Hint>
 
             고객사가 보유한 회원 CI를 설정하면 내통장 결제에 등록한 CI와 비교하여 동일인인지 자동검증되며
@@ -229,9 +244,24 @@ callback) 호출 후 **callback** 으로 수신되며,
             **주문자 CI**
 
             <Hint style="warning">
-              **2024년 6월부터 필수 파라미터로 변경되었습니다.** (신규 계약 고객의 경우 해당 파라미터를 누락한 채
-              결제 요청하실 경우, 결제가 중단될 수 있습니다. 다만, 기존 고객의 경우 당분간은 해당 파라미터를 제외한 채
-              결제가 가능하오나 자세한 사항은 헥토파이낸셜에 문의해 주시기 바랍니다.)
+              본인인증 후 전달받은 CI 값을 AES-256-ECB 방식을 사용해 암호화하여 16진수로 인코딩한 결과를 입력해야합니다.
+              암호화 키(key)는 포트원 관리자콘솔 채널 등록 시 "암호화 키" 항목에 입력한 값을 사용합니다.
+
+              ```
+              INPUT: ci (string), key (string)
+              OUTPUT: custCI (string)
+
+              BEGIN
+              # Step 1: CI 데이터를 AES-256-ECB 방식으로 암호화
+              binaryData ← AES256ECB(key, ci)
+
+              # Step 2: 암호화된 데이터를 16진수 문자열로 변환
+              custCI ← ConvertToHex(binaryData)
+
+              # Step 3: 결과 반환
+              RETURN custCI
+              END
+              ```
             </Hint>
 
             고객사가 보유한 회원 CI를 설정하면 내통장 결제에 등록한 CI와 비교하여 동일인인지 자동검증되며


### PR DESCRIPTION
v1 헥토, 퀵페이에서 ci 값을 평문이 아닌 암호화된 값으로 전달하도록 문서 수정했습니다.