### PR TITLE
:memo: docs(rest-v1): 보안규격 지원 종료안내 강제 개행 수정

### DIFF
--- a/src/routes/(root)/api/rest-v1/[...slug].tsx
+++ b/src/routes/(root)/api/rest-v1/[...slug].tsx
@@ -54,14 +54,9 @@ export default function ApiV1Docs() {
           비인증 결제, 정기 자동결제 등 부가기능을 위한 REST API도 제공합니다.
         </prose.p>
         <Hint style="danger">
-          2024년 9월 1일부로 포트원 V1 API에 대해 일부 보안 규격이 지원
-          종료됩니다.
-          <br />
-          자세한 사항은
-          <a href="/opi/ko/support/tls-support?v=v1" style="color:orange">
-            TLS 지원 범위
-          </a>
-          를 참고해주세요.
+          2024년 9월 1일부로 포트원 V1 API에 대해 일부 보안 규격이 지원 종료됩니다.
+      
+          자세한 사항은 [TLS 지원 범위](/opi/ko/support/tls-support?v=v1)를 참고해주세요.
         </Hint>
         <prose.p>
           <strong>V1 API hostname: </strong>

--- a/src/routes/(root)/api/rest-v1/[...slug].tsx
+++ b/src/routes/(root)/api/rest-v1/[...slug].tsx
@@ -54,9 +54,8 @@ export default function ApiV1Docs() {
           비인증 결제, 정기 자동결제 등 부가기능을 위한 REST API도 제공합니다.
         </prose.p>
         <Hint style="danger">
-          2024년 9월 1일부로 포트원 V1 API에 대해 일부 보안 규격이 지원 종료됩니다.
-      
-          자세한 사항은 [TLS 지원 범위](/opi/ko/support/tls-support?v=v1)를 참고해주세요.
+          <prose.p>2024년 9월 1일부로 포트원 V1 API에 대해 일부 보안 규격이 지원 종료됩니다.</prose.p>
+          <prose.p>자세한 사항은 <a href="/opi/ko/support/tls-support?v=v1" className="text-orange-5 hover:text-orange-7">TLS 지원 범위</a>를 참고해주세요.</prose.p>
         </Hint>
         <prose.p>
           <strong>V1 API hostname: </strong>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/f20d65e8-9fc4-42f5-9bf0-7f3baf443b0f)


해당 강제개행 되는 문제를 해결합니다.
https://github.com/portone-io/developers.portone.io/blob/main/src/routes/(root)/opi/ko/readme/index.mdx?plain=1 해당 파일에서 Hint 컴포넌트를 복사했습니다.