### PR TITLE
v1 가이드 설명 보완 및 잘못된 연동 예시 코드 수정

### DIFF
--- a/src/routes/(root)/opi/ko/integration/pg/v1/ksnet/readme.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/ksnet/readme.mdx
@@ -177,6 +177,12 @@ KSNET 결제창을 호출할 수 있습니다. **결제결과**는 PC의 경우 
 
     **카드 결제시, 카드 결제창에 앱카드만 선택 가능하도록 할지 여부 (기본값: **false**)**
 
+    **`useFreeInterestFromMall`** <mark style="color:orange;">**boolean**</mark>
+
+    **상점 부담 무이자 할부 사용 여부**
+
+    고객사가 부담하는 무이자 할부 여부를 설정 할 수 있습니다.
+
     **`display`** <mark style="color:blue;">**object**</mark>
 
     **결제창에 렌더링될 카드 할부 개월수 리스트 설정**
@@ -333,6 +339,25 @@ curl -H "Content-Type: application/json" \
 }
 ```
 
+상점 부담 무이자 할부의 경우 card.detail 파라미터를 사용하여 최대 할부개월수 설정이 가능합니다.
+
+```json
+{
+  "card": {
+    "detail": [
+      { "card_code": "366", "max_month": 5 }, // 특정 카드사 (신한카드) 상점 부담 무이자 최대 5개월 할부 설정
+      { "card_code": "381", "max_month": 3 } // 특정 카드사 (KB국민카드) 상점 부담 무이자 최대 3개월 할부 설정
+    ]
+  }
+}
+```
+
+<Hint style="info">
+  KB 앱카드 결제 시, card.useInstallment 파라미터 true 설정 시에만 할부 개월 수 설정이 가능합니다.
+</Hint>
+
+자세한 상점 부담 무이자 할부 설정 가이드는  [\[API\&SDK\] - \[브라우저 SDK\] - \[결제요청 파라미터\] - \[상점 부담 무이자 할부 최대 개월수 설정하기](/sdk/ko/v1-sdk/javascript-sdk/payrq?v=v1#상점-부담-무이자-할부-최대-개월수-설정하기) 에서 확인 가능합니다.
+
 **파라미터 설명**
 
 <ParamTree>
@@ -347,6 +372,34 @@ curl -H "Content-Type: application/json" \
 
       `[0]` : 일시불
       `[2,3,4]` : 2,3,4 개월
+  </ParamTree>
+
+  `useFreeInterestFromMall` <mark style="color:orange;">**boolean**</mark>
+
+  **상점 부담 무이자 할부 사용 여부**
+
+  `card` <mark style="color:blue;">**object**</mark>
+
+  **카드 결제시, 카드 결제에 대한 세부 정보 설정**
+
+  <ParamTree>
+    - `useInstallment` <mark style="color:orange;">**boolean**</mark>
+
+      **할부 가능 여부**
+
+    - `detail` <mark style="color:blue;">**array**</mark>
+
+      **카드사 렌더링 정보**
+
+      <ParamTree>
+        - `card_code` <mark style="color:green;">**string**</mark>
+
+          **카드사 코드**
+
+        - `max_month` <mark style="color:purple;">**number**</mark>
+
+          **상점 부담 무이자 할부 최대 개월수**
+      </ParamTree>
   </ParamTree>
 </ParamTree>
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/naver.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/naver.mdx
@@ -470,3 +470,8 @@ callback) 호출 후 <mark style="color:red;">**callback**</mark> 으로 수신 
     ```
   </Details.Content>
 </Details>
+
+## 3. 검수요청 하기
+
+네이버페이(결제형)은 다른 결제대행사와 다르게 별도의 검수절차가 존재합니다.
+자세한 검수 요청 가이드는 [헬프센터 > 네이버페이(결제형) 검수요청 항목](https://help.portone.io/content/naverpay-review-items) 페이지를 참고부탁드립니다.

--- a/src/routes/(root)/opi/ko/integration/start/v1/auth.mdx
+++ b/src/routes/(root)/opi/ko/integration/start/v1/auth.mdx
@@ -363,7 +363,8 @@ SDK의 반환값 대신 URL의 [쿼리 문자열](http://en.wikipedia.org/wiki/Q
       });
       if (!tokenResponse.ok)
         throw new Error(`tokenResponse: ${await tokenResponse.json()}`);
-      const { access_token } = await tokenResponse.json();
+      const { response } = await tokenResponse.json();
+      const { access_token } = response;
 
       // 2. 포트원 결제내역 단건조회 API 호출
       const paymentResponse = await fetch(

--- a/src/routes/(root)/sdk/ko/v1-sdk/javascript-sdk/payrq.mdx
+++ b/src/routes/(root)/sdk/ko/v1-sdk/javascript-sdk/payrq.mdx
@@ -345,6 +345,12 @@ PG사별 지원되는 결제수단이 모두 상이합니다.
 
 - 다날 가상계좌 결제수단 사용 시 필수 항목입니다.
 
+### **`useFreeInterestFromMall`** <mark style="color:orange;">**boolean**</mark>
+
+**상점 부담 무이자 할부 사용 여부**
+
+고객사가 부담하는 무이자 할부 여부를 설정 할 수 있습니다.
+
 ## 부가기능
 
 ### 원하는 할부개월수만 활성화하기
@@ -412,3 +418,36 @@ const param = {
 
 - **card\_code :** 금결원 카드사 코드 [<mark style="color:red;">**링크**</mark>](/opi/ko/support/code-info/card-code) 참조 (<mark style="color:green;">**string)**</mark>
 - **enabled :** 해당 카드 활성화 여부 (<mark style="color:orange;">**boolean)**</mark>
+
+### 상점 부담 무이자 할부 최대 개월수 설정하기
+
+```json
+{
+  "card": {
+    "detail": [
+      { "card_code": "366", "max_month": 5 }, // 특정 카드사 (신한카드) 상점 부담 무이자 최대 5개월 할부 설정
+      { "card_code": "381", "max_month": 3 } // 특정 카드사 (KB국민카드) 상점 부담 무이자 최대 3개월 할부 설정
+    ]
+  },
+  "useFreeInterestFromMall": true
+}
+```
+
+**파라미터 설명**
+
+- **useFreeInterestFromMall :** 상점 부담 무이자 할부 사용 여부 (<mark style="color:orange;">**boolean)**</mark>
+- **card.detail.card\_code :** 금결원 카드사 코드 [<mark style="color:red;">**링크**</mark>](/opi/ko/support/code-info/card-code) 참조 (<mark style="color:green;">**string)**</mark>
+- **card.detail.max\_month :** 상점 부담 무이자 할부 최대 개월수 (<mark style="color:purple;">**number)**</mark>
+
+<Details>
+  <Details.Summary>지원되는 PG사</Details.Summary>
+
+  <Details.Content>
+    - 토스페이먼츠(신모듈)
+    - KSNET
+    - 나이스페이(신모듈)
+    - 웰컴페이먼츠
+    - KSNET 카드 다이렉트
+    - 이니시스
+  </Details.Content>
+</Details>


### PR DESCRIPTION
- v1 네이버페이 결제형 연동문서에 헬프센터 검수요청 가이드 링크 추가
- v1 인증결제 연동 예시 코드 중 잘못된 코드 수정
- v1 SDK > 결제요청 파라미터와 v1 KSNET 연동 가이드에 상점 부담 무이자 할부에 대한 설정 방법과 그와 관련된 파라미터 설명 추가