### PR TITLE
SDK 파라미터 작성 간소화

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 node-options=--max-old-space-size=6144
+side-effects-cache=false

--- a/app.config.ts
+++ b/app.config.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 
+import remarkParamTree from "@portone-io/remark-param-tree";
 import yaml from "@rollup/plugin-yaml";
 import rehypeShiki, { type RehypeShikiOptions } from "@shikijs/rehype";
 import { transformerMetaHighlight } from "@shikijs/transformers";
@@ -44,7 +45,7 @@ export default defineConfig({
           jsx: true,
           jsxImportSource: "solid-js",
           providerImportSource: "solid-mdx",
-          remarkPlugins: [remarkFrontmatter, remarkGfm],
+          remarkPlugins: [remarkFrontmatter, remarkGfm, remarkParamTree],
           rehypePlugins: [
             rehypeSlug,
             [

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -47,6 +47,7 @@ export default [
       "**/routes/(root)/docs/**/*",
       ".vinxi",
       ".output",
+      "packages/**/dist",
     ],
   },
   {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"@parcel/watcher": "^2.4.1",
 		"@portone-io/lint-local-links-valid": "workspace:^",
 		"@portone-io/lint-no-jamo": "workspace:^",
+		"@portone-io/remark-param-tree": "workspace:^",
 		"@portone/browser-sdk": "^0.0.10",
 		"@rollup/plugin-yaml": "^4.1.2",
 		"@shikijs/rehype": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -5,15 +5,17 @@
 	"license": "AGPL-3.0-or-later",
 	"repository": "https://github.com/portone-io/developers.portone.io",
 	"scripts": {
-		"dev": "pnpm --filter @portone-io/remark-param-tree build && concurrently -k \"vinxi dev\" \"pnpm gen-collections watch\"",
-		"build": "pnpm gen-collections && pnpm --filter @portone-io/remark-param-tree build && vinxi build",
+		"dev": "pnpm build:deps && concurrently -k \"vinxi dev\" \"pnpm gen-collections watch\"",
+		"build": "pnpm gen-collections && pnpm build:deps && vinxi build",
+		"build:deps": "pnpm --filter @portone-io/remark-param-tree build",
 		"start": "vinxi start",
 		"version": "vinxi version",
 		"check": "pnpm lint",
 		"gen-collections": "tsx src/genCollections.ts",
 		"lint:fix": "NODE_OPTIONS=\"$NODE_OPTIONS --loader ts-node/esm\" eslint --fix .",
 		"lint": "NODE_OPTIONS=\"$NODE_OPTIONS --loader ts-node/esm\" eslint .",
-		"eslint": "NODE_OPTIONS=\"$NODE_OPTIONS --loader ts-node/esm\" eslint"
+		"eslint": "NODE_OPTIONS=\"$NODE_OPTIONS --loader ts-node/esm\" eslint",
+		"postinstall": "pnpm build:deps"
 	},
 	"imports": {
 		"#content": "./src/content/__generated__/index.ts",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
 	"license": "AGPL-3.0-or-later",
 	"repository": "https://github.com/portone-io/developers.portone.io",
 	"scripts": {
-		"dev": "concurrently -k \"vinxi dev\" \"pnpm gen-collections watch\"",
-		"build": "pnpm gen-collections && vinxi build",
+		"dev": "pnpm --filter @portone-io/remark-param-tree build && concurrently -k \"vinxi dev\" \"pnpm gen-collections watch\"",
+		"build": "pnpm gen-collections && pnpm --filter @portone-io/remark-param-tree build && vinxi build",
 		"start": "vinxi start",
 		"version": "vinxi version",
 		"check": "pnpm lint",

--- a/packages/remark-param-tree/README.md
+++ b/packages/remark-param-tree/README.md
@@ -1,0 +1,1 @@
+## @portone-io/remark-param-tree

--- a/packages/remark-param-tree/package.json
+++ b/packages/remark-param-tree/package.json
@@ -4,30 +4,32 @@
   "repository": "https://github.com/portone-io/developers.portone.io",
   "type": "module",
   "private": true,
-  "main": "src/index.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
-    "test": "vitest"
+    "test": "vitest",
+    "build": "rm -rf dist && rollup -c"
   },
   "dependencies": {
     "mdast-util-from-markdown": "^2.0.1",
     "mdast-util-to-string": "^4.0.0",
     "ts-pattern": "^5.1.1",
     "unified": "^11.0.5",
-    "unist-util-visit": "^5.0.0",
-    "unist-util-visit-parents": "^6.0.1"
+    "unist-builder": "^4.0.0",
+    "unist-util-visit": "^5.0.0"
   },
   "devDependencies": {
+    "@rollup/plugin-typescript": "^12.1.2",
     "@types/mdast": "^4.0.4",
     "@types/node": "^20.12.7",
-    "@types/unist": "^3.0.3",
     "@vitest/ui": "^1.5.3",
     "fast-glob": "^3.3.2",
-    "mdast-util-mdx-jsx": "^3.1.3",
     "remark-frontmatter": "^5.0.0",
     "remark-gfm": "^4.0.0",
     "remark-mdx": "^3.0.1",
     "remark-parse": "^11.0.0",
     "remark-stringify": "^11.0.0",
+    "rollup": "^4.29.1",
     "string-width": "^5.1.2",
     "vfile": "^6.0.3",
     "vite-tsconfig-paths": "^4.3.2",

--- a/packages/remark-param-tree/package.json
+++ b/packages/remark-param-tree/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@portone-io/remark-param-tree",
+  "version": "0.0.1",
+  "repository": "https://github.com/portone-io/developers.portone.io",
+  "type": "module",
+  "private": true,
+  "main": "src/index.ts",
+  "scripts": {
+    "test": "vitest"
+  },
+  "dependencies": {
+    "mdast-util-from-markdown": "^2.0.1",
+    "mdast-util-to-string": "^4.0.0",
+    "ts-pattern": "^5.1.1",
+    "unified": "^11.0.5",
+    "unist-util-visit": "^5.0.0",
+    "unist-util-visit-parents": "^6.0.1"
+  },
+  "devDependencies": {
+    "@types/mdast": "^4.0.4",
+    "@types/node": "^20.12.7",
+    "@types/unist": "^3.0.3",
+    "@vitest/ui": "^1.5.3",
+    "fast-glob": "^3.3.2",
+    "mdast-util-mdx-jsx": "^3.1.3",
+    "remark-frontmatter": "^5.0.0",
+    "remark-gfm": "^4.0.0",
+    "remark-mdx": "^3.0.1",
+    "remark-parse": "^11.0.0",
+    "remark-stringify": "^11.0.0",
+    "string-width": "^5.1.2",
+    "vfile": "^6.0.3",
+    "vite-tsconfig-paths": "^4.3.2",
+    "vitest": "^1.5.3"
+  }
+}

--- a/packages/remark-param-tree/rollup.config.js
+++ b/packages/remark-param-tree/rollup.config.js
@@ -1,0 +1,13 @@
+import typescript from "@rollup/plugin-typescript";
+import { defineConfig } from "rollup";
+
+export default defineConfig({
+  input: "src/index.ts",
+  output: [
+    {
+      format: "esm",
+      file: "dist/index.js",
+    },
+  ],
+  plugins: [typescript()],
+});

--- a/packages/remark-param-tree/scripts/migration.ts
+++ b/packages/remark-param-tree/scripts/migration.ts
@@ -1,0 +1,143 @@
+import "mdast-util-mdx-jsx";
+
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import fastGlob from "fast-glob";
+import type { Paragraph, Root } from "mdast";
+import { fromMarkdown } from "mdast-util-from-markdown";
+import { toString } from "mdast-util-to-string";
+import remarkFrontmatter from "remark-frontmatter";
+import remarkGfm from "remark-gfm";
+import remarkMdx from "remark-mdx";
+import remarkParse from "remark-parse";
+import remarkStringify from "remark-stringify";
+import stringWidth from "string-width";
+import { match, P } from "ts-pattern";
+import { unified } from "unified";
+import { SKIP, visit } from "unist-util-visit";
+import type { VFile } from "vfile";
+
+type TypeDefinition = {
+  name: string;
+  type: string;
+  optional: boolean;
+};
+
+function migration() {
+  return function (tree: Root, file: VFile) {
+    visit(tree, "mdxJsxFlowElement", (node) => {
+      if (node.name === "ParamTree") {
+        visit(node, "listItem", (listItem) => {
+          if (listItem.children[0]?.type !== "paragraph") {
+            return;
+          }
+          listItem.children[0].children = listItem.children[0].children.filter(
+            (child) =>
+              match(child)
+                .with(
+                  {
+                    type: "text",
+                    value: P.when((value) => value.trim() === ""),
+                  },
+                  () => false,
+                )
+                .otherwise(() => true),
+          );
+          const typeDefinition: TypeDefinition | null = match(
+            listItem.children[0],
+          )
+            .with(
+              {
+                children: [
+                  { type: P.not(P.union("inlineCode", "strong")) },
+                  ...P.array(),
+                ],
+              },
+              () => null,
+            )
+            .with(
+              {
+                children: [
+                  { type: P.union("inlineCode", "strong") },
+                  {
+                    type: "mdxJsxTextElement",
+                    name: "mark",
+                  },
+                ],
+              },
+              (typeDefinition) => {
+                return {
+                  name: toString(typeDefinition.children[0]),
+                  type: toString(typeDefinition.children[1]),
+                  optional: true,
+                } satisfies TypeDefinition;
+              },
+            )
+            .with(
+              {
+                children: [
+                  { type: P.union("inlineCode", "strong") },
+                  {
+                    type: "mdxJsxTextElement",
+                    name: "mark",
+                  },
+                  {
+                    type: "mdxJsxTextElement",
+                    name: "mark",
+                  },
+                ],
+              },
+              (typeDefinition) => {
+                return {
+                  name: toString(typeDefinition.children[0]),
+                  type: toString(typeDefinition.children[2]),
+                  optional: false,
+                } satisfies TypeDefinition;
+              },
+            )
+            .otherwise(() => {
+              // console.log(workingFile, toString(listItem.children[0]));
+              return null;
+            });
+
+          if (typeDefinition) {
+            listItem.children[0] = fromMarkdown(
+              `${typeDefinition.name}${typeDefinition.optional ? "?" : ""}: ${typeDefinition.type}`,
+              "utf-8",
+            ).children[0] as Paragraph;
+          }
+        });
+        return SKIP;
+      }
+      return;
+    });
+  };
+}
+
+const files = await fastGlob("**/*.mdx", {
+  cwd: path.resolve(import.meta.dirname, "../../../src/routes/(root)"),
+  absolute: true,
+  onlyFiles: true,
+});
+
+const processor = unified()
+  .use(remarkParse)
+  .use(remarkFrontmatter)
+  .use(remarkMdx)
+  .use(remarkGfm, { tableCellPadding: false, stringLength: stringWidth })
+  .use(migration)
+  .use(remarkStringify)
+  .data("settings", {
+    bullet: "-",
+    rule: "-",
+    emphasis: "_",
+  });
+
+await Promise.all(
+  files.map(async (file) => {
+    const content = await fs.readFile(file, "utf-8");
+    const vFile = await processor.process(content);
+    await fs.writeFile(file, vFile.toString());
+  }),
+);

--- a/packages/remark-param-tree/scripts/migration.ts
+++ b/packages/remark-param-tree/scripts/migration.ts
@@ -1,5 +1,3 @@
-import "mdast-util-mdx-jsx";
-
 import fs from "node:fs/promises";
 import path from "node:path";
 

--- a/packages/remark-param-tree/src/index.ts
+++ b/packages/remark-param-tree/src/index.ts
@@ -43,7 +43,7 @@ export default function remarkParamTreePlugin() {
           const [typeNode, typeStr] = result;
 
           const exec =
-            /^(?<name>[a-zA-Z_$][a-zA-Z0-9_$]*)(?<optional>\?)?:\s*(?<type>.+)$/.exec(
+            /^(?<name>[a-zA-Z_$][a-zA-Z0-9_$]*)(?<optional>\?)?:\s*(?<type>[a-zA-Z0-9_$<>[\]{}|&?()\s]+)$/.exec(
               typeStr,
             );
           if (exec === null) {

--- a/packages/remark-param-tree/src/index.ts
+++ b/packages/remark-param-tree/src/index.ts
@@ -1,15 +1,13 @@
-import "mdast-util-mdx-jsx";
-
-import path from "node:path";
-
-import type { BlockContent, DefinitionContent, Paragraph, Root } from "mdast";
-import { fromMarkdown } from "mdast-util-from-markdown";
+import type {
+  Heading,
+  ListItem,
+  Paragraph,
+  PhrasingContent,
+  Root,
+} from "mdast";
 import { toString } from "mdast-util-to-string";
 import { match, P } from "ts-pattern";
-import { SKIP, visit } from "unist-util-visit";
-import type { VFile } from "vfile";
-
-const isParameter = (node: BlockContent | DefinitionContent) => {};
+import { type BuildVisitor, SKIP, visit } from "unist-util-visit";
 
 type TypeDefinition = {
   name: string;
@@ -18,5 +16,148 @@ type TypeDefinition = {
 };
 
 export default function remarkParamTreePlugin() {
-  return function (tree: Root, file: VFile) {};
+  return function (tree: Root) {
+    visit(tree, "mdxJsxFlowElement", (node) => {
+      if (node.name === "ParamTree") {
+        const generateTypeDefinition = (
+          node: ListItem | Heading,
+        ):
+          | [node: Heading | Paragraph, typeDefinition: TypeDefinition]
+          | null => {
+          const result = match(node)
+            .with(
+              {
+                type: "heading",
+              },
+              (node) => [node, toString(node)] as const,
+            )
+            .with(
+              {
+                type: "listItem",
+                children: [{ type: "paragraph" }, ...P.array()],
+              },
+              (node) => [node.children[0], toString(node.children[0])] as const,
+            )
+            .otherwise(() => null);
+          if (result === null) return null;
+          const [typeNode, typeStr] = result;
+
+          const exec =
+            /^(?<name>[a-zA-Z_$][a-zA-Z0-9_$]*)(?<optional>\?)?:\s*(?<type>.+)$/.exec(
+              typeStr,
+            );
+          if (exec === null) {
+            return null;
+          }
+
+          return match(exec.groups)
+            .with(
+              {
+                name: P.string,
+                type: P.string,
+                optional: P.optional(P.string),
+              },
+              ({ name, type, optional }) =>
+                [
+                  typeNode,
+                  {
+                    name,
+                    type,
+                    optional: Boolean(optional),
+                  },
+                ] satisfies [
+                  node: Heading | Paragraph,
+                  typeDefinition: TypeDefinition,
+                ],
+            )
+            .otherwise(() => null);
+        };
+        const transformNode: (
+          ...params: Parameters<
+            | BuildVisitor<typeof node, "listItem">
+            | BuildVisitor<typeof node, "heading">
+          >
+        ) => void = (node, index, parent) => {
+          if (index === undefined) return;
+          if (parent === undefined) return;
+          const _typeDefinition = generateTypeDefinition(node);
+          if (_typeDefinition === null) return;
+          const [, typeDefinition] = _typeDefinition;
+          const typeMdast = [
+            {
+              type: "strong",
+              children: [
+                {
+                  type: "inlineCode",
+                  value: typeDefinition.name,
+                },
+              ],
+            },
+            { type: "text", value: " " },
+            typeDefinition.optional === true && {
+              type: "mdxJsxTextElement",
+              name: "mark",
+              attributes: [
+                {
+                  type: "mdxJsxAttribute",
+                  name: "style",
+                  value: "color:red;",
+                },
+              ],
+              children: [
+                {
+                  type: "strong",
+                  children: [{ type: "text", value: "*" }],
+                },
+              ],
+            },
+            typeDefinition.optional === true && { type: "text", value: " " },
+            {
+              type: "mdxJsxTextElement",
+              name: "mark",
+              attributes: [
+                {
+                  type: "mdxJsxAttribute",
+                  name: "style",
+                  value: "color:#1e293b;",
+                },
+              ],
+              children: [
+                {
+                  type: "strong",
+                  children: [{ type: "text", value: typeDefinition.type }],
+                },
+              ],
+            },
+          ].filter((node) => node !== false);
+          match(node)
+            .with(
+              {
+                type: "heading",
+              },
+              (node) => {
+                node.children = typeMdast as PhrasingContent[];
+              },
+            )
+            .with(
+              {
+                type: "listItem",
+                children: [{ type: "paragraph" }, ...P.array()],
+              },
+              (node) => {
+                node.children[0] = {
+                  type: "paragraph",
+                  children: typeMdast as PhrasingContent[],
+                };
+              },
+            )
+            .otherwise(() => {});
+        };
+        visit(node, "listItem", transformNode);
+        visit(node, "heading", transformNode);
+        return SKIP;
+      }
+      return;
+    });
+  };
 }

--- a/packages/remark-param-tree/src/index.ts
+++ b/packages/remark-param-tree/src/index.ts
@@ -1,0 +1,22 @@
+import "mdast-util-mdx-jsx";
+
+import path from "node:path";
+
+import type { BlockContent, DefinitionContent, Paragraph, Root } from "mdast";
+import { fromMarkdown } from "mdast-util-from-markdown";
+import { toString } from "mdast-util-to-string";
+import { match, P } from "ts-pattern";
+import { SKIP, visit } from "unist-util-visit";
+import type { VFile } from "vfile";
+
+const isParameter = (node: BlockContent | DefinitionContent) => {};
+
+type TypeDefinition = {
+  name: string;
+  type: string;
+  optional: boolean;
+};
+
+export default function remarkParamTreePlugin() {
+  return function (tree: Root, file: VFile) {};
+}

--- a/packages/remark-param-tree/tsconfig.json
+++ b/packages/remark-param-tree/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["vitest/globals"],
+    "baseUrl": "./"
+  }
+}

--- a/packages/remark-param-tree/tsconfig.json
+++ b/packages/remark-param-tree/tsconfig.json
@@ -12,6 +12,5 @@
     "types": ["vitest/globals"],
     "baseUrl": "./src",
     "outDir": "dist"
-  },
-  "include": ["./src/**/*"]
+  }
 }

--- a/packages/remark-param-tree/tsconfig.json
+++ b/packages/remark-param-tree/tsconfig.json
@@ -8,7 +8,10 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
+    "declaration": true,
     "types": ["vitest/globals"],
-    "baseUrl": "./"
-  }
+    "baseUrl": "./src",
+    "outDir": "dist"
+  },
+  "include": ["./src/**/*"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -534,31 +534,28 @@ importers:
       unified:
         specifier: ^11.0.5
         version: 11.0.5
+      unist-builder:
+        specifier: ^4.0.0
+        version: 4.0.0
       unist-util-visit:
         specifier: ^5.0.0
         version: 5.0.0
-      unist-util-visit-parents:
-        specifier: ^6.0.1
-        version: 6.0.1
     devDependencies:
+      '@rollup/plugin-typescript':
+        specifier: ^12.1.2
+        version: 12.1.2(rollup@4.29.1)(tslib@2.6.2)(typescript@5.6.3)
       '@types/mdast':
         specifier: ^4.0.4
         version: 4.0.4
       '@types/node':
         specifier: ^20.12.7
         version: 20.12.7
-      '@types/unist':
-        specifier: ^3.0.3
-        version: 3.0.3
       '@vitest/ui':
         specifier: ^1.5.3
         version: 1.5.3(vitest@1.5.3)
       fast-glob:
         specifier: ^3.3.2
         version: 3.3.2
-      mdast-util-mdx-jsx:
-        specifier: ^3.1.3
-        version: 3.1.3
       remark-frontmatter:
         specifier: ^5.0.0
         version: 5.0.0
@@ -574,6 +571,9 @@ importers:
       remark-stringify:
         specifier: ^11.0.0
         version: 11.0.0
+      rollup:
+        specifier: ^4.29.1
+        version: 4.29.1
       string-width:
         specifier: ^5.1.2
         version: 5.1.2
@@ -1749,6 +1749,19 @@ packages:
       rollup:
         optional: true
 
+  '@rollup/plugin-typescript@12.1.2':
+    resolution: {integrity: sha512-cdtSp154H5sv637uMr1a8OTWB0L1SWDSm1rDGiyfcGcvQ6cuTs4MDk2BVEBGysUWago4OJN4EQZqOTl/QY3Jgg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.14.0||^3.0.0||^4.0.0
+      tslib: '*'
+      typescript: '>=3.7.0'
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+      tslib:
+        optional: true
+
   '@rollup/plugin-yaml@4.1.2':
     resolution: {integrity: sha512-RpupciIeZMUqhgFE97ba0s98mOFS7CWzN3EJNhJkqSv9XLlWYtwVdtE6cDw6ASOF/sZVFS7kRJXftaqM2Vakdw==}
     engines: {node: '>=14.0.0'}
@@ -1794,8 +1807,18 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@rollup/rollup-android-arm-eabi@4.29.1':
+    resolution: {integrity: sha512-ssKhA8RNltTZLpG6/QNkCSge+7mBQGUqJRisZ2MDQcEGaK93QESEgWK2iOpIDZ7k9zPVkG5AS3ksvD5ZWxmItw==}
+    cpu: [arm]
+    os: [android]
+
   '@rollup/rollup-android-arm64@4.18.1':
     resolution: {integrity: sha512-F/tkdw0WSs4ojqz5Ovrw5r9odqzFjb5LIgHdHZG65dFI1lWTWRVy32KDJLKRISHgJvqUeUhdIvy43fX41znyDg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.29.1':
+    resolution: {integrity: sha512-CaRfrV0cd+NIIcVVN/jx+hVLN+VRqnuzLRmfmlzpOzB87ajixsN/+9L5xNmkaUUvEbI5BmIKS+XTwXsHEb65Ew==}
     cpu: [arm64]
     os: [android]
 
@@ -1804,13 +1827,38 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rollup/rollup-darwin-arm64@4.29.1':
+    resolution: {integrity: sha512-2ORr7T31Y0Mnk6qNuwtyNmy14MunTAMx06VAPI6/Ju52W10zk1i7i5U3vlDRWjhOI5quBcrvhkCHyF76bI7kEw==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rollup/rollup-darwin-x64@4.18.1':
     resolution: {integrity: sha512-IgpzXKauRe1Tafcej9STjSSuG0Ghu/xGYH+qG6JwsAUxXrnkvNHcq/NL6nz1+jzvWAnQkuAJ4uIwGB48K9OCGA==}
     cpu: [x64]
     os: [darwin]
 
+  '@rollup/rollup-darwin-x64@4.29.1':
+    resolution: {integrity: sha512-j/Ej1oanzPjmN0tirRd5K2/nncAhS9W6ICzgxV+9Y5ZsP0hiGhHJXZ2JQ53iSSjj8m6cRY6oB1GMzNn2EUt6Ng==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.29.1':
+    resolution: {integrity: sha512-91C//G6Dm/cv724tpt7nTyP+JdN12iqeXGFM1SqnljCmi5yTXriH7B1r8AD9dAZByHpKAumqP1Qy2vVNIdLZqw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.29.1':
+    resolution: {integrity: sha512-hEioiEQ9Dec2nIRoeHUP6hr1PSkXzQaCUyqBDQ9I9ik4gCXQZjJMIVzoNLBRGet+hIUb3CISMh9KXuCcWVW/8w==}
+    cpu: [x64]
+    os: [freebsd]
+
   '@rollup/rollup-linux-arm-gnueabihf@4.18.1':
     resolution: {integrity: sha512-P9bSiAUnSSM7EmyRK+e5wgpqai86QOSv8BwvkGjLwYuOpaeomiZWifEos517CwbG+aZl1T4clSE1YqqH2JRs+g==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.29.1':
+    resolution: {integrity: sha512-Py5vFd5HWYN9zxBv3WMrLAXY3yYJ6Q/aVERoeUFwiDGiMOWsMs7FokXihSOaT/PMWUty/Pj60XDQndK3eAfE6A==}
     cpu: [arm]
     os: [linux]
 
@@ -1819,8 +1867,18 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@rollup/rollup-linux-arm-musleabihf@4.29.1':
+    resolution: {integrity: sha512-RiWpGgbayf7LUcuSNIbahr0ys2YnEERD4gYdISA06wa0i8RALrnzflh9Wxii7zQJEB2/Eh74dX4y/sHKLWp5uQ==}
+    cpu: [arm]
+    os: [linux]
+
   '@rollup/rollup-linux-arm64-gnu@4.18.1':
     resolution: {integrity: sha512-8mwmGD668m8WaGbthrEYZ9CBmPug2QPGWxhJxh/vCgBjro5o96gL04WLlg5BA233OCWLqERy4YUzX3bJGXaJgQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.29.1':
+    resolution: {integrity: sha512-Z80O+taYxTQITWMjm/YqNoe9d10OX6kDh8X5/rFCMuPqsKsSyDilvfg+vd3iXIqtfmp+cnfL1UrYirkaF8SBZA==}
     cpu: [arm64]
     os: [linux]
 
@@ -1829,8 +1887,23 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@rollup/rollup-linux-arm64-musl@4.29.1':
+    resolution: {integrity: sha512-fOHRtF9gahwJk3QVp01a/GqS4hBEZCV1oKglVVq13kcK3NeVlS4BwIFzOHDbmKzt3i0OuHG4zfRP0YoG5OF/rA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loongarch64-gnu@4.29.1':
+    resolution: {integrity: sha512-5a7q3tnlbcg0OodyxcAdrrCxFi0DgXJSoOuidFUzHZ2GixZXQs6Tc3CHmlvqKAmOs5eRde+JJxeIf9DonkmYkw==}
+    cpu: [loong64]
+    os: [linux]
+
   '@rollup/rollup-linux-powerpc64le-gnu@4.18.1':
     resolution: {integrity: sha512-V72cXdTl4EI0x6FNmho4D502sy7ed+LuVW6Ym8aI6DRQ9hQZdp5sj0a2usYOlqvFBNKQnLQGwmYnujo2HvjCxQ==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-powerpc64le-gnu@4.29.1':
+    resolution: {integrity: sha512-9b4Mg5Yfz6mRnlSPIdROcfw1BU22FQxmfjlp/CShWwO3LilKQuMISMTtAu/bxmmrE6A902W2cZJuzx8+gJ8e9w==}
     cpu: [ppc64]
     os: [linux]
 
@@ -1839,8 +1912,18 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@rollup/rollup-linux-riscv64-gnu@4.29.1':
+    resolution: {integrity: sha512-G5pn0NChlbRM8OJWpJFMX4/i8OEU538uiSv0P6roZcbpe/WfhEO+AT8SHVKfp8qhDQzaz7Q+1/ixMy7hBRidnQ==}
+    cpu: [riscv64]
+    os: [linux]
+
   '@rollup/rollup-linux-s390x-gnu@4.18.1':
     resolution: {integrity: sha512-qb1hMMT3Fr/Qz1OKovCuUM11MUNLUuHeBC2DPPAWUYYUAOFWaxInaTwTQmc7Fl5La7DShTEpmYwgdt2hG+4TEg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.29.1':
+    resolution: {integrity: sha512-WM9lIkNdkhVwiArmLxFXpWndFGuOka4oJOZh8EP3Vb8q5lzdSCBuhjavJsw68Q9AKDGeOOIHYzYm4ZFvmWez5g==}
     cpu: [s390x]
     os: [linux]
 
@@ -1849,8 +1932,18 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@rollup/rollup-linux-x64-gnu@4.29.1':
+    resolution: {integrity: sha512-87xYCwb0cPGZFoGiErT1eDcssByaLX4fc0z2nRM6eMtV9njAfEE6OW3UniAoDhX4Iq5xQVpE6qO9aJbCFumKYQ==}
+    cpu: [x64]
+    os: [linux]
+
   '@rollup/rollup-linux-x64-musl@4.18.1':
     resolution: {integrity: sha512-pDLkYITdYrH/9Cv/Vlj8HppDuLMDUBmgsM0+N+xLtFd18aXgM9Nyqupb/Uw+HeidhfYg2lD6CXvz6CjoVOaKjQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.29.1':
+    resolution: {integrity: sha512-xufkSNppNOdVRCEC4WKvlR1FBDyqCSCpQeMMgv9ZyXqqtKBfkw1yfGMTUTs9Qsl6WQbJnsGboWCp7pJGkeMhKA==}
     cpu: [x64]
     os: [linux]
 
@@ -1859,13 +1952,28 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@rollup/rollup-win32-arm64-msvc@4.29.1':
+    resolution: {integrity: sha512-F2OiJ42m77lSkizZQLuC+jiZ2cgueWQL5YC9tjo3AgaEw+KJmVxHGSyQfDUoYR9cci0lAywv2Clmckzulcq6ig==}
+    cpu: [arm64]
+    os: [win32]
+
   '@rollup/rollup-win32-ia32-msvc@4.18.1':
     resolution: {integrity: sha512-ELfEX1/+eGZYMaCIbK4jqLxO1gyTSOIlZr6pbC4SRYFaSIDVKOnZNMdoZ+ON0mrFDp4+H5MhwNC1H/AhE3zQLg==}
     cpu: [ia32]
     os: [win32]
 
+  '@rollup/rollup-win32-ia32-msvc@4.29.1':
+    resolution: {integrity: sha512-rYRe5S0FcjlOBZQHgbTKNrqxCBUmgDJem/VQTCcTnA2KCabYSWQDrytOzX7avb79cAAweNmMUb/Zw18RNd4mng==}
+    cpu: [ia32]
+    os: [win32]
+
   '@rollup/rollup-win32-x64-msvc@4.18.1':
     resolution: {integrity: sha512-yjk2MAkQmoaPYCSu35RLJ62+dz358nE83VfTePJRp8CG7aMg25mEJYpXFiD+NcevhX8LxD5OP5tktPXnXN7GDw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.29.1':
+    resolution: {integrity: sha512-+10CMg9vt1MoHj6x1pxyjPSMjHTIlqs8/tBztXvPAx24SKs9jwVnKqHJumlH/IzhaPUaj3T6T6wfZr8okdXaIg==}
     cpu: [x64]
     os: [win32]
 
@@ -2052,11 +2160,11 @@ packages:
   '@types/estree-jsx@1.0.0':
     resolution: {integrity: sha512-3qvGd0z8F2ENTGr/GG1yViqfiKmRfrXVx5sJyHGFu3z7m5g5utCQtGp/g29JnjflhtQJBv1WDQukHiT58xPcYQ==}
 
-  '@types/estree@1.0.0':
-    resolution: {integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==}
-
   '@types/estree@1.0.5':
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
+
+  '@types/estree@1.0.6':
+    resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
 
   '@types/har-format@1.2.15':
     resolution: {integrity: sha512-RpQH4rXLuvTXKR0zqHq3go0RVXYv/YVqv4TnPH95VbwUxZdQlK1EtcMvQvMpDngHbt13Csh9Z4qT9AbkiQH5BA==}
@@ -4054,9 +4162,6 @@ packages:
   mdast-util-mdx-jsx@3.1.2:
     resolution: {integrity: sha512-eKMQDeywY2wlHc97k5eD8VC+9ASMjN8ItEZQNGwJ6E0XWKiW/Z0V5/H8pvoXUf+y+Mj0VIgeRRbujBmFn4FTyA==}
 
-  mdast-util-mdx-jsx@3.1.3:
-    resolution: {integrity: sha512-bfOjvNt+1AcbPLTFMFWY149nJz0OjmewJs3LQQ5pIyVGxP4CdOqNVJL6kTaM5c68p8q82Xv3nCyFfUnuEcH3UQ==}
-
   mdast-util-mdx@3.0.0:
     resolution: {integrity: sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==}
 
@@ -4880,6 +4985,11 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rollup@4.29.1:
+    resolution: {integrity: sha512-RaJ45M/kmJUzSWDs1Nnd5DdV4eerC98idtUOVr6FfKcgxqvjwHmxc5upLF9qZU9EpsVzzhleFahrT3shLuJzIw==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -5427,6 +5537,9 @@ packages:
 
   unimport@3.7.2:
     resolution: {integrity: sha512-91mxcZTadgXyj3lFWmrGT8GyoRHWuE5fqPOjg5RVtF6vj+OfM5G6WCzXjuYtSgELE5ggB34RY4oiCSEP8I3AHw==}
+
+  unist-builder@4.0.0:
+    resolution: {integrity: sha512-wmRFnH+BLpZnTKpc5L7O67Kac89s9HMrtELpnNaE6TAobq5DTZZs5YaTQfAZBA9bFPECx2uVAPO31c+GVug8mg==}
 
   unist-util-generated@2.0.1:
     resolution: {integrity: sha512-qF72kLmPxAw0oN2fwpWIqbXAVyEqUzDHMsbtPvOudIlUzXYFIeQIuxXQCRCFh22B7cixvU0MG7m3MW8FTq/S+A==}
@@ -6797,6 +6910,15 @@ snapshots:
     optionalDependencies:
       rollup: 4.18.1
 
+  '@rollup/plugin-typescript@12.1.2(rollup@4.29.1)(tslib@2.6.2)(typescript@5.6.3)':
+    dependencies:
+      '@rollup/pluginutils': 5.1.2(rollup@4.29.1)
+      resolve: 1.22.8
+      typescript: 5.6.3
+    optionalDependencies:
+      rollup: 4.29.1
+      tslib: 2.6.2
+
   '@rollup/plugin-yaml@4.1.2(rollup@4.18.1)':
     dependencies:
       '@rollup/pluginutils': 5.0.2(rollup@4.18.1)
@@ -6812,7 +6934,7 @@ snapshots:
 
   '@rollup/pluginutils@5.0.2(rollup@4.18.1)':
     dependencies:
-      '@types/estree': 1.0.0
+      '@types/estree': 1.0.5
       estree-walker: 2.0.2
       picomatch: 2.3.1
     optionalDependencies:
@@ -6834,52 +6956,117 @@ snapshots:
     optionalDependencies:
       rollup: 4.18.1
 
+  '@rollup/pluginutils@5.1.2(rollup@4.29.1)':
+    dependencies:
+      '@types/estree': 1.0.5
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+    optionalDependencies:
+      rollup: 4.29.1
+
   '@rollup/rollup-android-arm-eabi@4.18.1':
+    optional: true
+
+  '@rollup/rollup-android-arm-eabi@4.29.1':
     optional: true
 
   '@rollup/rollup-android-arm64@4.18.1':
     optional: true
 
+  '@rollup/rollup-android-arm64@4.29.1':
+    optional: true
+
   '@rollup/rollup-darwin-arm64@4.18.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.29.1':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.18.1':
     optional: true
 
+  '@rollup/rollup-darwin-x64@4.29.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.29.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.29.1':
+    optional: true
+
   '@rollup/rollup-linux-arm-gnueabihf@4.18.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.29.1':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.18.1':
     optional: true
 
+  '@rollup/rollup-linux-arm-musleabihf@4.29.1':
+    optional: true
+
   '@rollup/rollup-linux-arm64-gnu@4.18.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.29.1':
     optional: true
 
   '@rollup/rollup-linux-arm64-musl@4.18.1':
     optional: true
 
+  '@rollup/rollup-linux-arm64-musl@4.29.1':
+    optional: true
+
+  '@rollup/rollup-linux-loongarch64-gnu@4.29.1':
+    optional: true
+
   '@rollup/rollup-linux-powerpc64le-gnu@4.18.1':
+    optional: true
+
+  '@rollup/rollup-linux-powerpc64le-gnu@4.29.1':
     optional: true
 
   '@rollup/rollup-linux-riscv64-gnu@4.18.1':
     optional: true
 
+  '@rollup/rollup-linux-riscv64-gnu@4.29.1':
+    optional: true
+
   '@rollup/rollup-linux-s390x-gnu@4.18.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.29.1':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.18.1':
     optional: true
 
+  '@rollup/rollup-linux-x64-gnu@4.29.1':
+    optional: true
+
   '@rollup/rollup-linux-x64-musl@4.18.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.29.1':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.18.1':
     optional: true
 
+  '@rollup/rollup-win32-arm64-msvc@4.29.1':
+    optional: true
+
   '@rollup/rollup-win32-ia32-msvc@4.18.1':
     optional: true
 
+  '@rollup/rollup-win32-ia32-msvc@4.29.1':
+    optional: true
+
   '@rollup/rollup-win32-x64-msvc@4.18.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.29.1':
     optional: true
 
   '@shikijs/core@1.11.0':
@@ -7110,9 +7297,9 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.5
 
-  '@types/estree@1.0.0': {}
-
   '@types/estree@1.0.5': {}
+
+  '@types/estree@1.0.6': {}
 
   '@types/har-format@1.2.15': {}
 
@@ -9043,7 +9230,7 @@ snapshots:
   hast-util-to-html@9.0.0:
     dependencies:
       '@types/hast': 3.0.4
-      '@types/unist': 3.0.2
+      '@types/unist': 3.0.3
       ccount: 2.0.1
       comma-separated-tokens: 2.0.3
       hast-util-raw: 9.0.1
@@ -9073,7 +9260,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.5
       '@types/hast': 3.0.4
-      '@types/unist': 3.0.2
+      '@types/unist': 3.0.3
       comma-separated-tokens: 2.0.3
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
@@ -9700,24 +9887,6 @@ snapshots:
       '@types/estree-jsx': 1.0.0
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
-      '@types/unist': 3.0.2
-      ccount: 2.0.1
-      devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.1
-      mdast-util-to-markdown: 2.1.0
-      parse-entities: 4.0.1
-      stringify-entities: 4.0.3
-      unist-util-remove-position: 5.0.0
-      unist-util-stringify-position: 4.0.0
-      vfile-message: 4.0.2
-    transitivePeerDependencies:
-      - supports-color
-
-  mdast-util-mdx-jsx@3.1.3:
-    dependencies:
-      '@types/estree-jsx': 1.0.0
-      '@types/hast': 3.0.4
-      '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
       ccount: 2.0.1
       devlop: 1.1.0
@@ -9725,6 +9894,7 @@ snapshots:
       mdast-util-to-markdown: 2.1.0
       parse-entities: 4.0.1
       stringify-entities: 4.0.3
+      unist-util-remove-position: 5.0.0
       unist-util-stringify-position: 4.0.0
       vfile-message: 4.0.2
     transitivePeerDependencies:
@@ -11166,6 +11336,31 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.18.1
       fsevents: 2.3.3
 
+  rollup@4.29.1:
+    dependencies:
+      '@types/estree': 1.0.6
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.29.1
+      '@rollup/rollup-android-arm64': 4.29.1
+      '@rollup/rollup-darwin-arm64': 4.29.1
+      '@rollup/rollup-darwin-x64': 4.29.1
+      '@rollup/rollup-freebsd-arm64': 4.29.1
+      '@rollup/rollup-freebsd-x64': 4.29.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.29.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.29.1
+      '@rollup/rollup-linux-arm64-gnu': 4.29.1
+      '@rollup/rollup-linux-arm64-musl': 4.29.1
+      '@rollup/rollup-linux-loongarch64-gnu': 4.29.1
+      '@rollup/rollup-linux-powerpc64le-gnu': 4.29.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.29.1
+      '@rollup/rollup-linux-s390x-gnu': 4.29.1
+      '@rollup/rollup-linux-x64-gnu': 4.29.1
+      '@rollup/rollup-linux-x64-musl': 4.29.1
+      '@rollup/rollup-win32-arm64-msvc': 4.29.1
+      '@rollup/rollup-win32-ia32-msvc': 4.29.1
+      '@rollup/rollup-win32-x64-msvc': 4.29.1
+      fsevents: 2.3.3
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -11858,6 +12053,10 @@ snapshots:
     transitivePeerDependencies:
       - rollup
 
+  unist-builder@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
   unist-util-generated@2.0.1: {}
 
   unist-util-inspect@8.0.0:
@@ -11874,7 +12073,7 @@ snapshots:
 
   unist-util-position-from-estree@2.0.0:
     dependencies:
-      '@types/unist': 3.0.2
+      '@types/unist': 3.0.3
 
   unist-util-position@5.0.0:
     dependencies:
@@ -12204,7 +12403,7 @@ snapshots:
     dependencies:
       esbuild: 0.20.2
       postcss: 8.4.38
-      rollup: 4.18.1
+      rollup: 4.29.1
     optionalDependencies:
       '@types/node': 20.12.7
       fsevents: 2.3.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -565,6 +565,9 @@ importers:
       remark-gfm:
         specifier: ^4.0.0
         version: 4.0.0
+      remark-mdx:
+        specifier: ^3.0.1
+        version: 3.0.1
       remark-parse:
         specifier: ^11.0.0
         version: 11.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,6 +70,9 @@ importers:
       '@portone-io/lint-no-jamo':
         specifier: workspace:^
         version: link:packages/lint-no-jamo
+      '@portone-io/remark-param-tree':
+        specifier: workspace:^
+        version: link:packages/remark-param-tree
       '@portone/browser-sdk':
         specifier: ^0.0.10
         version: 0.0.10
@@ -516,6 +519,70 @@ importers:
       '@types/node':
         specifier: ^20.12.7
         version: 20.12.7
+
+  packages/remark-param-tree:
+    dependencies:
+      mdast-util-from-markdown:
+        specifier: ^2.0.1
+        version: 2.0.1
+      mdast-util-to-string:
+        specifier: ^4.0.0
+        version: 4.0.0
+      ts-pattern:
+        specifier: ^5.1.1
+        version: 5.2.0
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
+      unist-util-visit:
+        specifier: ^5.0.0
+        version: 5.0.0
+      unist-util-visit-parents:
+        specifier: ^6.0.1
+        version: 6.0.1
+    devDependencies:
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
+      '@types/node':
+        specifier: ^20.12.7
+        version: 20.12.7
+      '@types/unist':
+        specifier: ^3.0.3
+        version: 3.0.3
+      '@vitest/ui':
+        specifier: ^1.5.3
+        version: 1.5.3(vitest@1.5.3)
+      fast-glob:
+        specifier: ^3.3.2
+        version: 3.3.2
+      mdast-util-mdx-jsx:
+        specifier: ^3.1.3
+        version: 3.1.3
+      remark-frontmatter:
+        specifier: ^5.0.0
+        version: 5.0.0
+      remark-gfm:
+        specifier: ^4.0.0
+        version: 4.0.0
+      remark-parse:
+        specifier: ^11.0.0
+        version: 11.0.0
+      remark-stringify:
+        specifier: ^11.0.0
+        version: 11.0.0
+      string-width:
+        specifier: ^5.1.2
+        version: 5.1.2
+      vfile:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite-tsconfig-paths:
+        specifier: ^4.3.2
+        version: 4.3.2(typescript@5.6.3)(vite@5.3.3(@types/node@20.12.7)(terser@5.31.1))
+      vitest:
+        specifier: ^1.5.3
+        version: 1.5.3(@types/node@20.12.7)(@vitest/ui@1.5.3)(terser@5.31.1)
 
 packages:
 
@@ -2047,6 +2114,9 @@ packages:
 
   '@types/unist@3.0.2':
     resolution: {integrity: sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@typescript-eslint/eslint-plugin@8.13.0':
     resolution: {integrity: sha512-nQtBLiZYMUPkclSeC3id+x4uVd1SGtHuElTxL++SfP47jR0zfkZBJHc+gL4qPsgTuypz0k8Y2GheaDYn6Gy3rg==}
@@ -3981,6 +4051,9 @@ packages:
   mdast-util-mdx-jsx@3.1.2:
     resolution: {integrity: sha512-eKMQDeywY2wlHc97k5eD8VC+9ASMjN8ItEZQNGwJ6E0XWKiW/Z0V5/H8pvoXUf+y+Mj0VIgeRRbujBmFn4FTyA==}
 
+  mdast-util-mdx-jsx@3.1.3:
+    resolution: {integrity: sha512-bfOjvNt+1AcbPLTFMFWY149nJz0OjmewJs3LQQ5pIyVGxP4CdOqNVJL6kTaM5c68p8q82Xv3nCyFfUnuEcH3UQ==}
+
   mdast-util-mdx@3.0.0:
     resolution: {integrity: sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==}
 
@@ -5527,6 +5600,9 @@ packages:
   vfile@6.0.1:
     resolution: {integrity: sha512-1bYqc7pt6NIADBJ98UiG0Bn/CHIVOoZ/IyEkqIruLg0mE1BKzkOXY2D6CSqQIcKqgadppE5lrxgWXJmXd7zZJw==}
 
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
   vinxi@0.4.3:
     resolution: {integrity: sha512-RgJz7RWftML5h/qfPsp3QKVc2FSlvV4+HevpE0yEY2j+PS/I2ULjoSsZDXaR8Ks2WYuFFDzQr8yrox7v8aqkng==}
     hasBin: true
@@ -7039,7 +7115,7 @@ snapshots:
 
   '@types/hast@3.0.4':
     dependencies:
-      '@types/unist': 3.0.2
+      '@types/unist': 3.0.3
 
   '@types/http-proxy@1.17.14':
     dependencies:
@@ -7063,7 +7139,7 @@ snapshots:
 
   '@types/mdast@4.0.4':
     dependencies:
-      '@types/unist': 3.0.2
+      '@types/unist': 3.0.3
 
   '@types/mdx@2.0.13': {}
 
@@ -7091,6 +7167,8 @@ snapshots:
   '@types/unist@2.0.6': {}
 
   '@types/unist@3.0.2': {}
+
+  '@types/unist@3.0.3': {}
 
   '@typescript-eslint/eslint-plugin@8.13.0(@typescript-eslint/parser@8.13.0(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0)(typescript@5.6.3)':
     dependencies:
@@ -8565,7 +8643,7 @@ snapshots:
   estree-util-visit@2.0.0:
     dependencies:
       '@types/estree-jsx': 1.0.0
-      '@types/unist': 3.0.2
+      '@types/unist': 3.0.3
 
   estree-walker@2.0.2: {}
 
@@ -8900,7 +8978,7 @@ snapshots:
   hast-util-from-parse5@8.0.1:
     dependencies:
       '@types/hast': 3.0.4
-      '@types/unist': 3.0.2
+      '@types/unist': 3.0.3
       devlop: 1.1.0
       hastscript: 8.0.0
       property-information: 6.2.0
@@ -8919,7 +8997,7 @@ snapshots:
   hast-util-raw@9.0.1:
     dependencies:
       '@types/hast': 3.0.4
-      '@types/unist': 3.0.2
+      '@types/unist': 3.0.3
       '@ungap/structured-clone': 1.2.0
       hast-util-from-parse5: 8.0.1
       hast-util-to-parse5: 8.0.0
@@ -8977,7 +9055,7 @@ snapshots:
   hast-util-to-html@9.0.3:
     dependencies:
       '@types/hast': 3.0.4
-      '@types/unist': 3.0.2
+      '@types/unist': 3.0.3
       ccount: 2.0.1
       comma-separated-tokens: 2.0.3
       hast-util-whitespace: 3.0.0
@@ -9485,7 +9563,7 @@ snapshots:
   mdast-util-directive@3.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      '@types/unist': 3.0.2
+      '@types/unist': 3.0.3
       devlop: 1.1.0
       mdast-util-from-markdown: 2.0.1
       mdast-util-to-markdown: 2.1.0
@@ -9632,6 +9710,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mdast-util-mdx-jsx@3.1.3:
+    dependencies:
+      '@types/estree-jsx': 1.0.0
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.1
+      mdast-util-to-markdown: 2.1.0
+      parse-entities: 4.0.1
+      stringify-entities: 4.0.3
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   mdast-util-mdx@3.0.0:
     dependencies:
       mdast-util-from-markdown: 2.0.1
@@ -9672,7 +9767,7 @@ snapshots:
   mdast-util-to-markdown@2.1.0:
     dependencies:
       '@types/mdast': 4.0.4
-      '@types/unist': 3.0.2
+      '@types/unist': 3.0.3
       longest-streak: 3.1.0
       mdast-util-phrasing: 4.0.0
       mdast-util-to-string: 4.0.0
@@ -9913,7 +10008,7 @@ snapshots:
     dependencies:
       '@types/acorn': 4.0.6
       '@types/estree': 1.0.5
-      '@types/unist': 3.0.2
+      '@types/unist': 3.0.3
       devlop: 1.1.0
       estree-util-visit: 2.0.0
       micromark-util-symbol: 2.0.0
@@ -11678,7 +11773,7 @@ snapshots:
       '@types/debug': 4.1.7
       '@types/is-empty': 1.2.3
       '@types/node': 20.12.7
-      '@types/unist': 3.0.2
+      '@types/unist': 3.0.3
       '@ungap/structured-clone': 1.2.0
       concat-stream: 2.0.0
       debug: 4.3.4
@@ -11764,7 +11859,7 @@ snapshots:
 
   unist-util-inspect@8.0.0:
     dependencies:
-      '@types/unist': 3.0.2
+      '@types/unist': 3.0.3
 
   unist-util-is@5.2.1:
     dependencies:
@@ -11772,7 +11867,7 @@ snapshots:
 
   unist-util-is@6.0.0:
     dependencies:
-      '@types/unist': 3.0.2
+      '@types/unist': 3.0.3
 
   unist-util-position-from-estree@2.0.0:
     dependencies:
@@ -11780,11 +11875,11 @@ snapshots:
 
   unist-util-position@5.0.0:
     dependencies:
-      '@types/unist': 3.0.2
+      '@types/unist': 3.0.3
 
   unist-util-remove-position@5.0.0:
     dependencies:
-      '@types/unist': 3.0.2
+      '@types/unist': 3.0.3
       unist-util-visit: 5.0.0
 
   unist-util-stringify-position@2.0.3:
@@ -11797,7 +11892,7 @@ snapshots:
 
   unist-util-stringify-position@4.0.0:
     dependencies:
-      '@types/unist': 3.0.2
+      '@types/unist': 3.0.3
 
   unist-util-visit-parents@5.1.3:
     dependencies:
@@ -11806,7 +11901,7 @@ snapshots:
 
   unist-util-visit-parents@6.0.1:
     dependencies:
-      '@types/unist': 3.0.2
+      '@types/unist': 3.0.3
       unist-util-is: 6.0.0
 
   unist-util-visit@4.1.2:
@@ -11817,7 +11912,7 @@ snapshots:
 
   unist-util-visit@5.0.0:
     dependencies:
-      '@types/unist': 3.0.2
+      '@types/unist': 3.0.3
       unist-util-is: 6.0.0
       unist-util-visit-parents: 6.0.1
 
@@ -11922,7 +12017,7 @@ snapshots:
 
   vfile-location@5.0.2:
     dependencies:
-      '@types/unist': 3.0.2
+      '@types/unist': 3.0.3
       vfile: 6.0.1
 
   vfile-message@2.0.4:
@@ -11937,7 +12032,7 @@ snapshots:
 
   vfile-message@4.0.2:
     dependencies:
-      '@types/unist': 3.0.2
+      '@types/unist': 3.0.3
       unist-util-stringify-position: 4.0.0
 
   vfile-reporter@8.1.0:
@@ -11979,6 +12074,11 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.2
       unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.2
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
   vinxi@0.4.3(patch_hash=vk5tzlju2n6nvc3afytkyf7yzy)(@types/node@20.12.7)(ioredis@5.4.1)(terser@5.31.1):

--- a/src/genCollections.ts
+++ b/src/genCollections.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs/promises";
 import path from "node:path";
 
 import { subscribe } from "@parcel/watcher";
+import remarkParamTree from "@portone-io/remark-param-tree";
 import fastGlob from "fast-glob";
 import Slugger from "github-slugger";
 import jsYaml from "js-yaml";
@@ -97,6 +98,7 @@ async function parseMdx(
     .use(remarkMdx)
     .use(remarkGfm)
     .use(remarkFrontmatter)
+    .use(remarkParamTree)
     .use(remarkHeadings)
     .use(function () {
       return function (_, file) {

--- a/src/routes/(root)/opi/ko/extra/promotion/integration.mdx
+++ b/src/routes/(root)/opi/ko/extra/promotion/integration.mdx
@@ -199,58 +199,53 @@ const paymentAmount = getPaymentAmount(discountScheme, orderAmount);
 
 ### 주요 파라미터
 
-<VersionGate v="v1">
-  **`promotion_id`** <mark style="color:green;">**string**</mark>
-</VersionGate>
+<ParamTree>
+  <VersionGate v="v1">
+    - **`promotion_id`** <mark style="color:green;">**string**</mark>
 
-<VersionGate v="v2">
-  **`promotionId`** <mark style="color:green;">**string**</mark>
-</VersionGate>
+      **프로모션 ID**
 
-**프로모션 ID**
+      관리자 콘솔의 \[프모로션] 메뉴에서 확인할 수 있습니다.
 
-- 관리자 콘솔의 \[프모로션] 메뉴에서 확인할 수 있습니다.
+      프로모션 ID 지정 및 카드 다이렉트 방식으로 결제창을 호출하면, 프로모션 내 설정된 할인 조건 및 금액에 따라
+      할인 금액이 적용되어 결제가 진행됩니다.
 
-- 프로모션 ID 지정 및 카드 다이렉트 방식으로 결제창을 호출하면, 프로모션 내 설정된 할인 조건 및 금액에 따라
-  할인 금액이 적용되어 결제가 진행됩니다.
+      - **`card`** <mark style="color:blue;">**object**</mark>
 
-<VersionGate v="v1">
-  <ParamTree>
-    - **`card`** <mark style="color:blue;">**object**</mark>
+        **카드 결제 옵션 설정**
 
-    **카드 결제 옵션 설정**
+        - **`direct`** <mark style="color:blue;">**object**</mark>
 
-    <ParamTree>
-      - **`direct`** <mark style="color:blue;">**object**</mark>
+          **카드 다이렉트 호출**
 
-      **카드 다이렉트 호출**
-
-      <ParamTree>
         - **`code`** <mark style="color:green;">**string**</mark>
 
-        **카드사 코드**
+          **카드사 코드**
 
-        카드 다이렉트 호출 시 [카드사 코드](/opi/ko/support/code-info/card-code) 문서를 참조하여 프로모션과 동일한 카드사로 지정해야 합니다.
-      </ParamTree>
-    </ParamTree>
-  </ParamTree>
-</VersionGate>
+          카드 다이렉트 호출 시 [카드사 코드](/opi/ko/support/code-info/card-code) 문서를 참조하여 프로모션과 동일한 카드사로 지정해야 합니다.
+  </VersionGate>
 
-<VersionGate v="v2">
-  <ParamTree>
-    - **`card`** <mark style="color:blue;">**object**</mark>
+  <VersionGate v="v2">
+    - **`promotionId`** <mark style="color:green;">**string**</mark>
 
-    **카드 정보**
+      **프로모션 ID**
 
-    <ParamTree>
-      - **`cardCompany`** <mark style="color:green;">**string**</mark>
+      관리자 콘솔의 \[프모로션] 메뉴에서 확인할 수 있습니다.
 
-      **카드사 다이렉트 호출 시 필요한 카드사 식별 값**
+      프로모션 ID 지정 및 카드 다이렉트 방식으로 결제창을 호출하면, 프로모션 내 설정된 할인 조건 및 금액에 따라
+      할인 금액이 적용되어 결제가 진행됩니다.
 
-      카드 다이렉트 호출 시 [카드사 식별 값](/sdk/ko/v2-sdk/payment-request?v=v2#card-object) 문서를 참조하여 프로모션과 동일한 카드사로 지정해야 합니다.
-    </ParamTree>
-  </ParamTree>
-</VersionGate>
+      - **`card`** <mark style="color:blue;">**object**</mark>
+
+        **카드 정보**
+
+        - **`cardCompany`** <mark style="color:green;">**string**</mark>
+
+          **카드사 다이렉트 호출 시 필요한 카드사 식별 값**
+
+          카드 다이렉트 호출 시 [카드사 식별 값](/sdk/ko/v2-sdk/payment-request?v=v2#card-object) 문서를 참조하여 프로모션과 동일한 카드사로 지정해야 합니다.
+  </VersionGate>
+</ParamTree>
 
 ### 유의사항
 
@@ -383,20 +378,29 @@ const paymentAmount = getPaymentAmount(discountScheme, orderAmount);
 
 ### 주요 파라미터
 
-<VersionGate v="v1">
-  **`promotion_id`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-</VersionGate>
+<ParamTree>
+  <VersionGate v="v1">
+    - **`promotion_id`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
-<VersionGate v="v2">
-  **`promotionId`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-</VersionGate>
+      **프로모션 ID**
 
-**프로모션 ID**
+      관리자 콘솔의 \[프모로션] 메뉴에서 확인할 수 있습니다.
 
-- 관리자 콘솔의 \[프모로션] 메뉴에서 확인할 수 있습니다.
+      프로모션 ID 지정 및 카드 다이렉트 방식으로 결제창을 호출하면, 프로모션 내 설정된 할인 조건 및 금액에 따라
+      할인 금액이 적용되어 결제가 진행됩니다.
+  </VersionGate>
 
-- 프로모션 ID 지정 및 카드 다이렉트 방식으로 결제창을 호출하면, 프로모션 내 설정된 할인 조건 및 금액에 따라
-  할인 금액이 적용되어 결제가 진행됩니다.
+  <VersionGate v="v2">
+    - **`promotionId`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+
+      **프로모션 ID**
+
+      관리자 콘솔의 \[프모로션] 메뉴에서 확인할 수 있습니다.
+
+      프로모션 ID 지정 및 카드 다이렉트 방식으로 결제창을 호출하면, 프로모션 내 설정된 할인 조건 및 금액에 따라
+      할인 금액이 적용되어 결제가 진행됩니다.
+  </VersionGate>
+</ParamTree>
 
 ### 유의사항
 
@@ -573,20 +577,29 @@ const paymentAmount = getPaymentAmount(discountScheme, orderAmount);
 
 ### 주요 파라미터
 
-<VersionGate v="v1">
-  **`promotion_id`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-</VersionGate>
+<ParamTree>
+  <VersionGate v="v1">
+    - **`promotion_id`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
-<VersionGate v="v2">
-  **`promotionId`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-</VersionGate>
+      **프로모션 ID**
 
-**프로모션 ID**
+      관리자 콘솔의 \[프모로션] 메뉴에서 확인할 수 있습니다.
 
-- 관리자 콘솔의 \[프모로션] 메뉴에서 확인할 수 있습니다.
+      프로모션 ID 지정 및 카드 다이렉트 방식으로 결제창을 호출하면, 프로모션 내 설정된 할인 조건 및 금액에 따라
+      할인 금액이 적용되어 결제가 진행됩니다.
+  </VersionGate>
 
-- 프로모션 ID 지정 및 카드 다이렉트 방식으로 결제창을 호출하면, 프로모션 내 설정된 할인 조건 및 금액에 따라
-  할인 금액이 적용되어 결제가 진행됩니다.
+  <VersionGate v="v2">
+    - **`promotionId`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+
+      **프로모션 ID**
+
+      관리자 콘솔의 \[프모로션] 메뉴에서 확인할 수 있습니다.
+
+      프로모션 ID 지정 및 카드 다이렉트 방식으로 결제창을 호출하면, 프로모션 내 설정된 할인 조건 및 금액에 따라
+      할인 금액이 적용되어 결제가 진행됩니다.
+  </VersionGate>
+</ParamTree>
 
 ### 유의사항
 

--- a/src/routes/(root)/opi/ko/extra/promotion/integration.mdx
+++ b/src/routes/(root)/opi/ko/extra/promotion/integration.mdx
@@ -201,7 +201,7 @@ const paymentAmount = getPaymentAmount(discountScheme, orderAmount);
 
 <ParamTree>
   <VersionGate v="v1">
-    - **`promotion_id`** <mark style="color:green;">**string**</mark>
+    - promotion\_id?: string
 
       **프로모션 ID**
 
@@ -210,15 +210,15 @@ const paymentAmount = getPaymentAmount(discountScheme, orderAmount);
       프로모션 ID 지정 및 카드 다이렉트 방식으로 결제창을 호출하면, 프로모션 내 설정된 할인 조건 및 금액에 따라
       할인 금액이 적용되어 결제가 진행됩니다.
 
-      - **`card`** <mark style="color:blue;">**object**</mark>
+      - card?: object
 
         **카드 결제 옵션 설정**
 
-        - **`direct`** <mark style="color:blue;">**object**</mark>
+        - direct?: object
 
           **카드 다이렉트 호출**
 
-        - **`code`** <mark style="color:green;">**string**</mark>
+        - code?: string
 
           **카드사 코드**
 
@@ -226,7 +226,7 @@ const paymentAmount = getPaymentAmount(discountScheme, orderAmount);
   </VersionGate>
 
   <VersionGate v="v2">
-    - **`promotionId`** <mark style="color:green;">**string**</mark>
+    - promotionId?: string
 
       **프로모션 ID**
 
@@ -235,11 +235,11 @@ const paymentAmount = getPaymentAmount(discountScheme, orderAmount);
       프로모션 ID 지정 및 카드 다이렉트 방식으로 결제창을 호출하면, 프로모션 내 설정된 할인 조건 및 금액에 따라
       할인 금액이 적용되어 결제가 진행됩니다.
 
-      - **`card`** <mark style="color:blue;">**object**</mark>
+      - card?: object
 
         **카드 정보**
 
-        - **`cardCompany`** <mark style="color:green;">**string**</mark>
+        - cardCompany?: string
 
           **카드사 다이렉트 호출 시 필요한 카드사 식별 값**
 
@@ -380,7 +380,7 @@ const paymentAmount = getPaymentAmount(discountScheme, orderAmount);
 
 <ParamTree>
   <VersionGate v="v1">
-    - **`promotion_id`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+    - promotion\_id: string
 
       **프로모션 ID**
 
@@ -391,7 +391,7 @@ const paymentAmount = getPaymentAmount(discountScheme, orderAmount);
   </VersionGate>
 
   <VersionGate v="v2">
-    - **`promotionId`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+    - promotionId: string
 
       **프로모션 ID**
 
@@ -579,7 +579,7 @@ const paymentAmount = getPaymentAmount(discountScheme, orderAmount);
 
 <ParamTree>
   <VersionGate v="v1">
-    - **`promotion_id`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+    - promotion\_id: string
 
       **프로모션 ID**
 
@@ -590,7 +590,7 @@ const paymentAmount = getPaymentAmount(discountScheme, orderAmount);
   </VersionGate>
 
   <VersionGate v="v2">
-    - **`promotionId`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+    - promotionId: string
 
       **프로모션 ID**
 

--- a/src/routes/(root)/opi/ko/extra/promotion/integration.mdx
+++ b/src/routes/(root)/opi/ko/extra/promotion/integration.mdx
@@ -216,7 +216,7 @@ const paymentAmount = getPaymentAmount(discountScheme, orderAmount);
 
 <VersionGate v="v1">
   <ParamTree>
-    **`card`** <mark style="color:blue;">**object**</mark>
+    - **`card`** <mark style="color:blue;">**object**</mark>
 
     **카드 결제 옵션 설정**
 
@@ -238,7 +238,7 @@ const paymentAmount = getPaymentAmount(discountScheme, orderAmount);
 
 <VersionGate v="v2">
   <ParamTree>
-    **`card`** <mark style="color:blue;">**object**</mark>
+    - **`card`** <mark style="color:blue;">**object**</mark>
 
     **카드 정보**
 

--- a/src/routes/(root)/opi/ko/extra/smart-routing/integration.mdx
+++ b/src/routes/(root)/opi/ko/extra/smart-routing/integration.mdx
@@ -75,86 +75,86 @@ PortOne.requestPayment({
 각 파라미터에 대한 상세한 설명은 [결제요청 파라미터](/sdk/ko/v2-sdk/payment-request) 문서를 참고하시기 바랍니다.
 
 <ParamTree>
-  - **`storeId`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - storeId: string
 
     **고객사 ID**
 
-  - **`paymentId`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - paymentId: string
 
     **고객사 주문 고유 번호**
 
-  - **`orderName`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - orderName: string
 
     **주문명**
 
-  - **`totalAmount`** <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
+  - totalAmount: number
 
     **결제 금액**
 
-  - **`currency`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - currency: string
 
     **결제 통화**
 
-  - **`payMethod`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - payMethod: string
 
     **결제수단 구분코드**
 
-  - **`virtualAccount`** <mark style="color:blue;">**object**</mark>
+  - virtualAccount?: object
 
     가상계좌 결제 사용 시 필요한 파라미터입니다.
 
     <ParamTree>
-      - **`accountExpiry`** <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+      - accountExpiry: object
 
         **가상계좌 입금 만료기한**
 
         스마트 라우팅을 이용한 가상계좌 결제 사용 시 필수 입력해야 합니다.
 
         <ParamTree>
-          - **`validHours`** <mark style="color:blue;">**number**</mark>
+          - validHours?: number
 
             **가상계좌 입금 유효 시간**
 
-          - **`dueDate`** <mark style="color:blue;">**string**</mark>
+          - dueDate?: string
 
             **가상계좌 입금 유효 시각**
         </ParamTree>
     </ParamTree>
 
-  - **`easyPay`** <mark style="color:blue;">**object**</mark>
+  - easyPay?: object
 
     **간편결제 정보**
 
     스마트 라우팅을 이용한 간편결제 다이렉트 호출 시 필수 입력해야 합니다.
 
     <ParamTree>
-      - **`easyPayProvider`** <mark style="color:green;">**string**</mark>
+      - easyPayProvider?: string
 
         **간편결제 수단**
     </ParamTree>
 
-  - **`productType`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - productType: string
 
     **상품 유형**
 
     스마트 라우팅을 이용한 휴대폰 소액결제 사용 시 필수 입력해야 합니다.
 
-  - **`customer`** <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+  - customer: object
 
     **구매자 정보**
 
     <ParamTree>
-      - **`fullName`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - fullName: string
 
         **구매자 전체 이름**
 
         `fullName` 파라미터 대신 `firstName`과 `lastName` 파라미터를 사용해도 됩니다.
 
-      - **`phoneNumber`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - phoneNumber: string
 
         **구매자 연락처**
 
-      - **`email`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - email: string
 
         **구매자 이메일 주소**
     </ParamTree>
@@ -320,153 +320,153 @@ API를 이용하는 경우 결제 호출 시 생성한 스마트 라우팅 그�
 ### 필수 파라미터
 
 <ParamTree>
-  - **`paymentId`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - paymentId: string
 
     **고객사 주문 고유 번호**
 
-  - **`orderName`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - orderName: string
 
     **주문명**
 
-  - **`amount`** <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+  - amount: object
 
     **주문 금액**
 
     <ParamTree>
-      - **`total`** <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
+      - total: number
 
         **결제 금액**
     </ParamTree>
 
-  - **`currency`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - currency: string
 
     **결제 통화**
 
-  - **`customer`** <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+  - customer: object
 
     **구매자 정보**
 
     <ParamTree>
-      - **`name`** <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+      - name: object
 
         **구매자 이름**
 
         <ParamTree>
-          - **`full`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+          - full: string
 
             **구매자 전체 이름**
 
             `full` 파라미터 대신 `separated.first` 와 `separated.last` 파라미터로 사용해도 됩니다.
         </ParamTree>
 
-      - **`phoneNumber`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - phoneNumber: string
 
         **구매자 연락처**
 
         가상계좌 발급 시 필수 입력해야 합니다.
 
-      - **`email`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - email: string
 
         **구매자 이메일 주소**
 
         가상계좌 발급 시 필수 입력해야 합니다.
     </ParamTree>
 
-  - **`method`** <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+  - method: object
 
     **결제 수단**
 
     <ParamTree>
-      - **`card`** <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+      - card: object
 
         **카드 결제**
 
         <ParamTree>
-          - **`credential`** <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+          - credential: object
 
             **카드 정보**
 
             <ParamTree>
-              - **`number`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+              - number: string
 
                 **카드 번호**
 
-              - **`expiryYear`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+              - expiryYear: string
 
                 **카드 유효기간 중 연도**
 
-              - **`expiryMonth`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+              - expiryMonth: string
 
                 **카드 유효기간 중 월**
 
-              - **`birthOrBusinessRegistrationNumber`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+              - birthOrBusinessRegistrationNumber: string
 
                 **생년월일 또는 사업자번호**
 
-              - **`passwordTwoDigits`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+              - passwordTwoDigits: string
 
                 **카드 비밀번호 앞 2자리**
             </ParamTree>
         </ParamTree>
 
-      - **`virtualAccount`** <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+      - virtualAccount: object
 
         **가상 계좌**
 
         <ParamTree>
-          - **`bank`** <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+          - bank: object
 
             **은행 정보**
 
-          - **`expiry`** <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+          - expiry: object
 
             **만료 기한**
 
             <ParamTree>
-              - **`dueDate`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+              - dueDate: string
 
                 **만료 시점**
             </ParamTree>
 
-          - **`option`** <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+          - option: object
 
             **가상계좌 발급 방식**
 
             <ParamTree>
-              - **`type`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+              - type: string
 
                 **가상계좌 발급 유형**
 
                 일반 가상계좌 (회전식)인 경우 `NOMAL`를 입력해야 합니다.
             </ParamTree>
 
-          - **`cashReceipt`** <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+          - cashReceipt: object
 
             **현금영수증 정보**
 
             <ParamTree>
-              - **`type`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+              - type: string
 
                 **현금영수증 발급 유형**
 
-              - **`customerIdentityNumber`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+              - customerIdentityNumber: string
 
                 **현금영수증 발급 식별 정보**
             </ParamTree>
 
-          - **`remitteeName`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+          - remitteeName: string
 
             **가상계좌 예금주명**
         </ParamTree>
     </ParamTree>
 
-  - **`productType`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - productType: string
 
     **상품 유형**
 
     KSNET로 카드 결제시에만 MID 설정 정보와 검증을 진행합니다. 다른 PG사 결제 요청시에는 별도로 검증하지 않습니다.
 
-  - **`productCount`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - productCount: string
 
     **상품 개수**
 
@@ -682,76 +682,76 @@ API를 이용하는 경우 결제 호출 시 생성한 스마트 라우팅 그�
 <Tabs>
   <Tabs.Tab title="빌링키 발급">
     <ParamTree>
-      - **`paymentId`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - paymentId: string
 
         **고객사 주문 고유 번호**
 
-      - **`customer`** <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+      - customer: object
 
         **구매자 정보**
 
         <ParamTree>
-          - **`id`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+          - id: string
 
             **구매자 식별정보**
 
-          - **`name`** <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+          - name: object
 
             **구매자 이름**
 
             <ParamTree>
-              - **`full`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+              - full: string
 
                 **구매자 전체 이름**
 
                 `full` 파라미터 대신 `separated.first` 와 `separated.last` 파라미터로 사용해도 됩니다.
             </ParamTree>
 
-          - **`phoneNumber`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+          - phoneNumber: string
 
             **구매자 연락처**
 
             가상계좌 발급 시 필수 입력해야 합니다.
 
-          - **`email`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+          - email: string
 
             **구매자 이메일 주소**
 
             가상계좌 발급 시 필수 입력해야 합니다.
         </ParamTree>
 
-      - **`method`** <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+      - method: object
 
         **결제 수단**
 
         <ParamTree>
-          - **`card`** <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+          - card: object
 
             **카드 결제**
 
             <ParamTree>
-              - **`credential`** <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+              - credential: object
 
                 **카드 정보**
 
                 <ParamTree>
-                  - **`number`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+                  - number: string
 
                     **카드 번호**
 
-                  - **`expiryYear`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+                  - expiryYear: string
 
                     **카드 유효기간 중 연도**
 
-                  - **`expiryMonth`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+                  - expiryMonth: string
 
                     **카드 유효기간 중 월**
 
-                  - **`birthOrBusinessRegistrationNumber`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+                  - birthOrBusinessRegistrationNumber: string
 
                     **생년월일 또는 사업자번호**
 
-                  - **`passwordTwoDigits`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+                  - passwordTwoDigits: string
 
                     **카드 비밀번호 앞 2자리**
                 </ParamTree>
@@ -762,69 +762,69 @@ API를 이용하는 경우 결제 호출 시 생성한 스마트 라우팅 그�
 
   <Tabs.Tab title="빌링키 결제">
     <ParamTree>
-      - **`paymentId`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - paymentId: string
 
         **고객사 주문 고유 번호**
 
-      - **`orderName`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - orderName: string
 
         **주문명**
 
-      - **`amount`** <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+      - amount: object
 
         **주문 금액**
 
         <ParamTree>
-          - **`total`** <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
+          - total: number
 
             **결제 금액**
         </ParamTree>
 
-      - **`currency`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - currency: string
 
         **결제 통화**
 
-      - **`customer`** <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+      - customer: object
 
         **구매자 정보**
 
         <ParamTree>
-          - **`id`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+          - id: string
 
             **구매자 식별정보**
 
-          - **`name`** <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+          - name: object
 
             **구매자 이름**
 
             <ParamTree>
-              - **`full`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+              - full: string
 
                 **구매자 전체 이름**
 
                 `full` 파라미터 대신 `separated.first` 와 `separated.last` 파라미터로 사용해도 됩니다.
             </ParamTree>
 
-          - **`phoneNumber`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+          - phoneNumber: string
 
             **구매자 연락처**
 
             가상계좌 발급 시 필수 입력해야 합니다.
 
-          - **`email`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+          - email: string
 
             **구매자 이메일 주소**
 
             가상계좌 발급 시 필수 입력해야 합니다.
         </ParamTree>
 
-      - **`productType`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - productType: string
 
         **상품 유형**
 
         KSNET로 카드 결제시에만 MID 설정 정보와 검증을 진행합니다. 다른 PG사 결제 요청시에는 별도로 검증하지 않습니다.
 
-      - **`productCount`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - productCount: string
 
         **상품 개수**
 
@@ -834,85 +834,85 @@ API를 이용하는 경우 결제 호출 시 생성한 스마트 라우팅 그�
 
   <Tabs.Tab title="빌링키 예약 결제">
     <ParamTree>
-      - **`paymentId`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - paymentId: string
 
         **고객사 주문 고유 번호**
 
-      - **`payment`** <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+      - payment: object
 
         **결제 정보**
 
         <ParamTree>
-          - **`billingKey`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+          - billingKey: string
 
             **빌링키**
 
-          - **`orderName`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+          - orderName: string
 
             **주문명**
 
-          - **`amount`** <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+          - amount: object
 
             **주문 금액**
 
             <ParamTree>
-              - **`total`** <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
+              - total: number
 
                 **결제 금액**
             </ParamTree>
 
-          - **`currency`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+          - currency: string
 
             **결제 통화**
 
-          - **`customer`** <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+          - customer: object
 
             **구매자 정보**
 
             <ParamTree>
-              - **`id`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+              - id: string
 
                 **구매자 식별정보**
 
-              - **`name`** <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+              - name: object
 
                 **구매자 이름**
 
                 <ParamTree>
-                  - **`full`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+                  - full: string
 
                     **구매자 전체 이름**
 
                     `full` 파라미터 대신 `separated.first` 와 `separated.last` 파라미터로 사용해도 됩니다.
                 </ParamTree>
 
-              - **`phoneNumber`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+              - phoneNumber: string
 
                 **구매자 연락처**
 
                 가상계좌 발급 시 필수 입력해야 합니다.
 
-              - **`email`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+              - email: string
 
                 **구매자 이메일 주소**
 
                 가상계좌 발급 시 필수 입력해야 합니다.
             </ParamTree>
 
-          - **`productType`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+          - productType: string
 
             **상품 유형**
 
             KSNET로 카드 결제시에만 MID 설정 정보와 검증을 진행합니다. 다른 PG사 결제 요청시에는 별도로 검증하지 않습니다.
 
-          - **`productCount`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+          - productCount: string
 
             **상품 개수**
 
             스마트로로 가상계좌 발급시에만 정보가 유효합니다. 다른 PG사 결제 요청시에는 별도로 검증하지 않습니다.
         </ParamTree>
 
-      - **`timeToPay`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - timeToPay: string
 
         **결제 예정 시점**
     </ParamTree>

--- a/src/routes/(root)/opi/ko/integration/pg/v1/hyphen.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/hyphen.mdx
@@ -105,7 +105,7 @@ import Hint from "~/components/Hint";
 
     (최신 JavaScript SDK 버전부터 사용 가능합니다.)
 
-  - `pg` (deprecated) <mark style="color:green;">**string**</mark>
+  - `pg` <mark style="color:green;">**string**</mark>
 
     **PG사 구분코드**
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/hyphen.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/hyphen.mdx
@@ -95,7 +95,7 @@ import Hint from "~/components/Hint";
 ### 주요 파라미터
 
 <ParamTree>
-  - `channelKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - channelKey: string
 
     **채널키**
 
@@ -105,7 +105,7 @@ import Hint from "~/components/Hint";
 
     (최신 JavaScript SDK 버전부터 사용 가능합니다.)
 
-  - `pg` <mark style="color:green;">**string**</mark>
+  - pg?: string
 
     **PG사 구분코드**
 
@@ -117,60 +117,60 @@ import Hint from "~/components/Hint";
       JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
     </Hint>
 
-  - `pay_method` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - pay\_method: string
 
     **결제수단 구분코드**
 
     하이픈의 경우 `trans`만 지원됩니다.
 
-  - `merchant_uid` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - merchant\_uid: string
 
     **고객사 주문 고유 번호**
 
     고객사에서 채번하는 주문 고유 번호로 매번 고유하게 채번되어야 합니다.
     이미 승인 완료된 `merchant_uid`로 결제를 시도하는 경우 에러가 발생합니다.
 
-  - `name` <mark style="color:red;">\*</mark> <mark style="color:green;">**string**</mark>
+  - name: string
 
     **주문명**
 
     주문명으로 고객사에서 자유롭게 입력합니다.
 
-  - `amount` <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
+  - amount: number
 
     **결제 금액**
 
     결제 금액으로 number 형식만 허용됩니다.
 
-  - `buyer_name` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - buyer\_name: string
 
     **구매자 이름**
 
     하이픈의 경우 필수로 입력해야 합니다.
 
-  - `storeDetails` <mark style="color:blue;">**object**</mark>
+  - storeDetails?: object
 
     **상점 정보**
 
     <ParamTree>
-      - `businessName` <mark style="color:green;">**string**</mark>
+      - businessName?: string
 
         **상호명**
 
         - 결제창에 표시될 상호명입니다. 입력하지 않으면 포트원 대표상점명으로 표시됩니다.
     </ParamTree>
 
-  - `bypass` <mark style="color:blue;">**oneof object**</mark>
+  - bypass?: oneof object
 
     **PG사 결제창 호출 시 PG사로 그대로 bypass할 파라미터들의 모음**
 
     <ParamTree>
-      - `hyphen` <mark style="color:blue;">**object**</mark>
+      - hyphen?: object
 
         **하이픈에서 제공하는 파라미터 모음**
 
         <ParamTree>
-          - `designCd` <mark style="color:green;">**string**</mark>
+          - designCd?: string
 
             **결제창 디자인 색상 코드**
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/ksnet/readme.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/ksnet/readme.mdx
@@ -366,7 +366,7 @@ curl -H "Content-Type: application/json" \
   **결제창에 렌더링될 카드 할부 개월수 리스트 설정**
 
   <ParamTree>
-    - `card_quota` <mark style="color:green;">**number\[]**</mark>
+    - card\_quota?: number\[]
 
       **할부 개월수 설정**
 
@@ -383,20 +383,20 @@ curl -H "Content-Type: application/json" \
   **카드 결제시, 카드 결제에 대한 세부 정보 설정**
 
   <ParamTree>
-    - `useInstallment` <mark style="color:orange;">**boolean**</mark>
+    - useInstallment?: boolean
 
       **할부 가능 여부**
 
-    - `detail` <mark style="color:blue;">**array**</mark>
+    - detail?: array
 
       **카드사 렌더링 정보**
 
       <ParamTree>
-        - `card_code` <mark style="color:green;">**string**</mark>
+        - card\_code?: string
 
           **카드사 코드**
 
-        - `max_month` <mark style="color:purple;">**number**</mark>
+        - max\_month?: number
 
           **상점 부담 무이자 할부 최대 개월수**
       </ParamTree>
@@ -430,12 +430,12 @@ curl -H "Content-Type: application/json" \
   **카드 결제시 세부 설정 정보**
 
   <ParamTree>
-    - `direct` <mark style="color:blue;">**object**</mark>
+    - direct?: object
 
       **카드사 다이렉트 호출시 설정 정보**
 
       <ParamTree>
-        - `code` <mark style="color:green;">**string**</mark>
+        - code?: string
 
           **카드사 코드**
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/nhn-kcp.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/nhn-kcp.mdx
@@ -107,7 +107,7 @@ KCP 기준으로 작성한 예시 코드는 아래와 같습니다.
 #### 주요 파라미터
 
 <ParamTree>
-  - **`channelKey` \*** <mark style="color:green;">**string**</mark>
+  - channelKey: string
 
     **채널키**
 
@@ -117,7 +117,7 @@ KCP 기준으로 작성한 예시 코드는 아래와 같습니다.
 
     (최신 JavaScript SDK 버전부터 사용 가능합니다.)
 
-  - **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
+  - pg (deprecated)?: string
 
     **PG사 구분코드**
 
@@ -130,7 +130,7 @@ KCP 기준으로 작성한 예시 코드는 아래와 같습니다.
       JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
     </Hint>
 
-  - **`pay_method`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - pay\_method: string
 
     **결제수단 구분코드**
 
@@ -151,13 +151,13 @@ KCP 기준으로 작성한 예시 코드는 아래와 같습니다.
     - applepay(애플페이)
     - point (베네피아 포인트)
 
-  - **`merchant_uid`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - merchant\_uid: string
 
     **고객사 주문 고유 번호**
 
     고객사에서 채번하는 주문 고유 번호로 매번 고유하게 채번되어야 합니다.
 
-  - **`amount`** <mark style="color:red;">**\***</mark> <mark style="color:purple;">**integer**</mark>
+  - amount: integer
 
     **결제금액**
 </ParamTree>
@@ -167,11 +167,11 @@ KCP 기준으로 작성한 예시 코드는 아래와 같습니다.
 #### 기타 파라미터
 
 <ParamTree>
-  - **`display`** <mark style="color:green;">**string**</mark>
+  - display?: string
 
     **결제창에 렌더링될 카드 할부 개월수 리스트 설정값**
 
-    - **`card_quota`** <mark style="color:purple;">**number**</mark>
+    - card\_quota?: number
 
       **할부 개월수**
 
@@ -195,21 +195,21 @@ KCP 기준으로 작성한 예시 코드는 아래와 같습니다.
       </Tabs.Tab>
     </Tabs>
 
-  - **`card`** <mark style="color:blue;">**oneof object**</mark>
+  - card?: oneof object
 
     **카드 결제시 세부 설정 정보**
 
-    - **`direct`** <mark style="color:blue;">**object**</mark>
+    - direct?: object
 
       **카드사 다이렉트 호출 정보**
 
-      - **`code`** <mark style="color:green;">**string**</mark>
+      - code?: string
 
         **카드사 코드**
 
         [카드사 코드](/opi/ko/support/code-info/card-code)를 참고하세요.
 
-      - **`quota`** <mark style="color:purple;">**number**</mark>
+      - quota?: number
 
         **고정 할부 개월수**
 
@@ -242,17 +242,17 @@ KCP 기준으로 작성한 예시 코드는 아래와 같습니다.
       </Tabs.Tab>
     </Tabs>
 
-    - **`detail`** <mark style="color:blue;">**array**</mark>
+    - detail?: object\[]
 
       **카드사 렌더링 정보**
 
-      - **`card_code`** <mark style="color:green;">**string**</mark>
+      - card\_code?: string
 
         **카드사 코드**
 
         [카드사 코드](/opi/ko/support/code-info/card-code)를 참고하세요.
 
-      - **`enabled`** <mark style="color:orange;">**boolean**</mark>
+      - enabled?: boolean
 
         **렌더링 여부**
 
@@ -273,7 +273,7 @@ KCP 기준으로 작성한 예시 코드는 아래와 같습니다.
       </Tabs.Tab>
     </Tabs>
 
-  - **`appCard`** <mark style="color:orange;">**boolean**</mark>
+  - appCard?: boolean
 
     **앱카드 렌더링 여부**
 
@@ -438,7 +438,7 @@ KCP 기준으로 작성한 예시 코드는 아래와 같습니다.
 #### 주요 파라미터 설명
 
 <ParamTree>
-  - **`channelKey` \*** <mark style="color:green;">**string**</mark>
+  - channelKey: string
 
     **채널키**
 
@@ -448,7 +448,7 @@ KCP 기준으로 작성한 예시 코드는 아래와 같습니다.
 
     (최신 JavaScript SDK 버전부터 사용 가능합니다.)
 
-  - **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
+  - pg (deprecated)?: string
 
     **PG사 구분코드**
 
@@ -461,13 +461,13 @@ KCP 기준으로 작성한 예시 코드는 아래와 같습니다.
       JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
     </Hint>
 
-  - **`customer_uid`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - customer\_uid: string
 
     **포트원 빌링키**
 
     빌링 결제시 사용되는 값으로 고객사에서 입력한 후 요청해야 합니다. 해당 값은 고객이 입력한 카드정보와 1:1로 매칭됩니다.
 
-  - **`amount`** <mark style="color:red;">**\***</mark> <mark style="color:purple;">**integer**</mark>
+  - amount: integer
 
     **결제금액**
 
@@ -861,7 +861,7 @@ KCP 퀵페이 기준으로 작성한 예시 코드는 아래와 같습니다.
 #### 주요 파라미터
 
 <ParamTree>
-  - **`channelKey` \*** <mark style="color:green;">**string**</mark>
+  - channelKey: string
 
     **채널키**
 
@@ -871,7 +871,7 @@ KCP 퀵페이 기준으로 작성한 예시 코드는 아래와 같습니다.
 
     (최신 JavaScript SDK 버전부터 사용 가능합니다.)
 
-  - **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
+  - pg (deprecated)?: string
 
     **PG사 구분코드**
 
@@ -884,7 +884,7 @@ KCP 퀵페이 기준으로 작성한 예시 코드는 아래와 같습니다.
       JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
     </Hint>
 
-  - **`pay_method`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - pay\_method: string
 
     **결제수단 구분코드**
 
@@ -893,33 +893,33 @@ KCP 퀵페이 기준으로 작성한 예시 코드는 아래와 같습니다.
     - card (카드)
     - trans (즉시출금)
 
-  - **`merchant_uid`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - merchant\_uid: string
 
     **고객사 주문 고유 번호**
 
     고객사에서 채번하는 주문 고유 번호로 매번 고유하게 채번되어야 합니다.
 
-  - **`amount`** <mark style="color:red;">**\***</mark> <mark style="color:purple;">**integer**</mark>
+  - amount: integer
 
     **결제금액**
 
-  - **`customer_uid`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - customer\_uid: string
 
     **결제 수단에 대한 고유 식별값**
 
     퀵페이에 등록된 결제수단과 1:1 맵핑됩니다.
 
-  - **`bypass`** <mark style="color:blue;">**oneof object**</mark>
+  - bypass?: oneof object
 
     **PG사 결제창 호출 시 PG사로 그대로 bypass할 파라미터들의 모음**
 
-    - **`kcpQuick`** <mark style="color:blue;">**object**</mark>
+    - kcpQuick?: object
 
       **KCP 퀵페이 설정정보**
 
       퀵페이 결제시 필수로 입력해야 합니다.
 
-      - **`actionType`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - actionType: string
 
         **호출 유형**
 
@@ -931,23 +931,23 @@ KCP 퀵페이 기준으로 작성한 예시 코드는 아래와 같습니다.
         - PhoneChange : 전화번호 변경
         - Terminate : 결제 수단 해지
 
-      - **`memberCI`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - memberCI: string
 
         **본인인증 CI값**
 
-      - **`memberID`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - memberID: string
 
         **사용자 식별값**
 
         최대 16byte까지 입력가능하며, 고객이 여러개의 결제수단을 등록하는 경우 동일한 `memberID`를 입력해야 합니다.
 
-      - **`deviceID`** <mark style="color:green;">**string**</mark>
+      - deviceID?: string
 
         **디바이스 식별값**
 
         미 입력시 고객이 사용한 브라우저 정보가 입력됩니다.
 
-      - **`noAuth`** <mark style="color:orange;">**boolean**</mark>
+      - noAuth?: boolean
 
         **무인증 등록/결제 여부**
 
@@ -956,13 +956,13 @@ KCP 퀵페이 기준으로 작성한 예시 코드는 아래와 같습니다.
         - true : 무인증 결제
         - false : 인증 결제
 
-      - **`installment`** <mark style="color:purple;">**number**</mark>
+      - installment?: number
 
         **할부 개월수**
 
         입력하지 않는 경우 일시불로 진행됩니다.
 
-      - **`useCardPoint`** <mark style="color:orange;">**boolean**</mark>
+      - useCardPoint?: boolean
 
         **카드사 포인트 결제 여부**
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/settle/mybank.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/settle/mybank.mdx
@@ -56,7 +56,7 @@ callback) 호출 후 <mark style="color:red;">**callback**</mark> 으로 수신�
     ### 주요 파라미터 설명
 
     <ParamTree>
-      **`channelKey` \*** <mark style="color:green;">**string**</mark>
+      - **`channelKey` \*** <mark style="color:green;">**string**</mark>
 
       **채널키**
 
@@ -66,7 +66,7 @@ callback) 호출 후 <mark style="color:red;">**callback**</mark> 으로 수신�
 
       (최신 JavaScript SDK 버전부터 사용 가능합니다.)
 
-      **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
+      - **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
       **PG사 구분코드**
 
@@ -78,34 +78,34 @@ callback) 호출 후 <mark style="color:red;">**callback**</mark> 으로 수신�
         JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
       </Hint>
 
-      **`pay_method`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - **`pay_method`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
       **결제수단 구분코드**
 
       `trans`만 사용 가능합니다.
 
-      **`merchant_uid`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - **`merchant_uid`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
       **고객사 고유주문번호**
 
       매번 고유하게 채번되어야 합니다.
 
-      **`buyer_tel`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - **`buyer_tel`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
       **구매자 연락처**
 
       필수 파라미터 입니다.
 
-      **`amount`** <mark style="color:red;">**\***</mark> <mark style="color:purple;">**integer**</mark>
+      - **`amount`** <mark style="color:red;">**\***</mark> <mark style="color:purple;">**integer**</mark>
 
       **결제금액**
 
-      **`bypass`** <mark style="color:blue;">**oneof object**</mark>
+      - **`bypass`** <mark style="color:blue;">**oneof object**</mark>
 
       **PG사 결제창 호출 시 PG사로 그대로 bypass할 값들의 모음**
 
       <ParamTree>
-        **`custCi`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+        - **`custCi`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
         **주문자 CI**
 
@@ -118,7 +118,7 @@ callback) 호출 후 <mark style="color:red;">**callback**</mark> 으로 수신�
         고객사가 보유한 회원 CI를 설정하면 내통장 결제에 등록한 CI와 비교하여 동일인인지 자동검증되며
         일치하지 않은 경우 결제가 중단됩니다.
 
-        **`addDeductionYn`** <mark style="color:green;">**string**</mark>
+        - **`addDeductionYn`** <mark style="color:green;">**string**</mark>
 
         **추가공제구분**
 
@@ -126,7 +126,7 @@ callback) 호출 후 <mark style="color:red;">**callback**</mark> 으로 수신�
 
         계약 후 사용 가능합니다.
 
-        **`criPsblYn`** <mark style="color:green;">**string**</mark>
+        - **`criPsblYn`** <mark style="color:green;">**string**</mark>
 
         **현금영수증 발행가능 여부**
 
@@ -187,7 +187,7 @@ callback) 호출 후 <mark style="color:red;">**callback**</mark> 으로 수신�
     #### 주요 파라미터 설명
 
     <ParamTree>
-      **`channelKey` \*** <mark style="color:green;">**string**</mark>
+      - **`channelKey` \*** <mark style="color:green;">**string**</mark>
 
       **채널키**
 
@@ -197,7 +197,7 @@ callback) 호출 후 <mark style="color:red;">**callback**</mark> 으로 수신�
 
       (최신 JavaScript SDK 버전부터 사용 가능합니다.)
 
-      **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
+      - **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
 
       **PG사 구분코드**
 
@@ -207,24 +207,24 @@ callback) 호출 후 <mark style="color:red;">**callback**</mark> 으로 수신�
         JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
       </Hint>
 
-      **`customer_uid`** <mark style="color:green;">**string**</mark>
+      - **`customer_uid`** <mark style="color:green;">**string**</mark>
 
       **빌링키**
 
       등록 계좌정보와 1:1로 매칭될 빌링키를 지정합니다.
 
-      **`amount`** <mark style="color:purple;">**integer**</mark>
+      - **`amount`** <mark style="color:purple;">**integer**</mark>
 
       **결제금액**
 
       0원으로 입력시 빌링키만 발급됩니다. 금액 설정시 결제와 동시에 빌링키가 발급됩니다.
 
-      **`bypass`** <mark style="color:blue;">**oneof object**</mark>
+      - **`bypass`** <mark style="color:blue;">**oneof object**</mark>
 
       **PG사 결제창 호출 시 PG사로 그대로 bypass할 값들의 모음**
 
       <ParamTree>
-        **`custCi`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+        - **`custCi`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
         **주문자 CI**
 
@@ -237,7 +237,7 @@ callback) 호출 후 <mark style="color:red;">**callback**</mark> 으로 수신�
         고객사가 보유한 회원 CI를 설정하면 내통장 결제에 등록한 CI와 비교하여 동일인인지 자동검증되며
         일치하지 않은 경우 결제가 중단됩니다.
 
-        **`addDeductionYn`** <mark style="color:green;">**string**</mark>
+        - **`addDeductionYn`** <mark style="color:green;">**string**</mark>
 
         **추가공제구분**
 
@@ -245,7 +245,7 @@ callback) 호출 후 <mark style="color:red;">**callback**</mark> 으로 수신�
 
         계약 후 사용 가능합니다.
 
-        **`criPsblYn`** <mark style="color:green;">**string**</mark>
+        - **`criPsblYn`** <mark style="color:green;">**string**</mark>
 
         **현금영수증 발행가능 여부**
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/settle/mybank.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/settle/mybank.mdx
@@ -56,7 +56,7 @@ callback) 호출 후 <mark style="color:red;">**callback**</mark> 으로 수신�
     ### 주요 파라미터 설명
 
     <ParamTree>
-      - **`channelKey` \*** <mark style="color:green;">**string**</mark>
+      - channelKey: string
 
       **채널키**
 
@@ -66,7 +66,7 @@ callback) 호출 후 <mark style="color:red;">**callback**</mark> 으로 수신�
 
       (최신 JavaScript SDK 버전부터 사용 가능합니다.)
 
-      - **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
+      - pg (deprecated)?: string
 
       **PG사 구분코드**
 
@@ -78,34 +78,34 @@ callback) 호출 후 <mark style="color:red;">**callback**</mark> 으로 수신�
         JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
       </Hint>
 
-      - **`pay_method`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - pay\_method: string
 
       **결제수단 구분코드**
 
       `trans`만 사용 가능합니다.
 
-      - **`merchant_uid`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - merchant\_uid: string
 
       **고객사 고유주문번호**
 
       매번 고유하게 채번되어야 합니다.
 
-      - **`buyer_tel`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - buyer\_tel: string
 
       **구매자 연락처**
 
       필수 파라미터 입니다.
 
-      - **`amount`** <mark style="color:red;">**\***</mark> <mark style="color:purple;">**integer**</mark>
+      - amount: integer
 
       **결제금액**
 
-      - **`bypass`** <mark style="color:blue;">**oneof object**</mark>
+      - bypass?: oneof object
 
       **PG사 결제창 호출 시 PG사로 그대로 bypass할 값들의 모음**
 
       <ParamTree>
-        - **`custCi`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+        - custCi: string
 
         **주문자 CI**
 
@@ -118,7 +118,7 @@ callback) 호출 후 <mark style="color:red;">**callback**</mark> 으로 수신�
         고객사가 보유한 회원 CI를 설정하면 내통장 결제에 등록한 CI와 비교하여 동일인인지 자동검증되며
         일치하지 않은 경우 결제가 중단됩니다.
 
-        - **`addDeductionYn`** <mark style="color:green;">**string**</mark>
+        - addDeductionYn?: string
 
         **추가공제구분**
 
@@ -126,7 +126,7 @@ callback) 호출 후 <mark style="color:red;">**callback**</mark> 으로 수신�
 
         계약 후 사용 가능합니다.
 
-        - **`criPsblYn`** <mark style="color:green;">**string**</mark>
+        - criPsblYn?: string
 
         **현금영수증 발행가능 여부**
 
@@ -187,7 +187,7 @@ callback) 호출 후 <mark style="color:red;">**callback**</mark> 으로 수신�
     #### 주요 파라미터 설명
 
     <ParamTree>
-      - **`channelKey` \*** <mark style="color:green;">**string**</mark>
+      - channelKey: string
 
       **채널키**
 
@@ -197,7 +197,7 @@ callback) 호출 후 <mark style="color:red;">**callback**</mark> 으로 수신�
 
       (최신 JavaScript SDK 버전부터 사용 가능합니다.)
 
-      - **`pg` (deprecated)** <mark style="color:green;">**string**</mark>
+      - pg (deprecated)?: string
 
       **PG사 구분코드**
 
@@ -207,24 +207,24 @@ callback) 호출 후 <mark style="color:red;">**callback**</mark> 으로 수신�
         JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
       </Hint>
 
-      - **`customer_uid`** <mark style="color:green;">**string**</mark>
+      - customer\_uid?: string
 
       **빌링키**
 
       등록 계좌정보와 1:1로 매칭될 빌링키를 지정합니다.
 
-      - **`amount`** <mark style="color:purple;">**integer**</mark>
+      - amount?: integer
 
       **결제금액**
 
       0원으로 입력시 빌링키만 발급됩니다. 금액 설정시 결제와 동시에 빌링키가 발급됩니다.
 
-      - **`bypass`** <mark style="color:blue;">**oneof object**</mark>
+      - bypass?: oneof object
 
       **PG사 결제창 호출 시 PG사로 그대로 bypass할 값들의 모음**
 
       <ParamTree>
-        - **`custCi`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+        - custCi: string
 
         **주문자 CI**
 
@@ -237,7 +237,7 @@ callback) 호출 후 <mark style="color:red;">**callback**</mark> 으로 수신�
         고객사가 보유한 회원 CI를 설정하면 내통장 결제에 등록한 CI와 비교하여 동일인인지 자동검증되며
         일치하지 않은 경우 결제가 중단됩니다.
 
-        - **`addDeductionYn`** <mark style="color:green;">**string**</mark>
+        - addDeductionYn?: string
 
         **추가공제구분**
 
@@ -245,7 +245,7 @@ callback) 호출 후 <mark style="color:red;">**callback**</mark> 으로 수신�
 
         계약 후 사용 가능합니다.
 
-        - **`criPsblYn`** <mark style="color:green;">**string**</mark>
+        - criPsblYn?: string
 
         **현금영수증 발행가능 여부**
 

--- a/src/routes/(root)/opi/ko/integration/pg/v2/hyphen.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v2/hyphen.mdx
@@ -82,95 +82,95 @@ import Tabs from "~/components/gitbook/Tabs";
 ### 주요 파라미터
 
 <ParamTree>
-  - `storeId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - storeId: string
 
     **스토어 아이디**
 
     포트원 계정에 생성된 상점을 식별하는 고유한 값으로 관리자 콘솔에서 확인할 수 있습니다.
 
-  - `paymentId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - paymentId: string
 
     **고객사 주문 고유 번호**
 
     고객사에서 채번하는 주문 고유 번호로 매번 고유하게 채번되어야 합니다. 이미 승인 완료된 `paymentId`로 결제를 시도하는 경우 에러가 발생합니다.
 
-  - `orderName` <mark style="color:red;">\*</mark> <mark style="color:green;">**string**</mark>
+  - orderName: string
 
     **주문명**
 
     주문명으로 고객사에서 자유롭게 입력합니다.
 
-  - `channelKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - channelKey: string
 
     **채널 키**
 
     포트원 콘솔 내 \[연동 관리] > \[연동 정보] > \[채널 관리] 화면에서 채널 추가 시 생성되는 값입니다. 결제 호출 시 채널을 지정할 때 사용됩니다.
 
-  - `totalAmount` <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
+  - totalAmount: number
 
     **결제 금액**
 
     결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
 
-  - `currency` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - currency: string
 
     **결제 통화**
 
     결제통화로 원화 결제 시 `KRW`로 입력해야 합니다.
 
-  - `payMethod` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - payMethod: string
 
     **결제수단 구분코드**
 
     결제 호출 시 결제수단을 지정할 때 사용됩니다. 하이픈의 경우 해당 값은 `EASY_PAY`로 고정해주세요.
 
-  - `customer` <mark style="color:blue;">**object**</mark>
+  - customer?: object
 
     **고객 정보**
 
     <ParamTree>
-      - `fullName` <mark style="color:green;">**string**</mark>
+      - fullName?: string
 
         **구매자 전체 이름**
 
         - 하이픈의 경우 fullName 혹은 (firstName + lastName)을 필수로 입력해야 합니다.
 
-      - `firstName` <mark style="color:green;">**string**</mark>
+      - firstName?: string
 
         **구매자 이름**
 
         - 하이픈의 경우 fullName 혹은 (firstName + lastName)을 필수로 입력해야 합니다.
 
-      - `lastName` <mark style="color:green;">**string**</mark>
+      - lastName?: string
 
         **구매자 성**
 
         - 하이픈의 경우 fullName 혹은 (firstName + lastName)을 필수로 입력해야 합니다.
     </ParamTree>
 
-  - `storeDetails` <mark style="color:blue;">**object**</mark>
+  - storeDetails?: object
 
     **상점 정보**
 
     <ParamTree>
-      - `businessName` <mark style="color:green;">**string**</mark>
+      - businessName?: string
 
         **상호명**
 
         - 결제창에 표시될 상호명입니다. 입력하지 않으면 포트원 대표상점명으로 표시됩니다.
     </ParamTree>
 
-  - `bypass` <mark style="color:blue;">**oneof object**</mark>
+  - bypass?: oneof object
 
     **PG사 결제창 호출 시 PG사로 그대로 bypass할 파라미터들의 모음**
 
     <ParamTree>
-      - `hyphen` <mark style="color:blue;">**object**</mark>
+      - hyphen?: object
 
         **하이픈에서 제공하는 파라미터 모음**
 
         <ParamTree>
-          - `designCd` <mark style="color:green;">**string**</mark>
+          - designCd?: string
 
             **결제창 디자인 색상 코드**
 

--- a/src/routes/(root)/opi/ko/integration/pg/v2/inicis-v2.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v2/inicis-v2.mdx
@@ -103,43 +103,43 @@ import Tabs from "~/components/gitbook/Tabs";
 ### 주요 파라미터
 
 <ParamTree>
-  - `storeId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - storeId: string
 
     **스토어 아이디**
 
     포트원 계정에 생성된 상점을 식별하는 고유한 값으로 관리자 콘솔에서 확인할 수 있습니다.
 
-  - `paymentId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - paymentId: string
 
     **고객사 주문 고유 번호**
 
     고객사에서 채번하는 주문 고유 번호로 매번 고유하게 채번되어야 합니다. 이미 승인 완료된 `paymentId`로 결제를 시도하는 경우 에러가 발생합니다.
 
-  - `orderName` <mark style="color:red;">\*</mark> <mark style="color:green;">**string**</mark>
+  - orderName: string
 
     **주문명**
 
     주문명으로 고객사에서 자유롭게 입력합니다.
 
-  - `channelKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - channelKey: string
 
     **채널 키**
 
     포트원 콘솔 내 \[결제연동] > \[채널관리] 화면에서 채널 추가 시 생성되는 값입니다. 결제 호출 시 채널을 지정할 때 사용됩니다.
 
-  - `totalAmount` <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
+  - totalAmount: number
 
     **결제 금액**
 
     결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
 
-  - `currency` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - currency: string
 
     **결제 통화**
 
     결제통화로 원화 결제 시 `KRW`로 입력해야 합니다.
 
-  - `payMethod` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - payMethod: string
 
     **결제수단 구분코드**
 
@@ -151,48 +151,48 @@ import Tabs from "~/components/gitbook/Tabs";
     - 휴대폰 소액결제 : `MOBILE`
     - 간편 결제 : `EASY_PAY`
 
-  - `customer` <mark style="color:blue;">**object**</mark>
+  - customer?: object
 
     **고객 정보**
 
     <ParamTree>
-      - `fullName` <mark style="color:green;">**string**</mark>
+      - fullName?: string
 
         **구매자 전체 이름**
 
         - 이니시스의 경우 fullName 혹은 (firstName + lastName)을 필수로 입력해야 합니다.
 
-      - `firstName` <mark style="color:green;">**string**</mark>
+      - firstName?: string
 
         **구매자 이름**
 
         - 이니시스의 경우 fullName 혹은 (firstName + lastName)을 필수로 입력해야 합니다.
 
-      - `lastName` <mark style="color:green;">**string**</mark>
+      - lastName?: string
 
         **구매자 성**
 
         - 이니시스의 경우 fullName 혹은 (firstName + lastName)을 필수로 입력해야 합니다.
 
-      - `phoneNumber` <mark style="color:green;">**string**</mark>
+      - phoneNumber?: string
 
         **구매자 연락처**
 
         - 이니시스의 PC 결제의 경우 필수로 입력해야 합니다. (모바일인 경우에는 optional)
 
-      - `email` <mark style="color:green;">**string**</mark>
+      - email?: string
 
         **구매자 이메일**
 
         - 이니시스의 PC 결제의 경우 필수로 입력해야 합니다. (모바일인 경우에는 optional)
     </ParamTree>
 
-  - `bypass` <mark style="color:blue;">**oneof object**</mark>
+  - bypass?: oneof object
 
     **PG사 결제창 호출 시 PG사로 그대로 bypass할 파라미터들의 모음**
 
     <ParamTree>
-      - `inicis_v2` <mark style="color:blue;">**object**</mark>
+      - inicis\_v2?: object
 
         **이니시스에서 제공하는 파라미터 모음**
 
@@ -203,74 +203,74 @@ import Tabs from "~/components/gitbook/Tabs";
         **PC용 파라미터**
 
         <ParamTree>
-          - `logo_url` <mark style="color:green;">**string**</mark>
+          - logo\_url?: string
 
             **결제창에 삽입할 메인 로고 url**
 
             - 결제창 중앙 상단에 표시됩니다.
             - 이미지 권장 사이즈는 89\*18 입니다.
 
-          - `logo_2nd` <mark style="color:green;">**string**</mark>
+          - logo\_2nd?: string
 
             **결제창에 삽입할 서브 로고 url**
 
             - 결제창 우측 상단에 표시됩니다.
             - 이미지 권장 사이즈는 64\*13 입니다.
 
-          - `parentemail` <mark style="color:green;">**string**</mark>
+          - parentemail?: string
 
             **보호자 이메일 주소l**
 
             - 14세 미만 고객의 경우 필수 입력입니다.
             - "@", "." 외의 특수문자는 입력 불가합니다.
 
-          - `Ini_SSGPAY_MDN` <mark style="color:green;">**string**</mark>
+          - Ini\_SSGPAY\_MDN?: string
 
             **SSGPAY 결제요청 시 PUSH 전송 휴대폰번호**
 
             - `-` 없이 숫자만 허용합니다.
 
-          - `acceptmethod` <mark style="color:green;">**string\[]**</mark>
+          - acceptmethod?: string\[]
 
             **추가 옵션**
 
             <ParamTree>
               - 아래 string 중 원하는 옵션들을 골라 array 형태로 입력합니다.
 
-              - `SKIN(${string})` <mark style="color:green;">**string**</mark>
+              - SKIN($\{string})?: string
 
                 **결제창 색상**
 
                 - `string` 부분에는 `#`으로 시작하는 여섯자리 Hex 값을 입력합니다. (ex. `SKIN(#C1272C)`)
 
-              - `below1000` <mark style="color:green;">**string**</mark>
+              - below1000?: string
 
                 **(카드결제 & 간편결제 시) 1000원 미만 결제 허용 옵션**
 
-              - `ocb` <mark style="color:green;">**string**</mark>
+              - ocb?: string
 
                 **(카드결제 시) 카드 메인화면에 OCB 적립을 위한 카드번호 창 표시옵션 (별도 계약시 이용 가능)**
 
-              - `paypopup` <mark style="color:green;">**string**</mark>
+              - paypopup?: string
 
                 **(카드결제 시) 안심클릭계열 신용카드 POPUP 형태 표시옵션**
 
-              - `hidebar` <mark style="color:green;">**string**</mark>
+              - hidebar?: string
 
                 **(카드결제 시) 프로그레스바 미노출 옵션**
 
-              - `noeasypay` <mark style="color:green;">**string**</mark>
+              - noeasypay?: string
 
                 **(카드결제 시) 간편결제 미노출 옵션**
 
-              - `slimquota(${string})` <mark style="color:green;">**string**</mark>
+              - slimquota($\{string})?: string
 
                 **부분 무이자 설정 (별도 계약시 이용 가능)**
 
                 - `string` 부분에는 `코드-개월:개월^코드-개월:개월` 와 같은 형식으로 입력합니다. (ex. `slimquota(11-2:3^34-2:3)`)
                 - 카드사 코드는 [이니시스 통합 코드](http://manual.inicis.com/pay/code.html) 페이지에서 "결제요청 시 카드코드" 섹션을 참고하시기 바랍니다.
 
-              - `mallpoint(${string})` <mark style="color:green;">**string**</mark>
+              - mallpoint($\{string})?: string
 
                 **몰포인트 (별도 계약시 이용 가능)**
 
@@ -282,37 +282,37 @@ import Tabs from "~/components/gitbook/Tabs";
         **모바일용 파라미터**
 
         <ParamTree>
-          - `P_CARD_OPTION` <mark style="color:green;">**string**</mark>
+          - P\_CARD\_OPTION?: string
 
             **신용카드 우선선택 옵션**
 
             - 설정한 카드코드에 해당하는 카드가 선택된 채로 Display 됩니다.
             - `selcode=카드코드` 형식으로 입력합니다. (ex. `selcode=14`)
 
-          - `P_MNAME` <mark style="color:green;">**string**</mark>
+          - P\_MNAME?: string
 
             **가맹점 이름**
 
-          - `P_RESERVED` <mark style="color:green;">**string\[]**</mark>
+          - P\_RESERVED?: string\[]
 
             **추가 옵션**
 
             <ParamTree>
               - 아래 string 중 원하는 옵션들을 골라 array 형태로 입력합니다.
 
-              - `below1000=Y` <mark style="color:green;">**string**</mark>
+              - below1000=Y?: string
 
                 **(카드결제 & 간편결제 시) 1000원 미만 결제 허용 옵션**
 
-              - `noeasypay=Y` <mark style="color:green;">**string**</mark>
+              - noeasypay=Y?: string
 
                 **(카드결제 시) 간편결제 미노출 옵션**
 
-              - `global_visa3d=Y` <mark style="color:green;">**string**</mark>
+              - global\_visa3d=Y?: string
 
                 **해외카드 노출 옵션**
 
-              - `apprun_check=Y` <mark style="color:green;">**string**</mark>
+              - apprun\_check=Y?: string
 
                 **(android의 경우) custom url scheme 대신 intent schema(intent://) 호출**
             </ParamTree>
@@ -577,90 +577,90 @@ import Tabs from "~/components/gitbook/Tabs";
 <br />
 
 <ParamTree>
-  - `storeId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - storeId: string
 
     **스토어 아이디**
 
     포트원 계정에 생성된 상점을 식별하는 고유한 값으로 관리자 콘솔에서 확인할 수 있습니다.
 
-  - `channelKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - channelKey: string
 
     **채널 키**
 
     포트원 콘솔 내 \[결제연동] > \[채널관리] 화면에서 채널 추가 시 생성되는 값입니다. 결제 호출 시 채널을 지정할 때 사용됩니다.
 
-  - `billingKeyMethod` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - billingKeyMethod: string
 
     **빌링키 발급수단**
 
     이니시스는 빌링키 발급 수단으로 카드만을 지원하므로 해당 파라미터는 `CARD`로 고정해야 합니다.
 
-  - `issueId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - issueId: string
 
     **빌링키 발급 건 고유 ID**
 
     - 고객사에서 채번하여 사용해야 합니다.
     - 이니시스의 경우 필수 입력해야 합니다.
 
-  - `issueName` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - issueName: string
 
     **빌링키 발급 시 결제창에 표시되는 제목**
 
     - 이니시스의 경우 필수 입력해야 합니다.
 
-  - `customer` <mark style="color:blue;">**object**</mark>
+  - customer?: object
 
     **고객 정보**
 
     <ParamTree>
-      - `fullName` <mark style="color:green;">**string**</mark>
+      - fullName?: string
 
         **구매자 전체 이름**
 
         - 이니시스의 경우 fullName 혹은 (firstName + lastName)을 필수로 입력해야 합니다.
 
-      - `firstName` <mark style="color:green;">**string**</mark>
+      - firstName?: string
 
         **구매자 이름**
 
         - 이니시스의 경우 fullName 혹은 (firstName + lastName)을 필수로 입력해야 합니다.
 
-      - `lastName` <mark style="color:green;">**string**</mark>
+      - lastName?: string
 
         **구매자 성**
 
         - 이니시스의 경우 fullName 혹은 (firstName + lastName)을 필수로 입력해야 합니다.
 
-      - `phoneNumber` <mark style="color:green;">**string**</mark>
+      - phoneNumber?: string
 
         **구매자 연락처**
 
         - 이니시스의 PC 빌링키 발급의 경우 필수로 입력해야 합니다. (모바일인 경우에는 optional)
 
-      - `email` <mark style="color:green;">**string**</mark>
+      - email?: string
 
         **구매자 이메일**
 
         - 이니시스의 PC 빌링키 발급의 경우 필수로 입력해야 합니다. (모바일인 경우에는 optional)
     </ParamTree>
 
-  - `offerPeriod` <mark style="color:blue;">**object**</mark>
+  - offerPeriod?: object
 
     **제공 기간**
 
     - 이니시스 모바일 빌링키 발급의 경우 필수로 입력해야 합니다. (PC인 경우에는 optional)
 
-  - `bypass` <mark style="color:blue;">**oneof object**</mark>
+  - bypass?: oneof object
 
     **PG사 결제창 호출 시 PG사로 그대로 bypass할 파라미터들의 모음**
 
     <ParamTree>
-      - `inicis_v2` <mark style="color:blue;">**object**</mark>
+      - inicis\_v2?: object
 
         **이니시스에서 제공하는 파라미터 모음**
 
         <ParamTree>
-          - `carduse` <mark style="color:green;">**'percard' | 'cocard'**</mark>
+          - carduse?: 'percard' | 'cocard'
 
             **개인/법인카드 사용 선택 옵션**
 
@@ -791,87 +791,87 @@ import Tabs from "~/components/gitbook/Tabs";
 ### 주요 파라미터
 
 <ParamTree>
-  - `paymentId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - paymentId: string
 
     **고객사 주문 고유 번호**
 
     고객사에서 채번하는 주문 고유 번호로 매번 고유하게 채번되어야 합니다. 이미 승인 완료된 `paymentId`로 결제를 시도하는 경우 에러가 발생합니다.
 
-  - `orderName` <mark style="color:red;">\*</mark> <mark style="color:green;">**string**</mark>
+  - orderName: string
 
     **주문명**
 
     주문명으로 고객사에서 자유롭게 입력합니다.
 
-  - `channelKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - channelKey: string
 
     **채널 키**
 
     포트원 콘솔 내 \[결제연동] > \[채널관리] 화면에서 채널 추가 시 생성되는 값입니다. 결제 호출 시 채널을 지정할 때 사용됩니다.
 
-  - `amount` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+  - amount: object
 
     **결제 금액**
 
     <ParamTree>
-      - `total` <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
+      - total: number
 
         **총 결제 금액**
 
         결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
 
-      - `taxFree` <mark style="color:purple;">**number**</mark>
+      - taxFree?: number
 
         **면세액**
 
         결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
     </ParamTree>
 
-  - `currency` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - currency: string
 
     **결제 통화**
 
     결제통화로 원화 결제 시 `KRW`로 입력해야 합니다.
 
-  - `method` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+  - method: object
 
     **결제수단 정보**
 
     <ParamTree>
-      - `virtualAccount` <mark style="color:blue;">**object**</mark>
+      - virtualAccount?: object
 
         **가상계좌 결제 시 파라미터**
 
         <ParamTree>
-          - `bank` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+          - bank: string
 
             **발급 은행**
 
             - 은행코드는 ENUM으로 정의되어 있습니다.
             - [BANK ENUM 바로가기](/api/rest-v2/type-def#Bank)
 
-          - `expiry` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+          - expiry: object
 
             **입금 만료 기한**
 
             <ParamTree>
-              - `validHours` <mark style="color:purple;">**integer**</mark>
+              - validHours?: integer
 
                 **유효 시간**
 
-              - `dueDate` <mark style="color:green;">**string**</mark>
+              - dueDate?: string
 
                 **만료 시점**
 
                 시간은 ISO8601 형식으로 입력해야 합니다.
             </ParamTree>
 
-          - `option` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+          - option: object
 
             **가상계좌 발급 방식**
 
             <ParamTree>
-              - `type` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+              - type: string
 
                 **가상계좌 발급 유형**
 
@@ -881,12 +881,12 @@ import Tabs from "~/components/gitbook/Tabs";
                 - 고정식 가상계좌 : `FIXED`
                 - 회전식 가상계좌는 일반적으로 사용되는 방식이며 PG사에서 직접 채번한 가상계좌번호를 사용합니다.
 
-              - `fixed` <mark style="color:blue;">**object**</mark>
+              - fixed?: object
 
                 **고정식 가상계좌 발급 유형**
 
                 <ParamTree>
-                  - `accountNumber` <mark style="color:green;">**string**</mark>
+                  - accountNumber?: string
 
                     **고정식 가상계좌번호**
 
@@ -895,12 +895,12 @@ import Tabs from "~/components/gitbook/Tabs";
                 </ParamTree>
             </ParamTree>
 
-          - `cashReceipt` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+          - cashReceipt: object
 
             **현금영수증 정보**
 
             <ParamTree>
-              - `type` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+              - type: string
 
                 **발급 유형**
 
@@ -910,7 +910,7 @@ import Tabs from "~/components/gitbook/Tabs";
                 - 지출증빙용 : `CORPORATE`
                 - 미발행 : `NO_RECEIPT`
 
-              - `customerIdentityNumber` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+              - customerIdentityNumber: string
 
                 **현금영수증 식별 번호**
 
@@ -918,86 +918,86 @@ import Tabs from "~/components/gitbook/Tabs";
                 - 지출증빙인 경우 사업자등록번호를 입력해야 합니다.
             </ParamTree>
 
-          - `remitteeName` <mark style="color:green;">**string**</mark>
+          - remitteeName?: string
 
             **예금주명**
         </ParamTree>
 
-      - `card` <mark style="color:blue;">**object**</mark>
+      - card?: object
 
         <ParamTree>
-          - `credential` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+          - credential: string
 
             **인증 관련 정보**
 
             <ParamTree>
-              - `number` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+              - number: object
 
                 **카드 번호**
 
-              - `expiryYear` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+              - expiryYear: object
 
                 **유효 기간 만료 연도 (YY 형식 ex. 24)**
 
-              - `expiryMonth` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+              - expiryMonth: string
 
                 **유효기간 만료 월 (MM 형식 ex. 05)**
 
-              - `birthOrBusinessRegistrationNumber` <mark style="color:green;">**string**</mark>
+              - birthOrBusinessRegistrationNumber?: string
 
                 **생년월일 또는 사업자 등록 번호**
 
-              - `passwordTwoDigits` <mark style="color:green;">**string**</mark>
+              - passwordTwoDigits?: string
 
                 **비밀번호 앞 두자리**
             </ParamTree>
         </ParamTree>
 
-      - `customer` <mark style="color:blue;">**object**</mark>
+      - customer?: object
 
         **고객 정보**
 
         <ParamTree>
-          - `name`  <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+          - name: object
 
             **고객 이름**
 
             - 이니시스의 경우 full 혹은 separated를 필수로 입력해야 합니다.
 
               <ParamTree>
-                - `full` <mark style="color:green;">**string**</mark>
+                - full?: string
 
                   **한 줄 이름 형식 (ex. 김포트)**
 
-                - `separated` <mark style="color:blue;">**object**</mark>
+                - separated?: object
 
                   **분리된 이름**
 
                   <ParamTree>
-                    - `first` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+                    - first: string
 
                       **이름**
 
-                    - `last` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+                    - last: string
 
                       **성**
                   </ParamTree>
               </ParamTree>
 
-          - `phoneNumber`  <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+          - phoneNumber: string
 
             **구매자 연락처**
 
           - 이니시스의 경우 필수 입력입니다.
 
-          - `email` <mark style="color:red;">**\***</mark>  <mark style="color:green;">**string**</mark>
+          - email: string
 
             **구매자 이메일**
 
           - 이니시스의 경우 필수 입력입니다.
         </ParamTree>
 
-      - `productCount` <mark style="color:purple;">**integer**</mark>
+      - productCount?: integer
 
         **상품 개수**
     </ParamTree>
@@ -1041,86 +1041,86 @@ import Tabs from "~/components/gitbook/Tabs";
 ### 주요 파라미터
 
 <ParamTree>
-  - `channelKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - channelKey: string
 
     **채널 키**
 
     포트원 콘솔 내 \[결제연동] > \[채널관리] 화면에서 채널 추가 시 생성되는 값입니다. 결제 호출 시 채널을 지정할 때 사용됩니다.
 
-  - `method` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+  - method: object
 
     **결제수단 정보**
 
-    - `card` <mark style="color:blue;">**object**</mark>
+    - card?: object
 
       **카드 빌링키 발급 시 파라미터**
 
       <ParamTree>
-        - `credential` <mark style="color:green;">**string**</mark>
+        - credential?: string
 
           **인증 관련 정보**
 
           <ParamTree>
-            - `number` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+            - number: object
 
               **카드 번호**
 
-            - `expiryYear` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+            - expiryYear: object
 
               **유효 기간 만료 연도 (YY 형식 ex. 24)**
 
-            - `expiryMonth` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+            - expiryMonth: string
 
               **유효기간 만료 월 (MM 형식 ex. 05)**
 
-            - `birthOrBusinessRegistrationNumber` <mark style="color:green;">**string**</mark>
+            - birthOrBusinessRegistrationNumber?: string
 
               **생년월일 또는 사업자 등록 번호**
 
-            - `passwordTwoDigits` <mark style="color:green;">**string**</mark>
+            - passwordTwoDigits?: string
 
               **비밀번호 앞 두자리**
           </ParamTree>
       </ParamTree>
 
-  - `customer`  <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+  - customer: object
 
     **고객 정보**
 
     <ParamTree>
-      - `name` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+      - name: object
 
         **고객 이름**
 
         - 이니시스의 경우 full 혹은 separated를 필수로 입력해야 합니다.
 
           <ParamTree>
-            - `full` <mark style="color:green;">**string**</mark>
+            - full?: string
 
               **한 줄 이름 형식 (ex. 김포트)**
 
-            - `separated` <mark style="color:blue;">**object**</mark>
+            - separated?: object
 
               **분리된 이름**
 
               <ParamTree>
-                - `first` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+                - first: string
 
                   **이름**
 
-                - `last` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+                - last: string
 
                   **성**
               </ParamTree>
           </ParamTree>
 
-      - `phoneNumber` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - phoneNumber: string
 
         **구매자 연락처**
 
         - 이니시스의 경우 필수로 입력해야 합니다.
 
-      - `email` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - email: string
 
         **구매자 이메일**
 
@@ -1163,90 +1163,90 @@ import Tabs from "~/components/gitbook/Tabs";
 ### 주요 파라미터
 
 <ParamTree>
-  - `paymentId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - paymentId: string
 
     **결제 주문 번호**
 
     - 고객사에서 채번하여 사용하는 주문번호로 고유한 값이여야 합니다.
     - URL path에 포함하여 요청해야 합니다.
 
-  - `billingKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - billingKey: string
 
     **빌링키 결제에 사용할 빌링키**
 
-  - `orderName`  <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - orderName: string
 
     **주문명**
 
-  - `amount` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+  - amount: object
 
     **결제 금액**
 
     <ParamTree>
-      - `total` <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
+      - total: number
 
         **총 결제 금액**
 
         결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
 
-      - `taxFree` <mark style="color:purple;">**number**</mark>
+      - taxFree?: number
 
         **면세액**
 
         결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
     </ParamTree>
 
-  - `currency` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - currency: string
 
     **결제 통화**
 
     결제통화로 원화 결제 시 `KRW`로 입력해야 합니다.
 
-  - `customer`  <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+  - customer: object
 
     **고객 정보**
 
     <ParamTree>
-      - `name` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+      - name: object
 
         **고객 이름**
 
         - 이니시스의 경우 full 혹은 separated를 필수로 입력해야 합니다.
 
           <ParamTree>
-            - `full` <mark style="color:green;">**string**</mark>
+            - full?: string
 
               **한 줄 이름 형식 (ex. 김포트)**
 
-            - `separated` <mark style="color:blue;">**object**</mark>
+            - separated?: object
 
               **분리된 이름**
 
               <ParamTree>
-                - `first` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+                - first: string
 
                   **이름**
 
-                - `last` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+                - last: string
 
                   **성**
               </ParamTree>
           </ParamTree>
 
-      - `phoneNumber` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - phoneNumber: string
 
         **구매자 연락처**
 
         - 이니시스의 경우 필수로 입력해야 합니다.
 
-      - `email` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - email: string
 
         **구매자 이메일**
 
         - 이니시스의 경우 필수로 입력해야 합니다.
     </ParamTree>
 
-  - `productCount` <mark style="color:purple;">**integer**</mark>
+  - productCount?: integer
 
     **상품 개수**
 </ParamTree>
@@ -1286,93 +1286,93 @@ import Tabs from "~/components/gitbook/Tabs";
 ### 주요 파라미터
 
 <ParamTree>
-  - `paymentId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - paymentId: string
 
     **결제 주문 번호**
 
     - 고객사에서 채번하여 사용하는 주문번호로 고유한 값이여야 합니다.
     - URL path에 포함하여 요청해야 합니다.
 
-  - `payment` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+  - payment: object
 
     **빌링키 결제 요청 입력정보**
 
     <ParamTree>
-      - `billingKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - billingKey: string
 
         **빌링키 결제에 사용할 빌링키**
 
-      - `orderName`  <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - orderName: string
 
         **주문명**
 
-      - `amount` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+      - amount: object
 
         **결제 금액**
 
         <ParamTree>
-          - `total` <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
+          - total: number
 
             **총 결제 금액**
 
             결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
 
-          - `taxFree` <mark style="color:purple;">**number**</mark>
+          - taxFree?: number
 
             **면세액**
 
             결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
         </ParamTree>
 
-      - `currency` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - currency: string
 
         **결제 통화**
 
         결제통화로 원화 결제 시 `KRW`로 입력해야 합니다.
     </ParamTree>
 
-  - `timeToPay` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - timeToPay: string
 
     **결제 예정 시점**
 
-  - `customer`  <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+  - customer: object
 
     **고객 정보**
 
     <ParamTree>
-      - `name` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+      - name: object
 
         **고객 이름**
 
         - 이니시스의 경우 full 혹은 separated를 필수로 입력해야 합니다.
 
           <ParamTree>
-            - `full` <mark style="color:green;">**string**</mark>
+            - full?: string
 
               **한 줄 이름 형식 (ex. 김포트)**
 
-            - `separated` <mark style="color:blue;">**object**</mark>
+            - separated?: object
 
               **분리된 이름**
 
               <ParamTree>
-                - `first` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+                - first: string
 
                   **이름**
 
-                - `last` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+                - last: string
 
                   **성**
               </ParamTree>
           </ParamTree>
 
-      - `phoneNumber` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - phoneNumber: string
 
         **구매자 연락처**
 
         - 이니시스의 경우 필수로 입력해야 합니다.
 
-      - `email` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - email: string
 
         **구매자 이메일**
 
@@ -1427,53 +1427,53 @@ import Tabs from "~/components/gitbook/Tabs";
 ### 주요 파라미터
 
 <ParamTree>
-  - `paymentId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - paymentId: string
 
     **결제 주문 번호**
 
     - 고객사에서 채번하여 사용하는 주문번호로 고유한 값이여야 합니다.
     - URL path에 포함하여 요청해야 합니다.
 
-  - `items` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**RegisterStoreReceiptBodyItem\[]**</mark>
+  - items: RegisterStoreReceiptBodyItem\[]
 
     **등록할 거래 건 리스트**
 
     \= 매출전표에 등록할 하위 상점 거래 건 리스트를 등록 하셔야합니다.
 
     <ParamTree>
-      - `storeBusinessRegistrationNumber` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - storeBusinessRegistrationNumber: string
 
         **하위 상점 사업자등록번호**
 
-      - `storeName` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - storeName: string
 
         **하위 상점 명**
 
-      - `totalAmount` <mark style="color:red;">**\***</mark> <mark style="color:green;">**number**</mark>
+      - totalAmount: number
 
         **총 결제 금액**
 
         결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
 
-      - `taxFreeAmount` <mark style="color:red;">**\***</mark> <mark style="color:green;">**number**</mark>
+      - taxFreeAmount: number
 
         **면세액**
 
         - 이니시스의 경우 필수로 입력해야 합니다.
 
-      - `vatAmount` <mark style="color:red;">**\***</mark> <mark style="color:green;">**number**</mark>
+      - vatAmount: number
 
         **부가세**
 
         - 이니시스의 경우 필수로 입력해야 합니다.
 
-      - `supplyAmount` <mark style="color:red;">**\***</mark> <mark style="color:green;">**number**</mark>
+      - supplyAmount: number
 
         **공급가액**
 
         - 이니시스의 경우 필수로 입력해야 합니다.
 
-      - `currency` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - currency: string
 
         **결제 통화**
 

--- a/src/routes/(root)/opi/ko/integration/pg/v2/inicis-v2.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v2/inicis-v2.mdx
@@ -1120,7 +1120,7 @@ import Tabs from "~/components/gitbook/Tabs";
 
         - 이니시스의 경우 필수로 입력해야 합니다.
 
-      - `email`<mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - `email` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
         **구매자 이메일**
 
@@ -1239,7 +1239,7 @@ import Tabs from "~/components/gitbook/Tabs";
 
         - 이니시스의 경우 필수로 입력해야 합니다.
 
-      - `email`<mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - `email` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
         **구매자 이메일**
 
@@ -1372,7 +1372,7 @@ import Tabs from "~/components/gitbook/Tabs";
 
         - 이니시스의 경우 필수로 입력해야 합니다.
 
-      - `email`<mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - `email` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
         **구매자 이메일**
 

--- a/src/routes/(root)/opi/ko/integration/pg/v2/kcp-v2.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v2/kcp-v2.mdx
@@ -864,7 +864,7 @@ KCP 기준으로 작성한 예시 코드는 아래와 같습니다.
 
                 **생년월일 또는 사업자 등록 번호**
 
-              - `passwordTwoDigits`<mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+              - `passwordTwoDigits` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
                 **비밀번호 앞 두자리**
             </ParamTree>
@@ -1079,7 +1079,7 @@ KCP 기준으로 작성한 예시 코드는 아래와 같습니다.
 
         **구매자 연락처**
 
-      - `email`<mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - `email` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
         **구매자 이메일**
     </ParamTree>
@@ -1193,7 +1193,7 @@ KCP 기준으로 작성한 예시 코드는 아래와 같습니다.
 
         **구매자 연락처**
 
-      - `email`<mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - `email` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
         **구매자 이메일**
     </ParamTree>
@@ -1315,7 +1315,7 @@ KCP 기준으로 작성한 예시 코드는 아래와 같습니다.
 
             **구매자 연락처**
 
-          - `email`<mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+          - `email` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
             **구매자 이메일**
         </ParamTree>

--- a/src/routes/(root)/opi/ko/integration/pg/v2/kcp-v2.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v2/kcp-v2.mdx
@@ -99,45 +99,45 @@ KCP 기준으로 작성한 예시 코드는 아래와 같습니다.
 ### 주요 파라미터
 
 <ParamTree>
-  - `storeId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - storeId: string
 
     **스토어 아이디**
 
     포트원 계정에 생성된 상점을 식별하는 고유한 값으로 관리자 콘솔에서 확인할 수 있습니다.
 
-  - `paymentId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - paymentId: string
 
     **고객사 주문 고유 번호**
 
     고객사에서 채번하는 주문 고유 번호로 매번 고유하게 채번되어야 합니다. 이미 승인 완료된 `paymentId`로 결제를 시도하는 경우 에러가 발생합니다.
     KCP의 경우 최대 40자 까지 허용합니다.
 
-  - `orderName` <mark style="color:red;">\*</mark> <mark style="color:green;">**string**</mark>
+  - orderName: string
 
     **주문명**
 
     주문명으로 고객사에서 자유롭게 입력합니다.
     KCP의 경우 최대 100Byte까지 허용합니다.
 
-  - `channelKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - channelKey: string
 
     **채널 키**
 
     포트원 콘솔 내 \[연동 관리] > \[연동 정보] > \[채널 관리] 화면에서 채널 추가 시 생성되는 값입니다. 결제 호출 시 채널을 지정할 때 사용됩니다.
 
-  - `totalAmount` <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
+  - totalAmount: number
 
     **결제 금액**
 
     결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
 
-  - `currency` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - currency: string
 
     **결제 통화**
 
     결제통화로 원화 결제 시 `KRW`로 입력해야 합니다.
 
-  - `payMethod` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - payMethod: string
 
     **결제수단 구분코드**
 
@@ -149,76 +149,76 @@ KCP 기준으로 작성한 예시 코드는 아래와 같습니다.
     - 휴대폰 소액결제 : `MOBILE`
     - 간편 결제 : `EASY_PAY`
 
-  - `customer` <mark style="color:blue;">**object**</mark>
+  - customer?: object
 
     **고객 정보**
 
     <ParamTree>
-      - `fullName` <mark style="color:green;">**string**</mark>
+      - fullName?: string
 
         **구매자 전체 이름**
 
-      - `firstName` <mark style="color:green;">**string**</mark>
+      - firstName?: string
 
         **구매자 이름**
 
-      - `lastName` <mark style="color:green;">**string**</mark>
+      - lastName?: string
 
         **구매자 성**
 
-      - `phoneNumber` <mark style="color:green;">**string**</mark>
+      - phoneNumber?: string
 
         **구매자 연락처**
 
-      - `email` <mark style="color:green;">**string**</mark>
+      - email?: string
 
         **구매자 이메일**
     </ParamTree>
 
-  - `bypass` <mark style="color:blue;">**oneof object**</mark>
+  - bypass?: oneof object
 
     **PG사 결제창 호출 시 PG사로 그대로 bypass할 파라미터들의 모음**
 
     <ParamTree>
-      - `kcp_v2` <mark style="color:blue;">**object**</mark>
+      - kcp\_v2?: object
 
         **KCP에서 제공하는 파라미터 모음**
 
         <ParamTree>
-          - `site_logo` <mark style="color:green;">**string**</mark>
+          - site\_logo?: string
 
             **결제창에 삽입할 메인 로고 url**
 
             - 결제창 왼쪽 상단에 표시됩니다.
             - 이미지 사이즈는 150\*50 미만으로 설정해야 하며, GIF, JPG 파일만 지원됩니다.
 
-          - `skin_indx` <mark style="color:green;">**integer**</mark>
+          - skin\_indx?: integer
 
             **결제창 색상**
 
             - PC로 결제창 호출 시 결제창 색상을 변경합니다.
             - 1\~12까지 설정 가능합니다.
 
-          - `kcp_pay_title` <mark style="color:green;">**string**</mark>
+          - kcp\_pay\_title?: string
 
             **결제창 상단 문구**
 
             - 결제창의 상단 문구를 변경합니다.
 
-          - `shop_user_id` <mark style="color:green;">**string**</mark>
+          - shop\_user\_id?: string
 
             **기관에 따라 리스크 관리 조치를 위한 쇼핑몰 관리 ID**
 
             - 상품권, 휴대폰 결제 시 필수로 입력해야 합니다.
 
-          - `site_name` <mark style="color:green;">**string**</mark>
+          - site\_name?: string
 
             **카드사 다이렉트 호출 시 결제창에 표기될 상호명**
 
             - PC의 경우 신한, 현대, 삼성, 농협, 하나, 외환, 롯데, 씨티, 우리카드사에 대해 다이렉트 호출 시 필수로 입력해야 합니다.
             - 모바일의 경우 필수로 입력해야 합니다.
 
-          - `disp_tax_yn` <mark style="color:green;">**string**</mark>
+          - disp\_tax\_yn?: string
 
             **결제창 현금영수증 노출 여부**
 
@@ -228,7 +228,7 @@ KCP 기준으로 작성한 예시 코드는 아래와 같습니다.
             - `R`: 소득공제로 노출
             - `E`: 지출증빙으로 노출
 
-          - `deli_term` <mark style="color:green;">**string**</mark>
+          - deli\_term?: string
 
             **에스크로 결제 예상 배송 소요일**
 
@@ -539,78 +539,78 @@ KCP 기준으로 작성한 예시 코드는 아래와 같습니다.
 <br />
 
 <ParamTree>
-  - `storeId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - storeId: string
 
     **스토어 아이디**
 
     포트원 계정에 생성된 상점을 식별하는 고유한 값으로 관리자 콘솔에서 확인할 수 있습니다.
 
-  - `channelKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - channelKey: string
 
     **채널 키**
 
     포트원 콘솔 내 \[연동 관리] > \[연동 정보] > \[채널 관리] 화면에서 채널 추가 시 생성되는 값입니다. 결제 호출 시 채널을 지정할 때 사용됩니다.
 
-  - `billingKeyMethod` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - billingKeyMethod: string
 
     **빌링키 발급수단**
 
     KCP는 빌링키 발급 수단으로 카드만을 지원하므로 해당 파라미터는 `CARD`로 고정해야 합니다.
 
-  - `issueId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - issueId: string
 
     **빌링키 발급 건 고유 ID**
 
     - 고객사에서 채번하여 사용해야 합니다.
     - KCP의 경우 필수 입력해야 합니다. // 추후 수정 필요, 포트원 내부 채번으로 수정할 예정
 
-  - `issueName` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - issueName: string
 
     **빌링키 발급 시 결제창에 표시되는 제목**
 
     - 모바일 발급의 경우 필수 입력해야 합니다.
 
-  - `customer` <mark style="color:blue;">**object**</mark>
+  - customer?: object
 
     **고객 정보**
 
     <ParamTree>
-      - `fullName` <mark style="color:green;">**string**</mark>
+      - fullName?: string
 
         **구매자 전체 이름**
 
-      - `firstName` <mark style="color:green;">**string**</mark>
+      - firstName?: string
 
         **구매자 이름**
 
-      - `lastName` <mark style="color:green;">**string**</mark>
+      - lastName?: string
 
         **구매자 성**
 
-      - `phoneNumber` <mark style="color:green;">**string**</mark>
+      - phoneNumber?: string
 
         **구매자 연락처**
 
-      - `email` <mark style="color:green;">**string**</mark>
+      - email?: string
 
         **구매자 이메일**
     </ParamTree>
 
-  - `offerPeriod` <mark style="color:blue;">**object**</mark>
+  - offerPeriod?: object
 
     **제공 기간**
 
-  - `bypass` <mark style="color:blue;">**oneof object**</mark>
+  - bypass?: oneof object
 
     **PG사 결제창 호출 시 PG사로 그대로 bypass할 파라미터들의 모음**
 
     <ParamTree>
-      - `kcp_v2` <mark style="color:blue;">**object**</mark>
+      - kcp\_v2?: object
 
         **KCP에서 제공하는 파라미터 모음**
 
         <ParamTree>
-          - `batch_soc_choice` <mark style="color:green;">**'percard' | 'cocard'**</mark>
+          - batch\_soc\_choice?: 'percard' | 'cocard'
 
             **결제창에서 주민번호/사업자 번호 고정여부 설정**
 
@@ -727,101 +727,101 @@ KCP 기준으로 작성한 예시 코드는 아래와 같습니다.
 ### 주요 파라미터
 
 <ParamTree>
-  - `paymentId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - paymentId: string
 
     **고객사 주문 고유 번호**
 
     고객사에서 채번하는 주문 고유 번호로 매번 고유하게 채번되어야 합니다. 이미 승인 완료된 `paymentId`로 결제를 시도하는 경우 에러가 발생합니다.
     KCP의 경우 최대 40자까지 허용합니다.
 
-  - `orderName` <mark style="color:red;">\*</mark> <mark style="color:green;">**string**</mark>
+  - orderName: string
 
     **주문명**
 
     주문명으로 고객사에서 자유롭게 입력합니다.
     KCP의 경우 최대 100 바이트까지 허용합니다.
 
-  - `channelKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - channelKey: string
 
     **채널 키**
 
     포트원 콘솔 내 \[연동 관리] > \[연동 정보] > \[채널 관리] 화면에서 채널 추가 시 생성되는 값입니다. 결제 호출 시 채널을 지정할 때 사용됩니다.
 
-  - `amount` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+  - amount: object
 
     **결제 금액**
 
     <ParamTree>
-      - `total` <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
+      - total: number
 
         **총 결제 금액**
 
         결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
 
-      - `taxFree` <mark style="color:purple;">**number**</mark>
+      - taxFree?: number
 
         **면세액**
 
         결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
     </ParamTree>
 
-  - `currency` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - currency: string
 
     **결제 통화**
 
     결제통화로 원화 결제 시 `KRW`로 입력해야 합니다.
 
-  - `method` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+  - method: object
 
     **결제수단 정보**
 
     <ParamTree>
-      - `virtualAccount` <mark style="color:blue;">**object**</mark>
+      - virtualAccount?: object
 
         **가상계좌 결제 시 파라미터**
 
         <ParamTree>
-          - `bank` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+          - bank: string
 
             **발급 은행**
 
             - 은행코드는 ENUM으로 정의되어 있습니다.
             - [BANK ENUM 바로가기](/api/rest-v2/type-def#Bank)
 
-          - `expiry` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+          - expiry: object
 
             **입금 만료 기한**
             `validHours` 또는 `dueDate` 필드 중 하나를 지정합니다.
 
             <ParamTree>
-              - `validHours` <mark style="color:purple;">**integer**</mark>
+              - validHours?: integer
 
                 **유효 시간**
 
-              - `dueDate` <mark style="color:green;">**string**</mark>
+              - dueDate?: string
 
                 **만료 시점**
 
                 시간은 RFC 3339 date-time 형식으로 입력해야 합니다.
             </ParamTree>
 
-          - `option` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+          - option: object
 
             **가상계좌 발급 방식**
 
             <ParamTree>
-              - `type` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+              - type: string
 
                 **가상계좌 발급 유형**
                 회전식 가상계좌만 지원하므로 `NORMAL`로 입력합니다.
             </ParamTree>
 
-          - `cashReceipt` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+          - cashReceipt: object
 
             **현금영수증 정보**
 
             <ParamTree>
-              - `type` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+              - type: string
 
                 **발급 유형**
                 `PERSONAL` 또는 `CORPORATE`로 입력합니다.
@@ -829,7 +829,7 @@ KCP 기준으로 작성한 예시 코드는 아래와 같습니다.
                 - 소득공제용 : `PERSONAL`
                 - 지출증빙용 : `CORPORATE`
 
-              - `customerIdentityNumber` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+              - customerIdentityNumber: string
 
                 **현금영수증 식별 번호**
 
@@ -838,75 +838,75 @@ KCP 기준으로 작성한 예시 코드는 아래와 같습니다.
             </ParamTree>
         </ParamTree>
 
-      - `card` <mark style="color:blue;">**object**</mark>
+      - card?: object
 
         **카드 결제 시 파라미터**
 
         <ParamTree>
-          - `credential` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+          - credential: string
 
             **인증 관련 정보**
 
             <ParamTree>
-              - `number` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+              - number: object
 
                 **카드 번호**
 
-              - `expiryYear` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+              - expiryYear: object
 
                 **유효 기간 만료 연도 (YY 형식 ex. 24)**
 
-              - `expiryMonth` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+              - expiryMonth: string
 
                 **유효기간 만료 월 (MM 형식 ex. 05)**
 
-              - `birthOrBusinessRegistrationNumber` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+              - birthOrBusinessRegistrationNumber: string
 
                 **생년월일 또는 사업자 등록 번호**
 
-              - `passwordTwoDigits` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+              - passwordTwoDigits: string
 
                 **비밀번호 앞 두자리**
             </ParamTree>
         </ParamTree>
     </ParamTree>
 
-  - `customer` <mark style="color:blue;">**object**</mark>
+  - customer?: object
 
     **고객 정보**
 
     <ParamTree>
-      - `name` <mark style="color:blue;">**object**</mark>
+      - name?: object
 
         **고객 이름**
 
         - full 또는 separated 중 하나를 입력할 수 있습니다.
 
           <ParamTree>
-            - `full` <mark style="color:green;">**string**</mark>
+            - full?: string
 
               **한 줄 이름 형식 (ex. 김포트)**
 
-            - `separated` <mark style="color:blue;">**object**</mark>
+            - separated?: object
 
               **분리된 이름**
 
               <ParamTree>
-                - `first` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+                - first: string
 
                   **이름**
 
-                - `last` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+                - last: string
 
                   **성**
               </ParamTree>
           </ParamTree>
 
-      - `phoneNumber` <mark style="color:green;">**string**</mark>
+      - phoneNumber?: string
 
         **구매자 연락처**
 
-      - `email` <mark style="color:green;">**string**</mark>
+      - email?: string
 
         **구매자 이메일**
     </ParamTree>
@@ -1002,43 +1002,43 @@ KCP 기준으로 작성한 예시 코드는 아래와 같습니다.
 ### 주요 파라미터
 
 <ParamTree>
-  - `channelKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - channelKey: string
 
     **채널 키**
 
     포트원 콘솔 내 \[연동 관리] > \[연동 정보] > \[채널 관리] 화면에서 채널 추가 시 생성되는 값입니다. 결제 호출 시 채널을 지정할 때 사용됩니다.
 
-  - `method` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+  - method: object
 
     **결제수단 정보**
 
-    - `card` <mark style="color:blue;">**object**</mark>
+    - card?: object
 
       **카드 빌링키 발급 시 파라미터**
 
       <ParamTree>
-        - `credential` <mark style="color:green;">**string**</mark>
+        - credential?: string
 
           **인증 관련 정보**
 
           <ParamTree>
-            - `number` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+            - number: object
 
               **카드 번호**
 
-            - `expiryYear` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+            - expiryYear: object
 
               **유효 기간 만료 연도 (YY 형식 ex. 24)**
 
-            - `expiryMonth` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+            - expiryMonth: string
 
               **유효기간 만료 월 (MM 형식 ex. 05)**
 
-            - `birthOrBusinessRegistrationNumber` <mark style="color:green;">**string**</mark>
+            - birthOrBusinessRegistrationNumber?: string
 
             - KCP의 경우 필수로 입력해야 합니다.
 
-            - `passwordTwoDigits` <mark style="color:green;">**string**</mark>
+            - passwordTwoDigits?: string
 
               **비밀번호 앞 두자리**
 
@@ -1046,40 +1046,40 @@ KCP 기준으로 작성한 예시 코드는 아래와 같습니다.
           </ParamTree>
       </ParamTree>
 
-  - `customer`  <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+  - customer: object
 
     **고객 정보**
 
     <ParamTree>
-      - `name` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+      - name: object
 
         **고객 이름**
 
         <ParamTree>
-          - `full` <mark style="color:green;">**string**</mark>
+          - full?: string
 
             **한 줄 이름 형식 (ex. 김포트)**
 
-          - `separated` <mark style="color:blue;">**object**</mark>
+          - separated?: object
 
             **분리된 이름**
 
             <ParamTree>
-              - `first` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+              - first: string
 
                 **이름**
 
-              - `last` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+              - last: string
 
                 **성**
             </ParamTree>
         </ParamTree>
 
-      - `phoneNumber` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - phoneNumber: string
 
         **구매자 연락처**
 
-      - `email` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - email: string
 
         **구매자 이메일**
     </ParamTree>
@@ -1121,84 +1121,84 @@ KCP 기준으로 작성한 예시 코드는 아래와 같습니다.
 ### 주요 파라미터
 
 <ParamTree>
-  - `paymentId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - paymentId: string
 
     **결제 주문 번호**
 
     - 고객사에서 채번하여 사용하는 주문번호로 고유한 값이여야 합니다.
     - URL path에 포함하여 요청해야 합니다.
 
-  - `billingKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - billingKey: string
 
     **빌링키 결제에 사용할 빌링키**
 
-  - `orderName`  <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - orderName: string
 
     **주문명**
 
-  - `amount` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+  - amount: object
 
     **결제 금액**
 
     <ParamTree>
-      - `total` <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
+      - total: number
 
         **총 결제 금액**
 
         결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
 
-      - `taxFree` <mark style="color:purple;">**number**</mark>
+      - taxFree?: number
 
         **면세액**
 
         결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
     </ParamTree>
 
-  - `currency` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - currency: string
 
     **결제 통화**
 
     결제통화로 원화 결제 시 `KRW`로 입력해야 합니다.
 
-  - `customer`  <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+  - customer: object
 
     **고객 정보**
 
     <ParamTree>
-      - `name` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+      - name: object
 
         **고객 이름**
 
         <ParamTree>
-          - `full` <mark style="color:green;">**string**</mark>
+          - full?: string
 
             **한 줄 이름 형식 (ex. 김포트)**
 
-          - `separated` <mark style="color:blue;">**object**</mark>
+          - separated?: object
 
             **분리된 이름**
 
             <ParamTree>
-              - `first` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+              - first: string
 
                 **이름**
 
-              - `last` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+              - last: string
 
                 **성**
             </ParamTree>
         </ParamTree>
 
-      - `phoneNumber` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - phoneNumber: string
 
         **구매자 연락처**
 
-      - `email` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - email: string
 
         **구매자 이메일**
     </ParamTree>
 
-  - `productCount` <mark style="color:purple;">**integer**</mark>
+  - productCount?: integer
 
     **상품 개수**
 </ParamTree>
@@ -1238,90 +1238,90 @@ KCP 기준으로 작성한 예시 코드는 아래와 같습니다.
 ### 주요 파라미터
 
 <ParamTree>
-  - `paymentId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - paymentId: string
 
     **결제 주문 번호**
 
     - 고객사에서 채번하여 사용하는 주문번호로 고유한 값이여야 합니다.
     - URL path에 포함하여 요청해야 합니다.
 
-  - `payment` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+  - payment: object
 
     **빌링키 결제 요청 입력정보**
 
     <ParamTree>
-      - `billingKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - billingKey: string
 
         **빌링키 결제에 사용할 빌링키**
 
-      - `orderName`  <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - orderName: string
 
         **주문명**
 
-      - `amount` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+      - amount: object
 
         **결제 금액**
 
         <ParamTree>
-          - `total` <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
+          - total: number
 
             **총 결제 금액**
 
             결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
 
-          - `taxFree` <mark style="color:purple;">**number**</mark>
+          - taxFree?: number
 
             **면세액**
 
             결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
         </ParamTree>
 
-      - `currency` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - currency: string
 
         **결제 통화**
 
         결제통화로 원화 결제 시 `KRW`로 입력해야 합니다.
 
-      - `customer`  <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+      - customer: object
 
         **고객 정보**
 
         <ParamTree>
-          - `name` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+          - name: object
 
             **고객 이름**
 
             <ParamTree>
-              - `full` <mark style="color:green;">**string**</mark>
+              - full?: string
 
                 **한 줄 이름 형식 (ex. 김포트)**
 
-              - `separated` <mark style="color:blue;">**object**</mark>
+              - separated?: object
 
                 **분리된 이름**
 
                 <ParamTree>
-                  - `first` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+                  - first: string
 
                     **이름**
 
-                  - `last` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+                  - last: string
 
                     **성**
                 </ParamTree>
             </ParamTree>
 
-          - `phoneNumber` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+          - phoneNumber: string
 
             **구매자 연락처**
 
-          - `email` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+          - email: string
 
             **구매자 이메일**
         </ParamTree>
     </ParamTree>
 
-  - `timeToPay` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - timeToPay: string
 
     **결제 예정 시점**
 </ParamTree>

--- a/src/routes/(root)/opi/ko/integration/pg/v2/kpn.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v2/kpn.mdx
@@ -88,43 +88,43 @@ function requestPayment() {
 ### 주요 파라미터
 
 <ParamTree>
-  - `storeId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - storeId: string
 
     **스토어 아이디**
 
     포트원 계정에 생성된 상점을 식별하는 고유한 값으로 관리자 콘솔에서 확인할 수 있습니다.
 
-  - `paymentId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - paymentId: string
 
     **고객사 주문 고유 번호**
 
     고객사에서 채번하는 주문 고유 번호로 매번 고유하게 채번되어야 합니다. 이미 승인 완료된 `paymentId`로 결제를 시도하는 경우 에러가 발생합니다.
 
-  - `orderName` <mark style="color:red;">\*</mark> <mark style="color:green;">**string**</mark>
+  - orderName: string
 
     **주문명**
 
     주문명으로 고객사에서 자유롭게 입력합니다.
 
-  - `channelKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - channelKey: string
 
     **채널 키**
 
     포트원 콘솔 내 \[결제연동] > \[채널관리] 화면에서 채널 추가 시 생성되는 값입니다. 결제 호출 시 채널을 지정할 때 사용됩니다.
 
-  - `totalAmount` <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
+  - totalAmount: number
 
     **결제 금액**
 
     결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
 
-  - `currency` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - currency: string
 
     **결제 통화**
 
     결제통화로 원화 결제 시 `KRW`로 입력해야 합니다.
 
-  - `payMethod` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - payMethod: string
 
     **결제수단 구분코드**
 
@@ -136,17 +136,17 @@ function requestPayment() {
     - 휴대폰 소액결제 : `MOBILE`
     - 간편 결제 : `EASY_PAY`
 
-  - `bypass` <mark style="color:blue;">**object**</mark>
+  - bypass?: object
 
     **PG사 결제창 호출 시 PG사로 그대로 bypass할 파라미터들의 모음**
 
     <ParamTree>
-      - `kpn` <mark style="color:blue;">**object**</mark>
+      - kpn?: object
 
         **한국결제네트웍스(KPN)에서 제공하는 파라미터**
 
         <ParamTree>
-          - `CardSelect` <mark style="color:green;">**enum\[]**</mark>
+          - CardSelect?: enum\[]
 
             **일부 렌더링할 결제방식 목록**
 
@@ -458,47 +458,48 @@ function requestIssueBillingKey() {
 ### 주요 파라미터
 
 <ParamTree>
-  - `storeId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - storeId: string
 
     **스토어 아이디**
 
     포트원 계정에 생성된 상점을 식별하는 고유한 값으로 관리자 콘솔에서 확인할 수 있습니다.
 
-  - `channelKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - channelKey: string
 
     **채널 키**
 
     포트원 콘솔 내 \[결제연동] > \[채널관리] 화면에서 채널 추가 시 생성되는 값입니다. 결제 호출 시 채널을 지정할 때 사용됩니다.
 
-  - `billingKeyMethod` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - billingKeyMethod: string
 
     **빌링키 발급수단**
 
     한국결제네트웍스(KPN)는 빌링키 발급 수단으로 카드만을 지원하므로 해당 파라미터는 `CARD`로 고정해야 합니다.
 
-  - `customer` <mark style="color:blue;">**object**</mark>
+  - customer?: object
 
     **고객 정보**
 
     <ParamTree>
-      - `customerId` <mark style="color:green;">**string**</mark>
+      - customerId?: string
+
         **구매자 고유 ID**
 
         - 한국결제네트웍스(KPN)의 경우 구매자 ID를 필수로 입력해야 합니다.
 
-      - `fullName` <mark style="color:green;">**string**</mark>
+      - fullName?: string
 
         **구매자 전체 이름**
 
         - 한국결제네트웍스(KPN)의 경우 `fullName` 혹은 (`firstName` + `lastName`)을 필수로 입력해야 합니다.
 
-      - `firstName` <mark style="color:green;">**string**</mark>
+      - firstName?: string
 
         **구매자 이름**
 
         - 한국결제네트웍스(KPN)의 경우 `fullName` 혹은 (`firstName` + `lastName`)을 필수로 입력해야 합니다.
 
-      - `lastName` <mark style="color:green;">**string**</mark>
+      - lastName?: string
 
         **구매자 성**
 
@@ -584,87 +585,87 @@ const issueResponse = await axios({
 ### 주요 파라미터
 
 <ParamTree>
-  - `paymentId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - paymentId: string
 
     **고객사 주문 고유 번호**
 
     고객사에서 채번하는 주문 고유 번호로 매번 고유하게 채번되어야 합니다. 이미 승인 완료된 `paymentId`로 결제를 시도하는 경우 에러가 발생합니다.
 
-  - `orderName` <mark style="color:red;">\*</mark> <mark style="color:green;">**string**</mark>
+  - orderName: string
 
     **주문명**
 
     주문명으로 고객사에서 자유롭게 입력합니다.
 
-  - `channelKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - channelKey: string
 
     **채널 키**
 
     포트원 콘솔 내 \[결제연동] > \[채널관리] 화면에서 채널 추가 시 생성되는 값입니다. 결제 호출 시 채널을 지정할 때 사용됩니다.
 
-  - `amount` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+  - amount: object
 
     **결제 금액**
 
     <ParamTree>
-      - `total` <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
+      - total: number
 
         **총 결제 금액**
 
         결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
 
-      - `taxFree` <mark style="color:purple;">**number**</mark>
+      - taxFree?: number
 
         **면세액**
 
         결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
     </ParamTree>
 
-  - `currency` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - currency: string
 
     **결제 통화**
 
     결제통화로 원화 결제 시 `KRW`로 입력해야 합니다.
 
-  - `method` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+  - method: object
 
     **결제수단 정보**
 
     <ParamTree>
-      - `virtualAccount` <mark style="color:blue;">**object**</mark>
+      - virtualAccount?: object
 
         **가상계좌 결제 시 파라미터**
 
         <ParamTree>
-          - `bank` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+          - bank: string
 
             **발급 은행**
 
             - 은행코드는 ENUM으로 정의되어 있습니다.
             - [BANK ENUM 바로가기](/api/rest-v2/type-def#Bank)
 
-          - `expiry` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+          - expiry: object
 
             **입금 만료 기한**
 
             <ParamTree>
-              - `validHours` <mark style="color:purple;">**integer**</mark>
+              - validHours?: integer
 
                 **유효 시간**
 
-              - `dueDate` <mark style="color:green;">**string**</mark>
+              - dueDate?: string
 
                 **만료 시점**
 
                 시간은 ISO8601 형식으로 입력해야 합니다.
             </ParamTree>
 
-          - `option` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+          - option: object
 
             **가상계좌 발급 방식**
 
             <ParamTree>
-              - `type` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+              - type: string
 
                 **가상계좌 발급 유형**
 
@@ -677,12 +678,12 @@ const issueResponse = await axios({
                 회전식 가상계좌는 일반적으로 사용되는 방식이며 PG사에서 직접 채번한 가상계좌번호를 사용합니다.
             </ParamTree>
 
-          - `cashReceipt` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+          - cashReceipt: object
 
             **현금영수증 정보**
 
             <ParamTree>
-              - `type` <mark style="color:red;">**\***</mark><mark style="color:green;">**string**</mark>
+              - type: string
 
                 **발급 유형**
 
@@ -692,7 +693,7 @@ const issueResponse = await axios({
                 - 지출증빙용 : `CORPORATE`
                 - 미발행 : `NO_RECEIPT`
 
-              - `customerIdentityNumber` <mark style="color:red;">**\***</mark><mark style="color:green;">**string**</mark>
+              - customerIdentityNumber: string
 
                 **현금영수증 식별 번호**
 
@@ -701,68 +702,68 @@ const issueResponse = await axios({
             </ParamTree>
         </ParamTree>
 
-      - `card` <mark style="color:blue;">**object**</mark>
+      - card?: object
 
         **카드 결제 시 파라미터**
 
         <ParamTree>
-          - `credential` <mark style="color:red;">**\***</mark><mark style="color:green;">**string**</mark>
+          - credential: string
 
             **인증 관련 정보**
 
             <ParamTree>
-              - `number` <mark style="color:red;">**\***</mark><mark style="color:blue;">**object**</mark>
+              - number: object
 
                 **카드 번호**
 
-              - `expiryYear` <mark style="color:red;">**\***</mark><mark style="color:blue;">**object**</mark>
+              - expiryYear: object
 
                 **유효 기간 만료 연도 (YY 형식 ex. 24)**
 
-              - `expiryMonth` <mark style="color:red;">**\***</mark><mark style="color:green;">**string**</mark>
+              - expiryMonth: string
 
                 **유효기간 만료 월 (MM 형식 ex. 05)**
 
-              - `birthOrBusinessRegistrationNumber` <mark style="color:green;">**string**</mark>
+              - birthOrBusinessRegistrationNumber?: string
 
                 **생년월일 6자리 또는 사업자 등록 번호**
 
-              - `passwordTwoDigits` <mark style="color:green;">**string**</mark>
+              - passwordTwoDigits?: string
 
                 **비밀번호 앞 두자리**
             </ParamTree>
         </ParamTree>
 
-      - `customer` <mark style="color:blue;">**object**</mark>
+      - customer?: object
 
         **고객 정보**
 
         <ParamTree>
-          - `name` <mark style="color:blue;">**object**</mark>
+          - name?: object
 
             **고객 이름**
 
             <ParamTree>
-              - `full` <mark style="color:green;">**string**</mark>
+              - full?: string
 
                 **한 줄 이름 형식 (ex. 김포트)**
 
-              - `separated` <mark style="color:blue;">**object**</mark>
+              - separated?: object
 
                 **분리된 이름**
 
                 <ParamTree>
-                  - `first` <mark style="color:red;">**\***</mark><mark style="color:green;">**string**</mark>
+                  - first: string
 
                     **이름**
 
-                  - `last` <mark style="color:red;">**\***</mark><mark style="color:green;">**string**</mark>
+                  - last: string
 
                     **성**
                 </ParamTree>
             </ParamTree>
 
-          - `phoneNumber` <mark style="color:green;">**string**</mark>
+          - phoneNumber?: string
 
             **구매자 연락처**
         </ParamTree>
@@ -846,80 +847,80 @@ const issueResponse = await axios({
 ### 주요 파라미터
 
 <ParamTree>
-  - `channelKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - channelKey: string
 
     **채널 키**
 
     포트원 콘솔 내 \[결제연동] > \[채널관리] 화면에서 채널 추가 시 생성되는 값입니다. 결제 호출 시 채널을 지정할 때 사용됩니다.
 
-  - `method` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+  - method: object
 
     **결제수단 정보**
 
-    - `card` <mark style="color:blue;">**object**</mark>
+    - card?: object
 
       **카드 빌링키 발급 시 파라미터**
 
       <ParamTree>
-        - `credential` <mark style="color:red;">**\***</mark><mark style="color:green;">**string**</mark>
+        - credential: string
 
           **인증 관련 정보**
 
           <ParamTree>
-            - `number` <mark style="color:red;">**\***</mark><mark style="color:blue;">**object**</mark>
+            - number: object
 
               **카드 번호**
 
-            - `expiryYear` <mark style="color:red;">**\***</mark><mark style="color:blue;">**object**</mark>
+            - expiryYear: object
 
               **유효 기간 만료 연도 (YY 형식 ex. 24)**
 
-            - `expiryMonth` <mark style="color:red;">**\***</mark><mark style="color:green;">**string**</mark>
+            - expiryMonth: string
 
               **유효기간 만료 월 (MM 형식 ex. 05)**
 
-            - `birthOrBusinessRegistrationNumber` <mark style="color:red;">**\***</mark><mark style="color:green;">**string**</mark>
+            - birthOrBusinessRegistrationNumber: string
 
               **생년월일 또는 사업자 등록 번호**
 
-            - `passwordTwoDigits` <mark style="color:red;">**\***</mark><mark style="color:green;">**string**</mark>
+            - passwordTwoDigits: string
 
               **비밀번호 앞 두자리**
           </ParamTree>
       </ParamTree>
 
-  - `customer`  <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+  - customer: object
 
     **고객 정보**
 
     <ParamTree>
-      - `name` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+      - name: object
 
         **고객 이름**
 
         - 한국결제네트웍스(KPN)의 경우 full 혹은 separated를 필수로 입력해야 합니다.
 
           <ParamTree>
-            - `full` <mark style="color:green;">**string**</mark>
+            - full?: string
 
               **한 줄 이름 형식 (ex. 김포트)**
 
-            - `separated` <mark style="color:blue;">**object**</mark>
+            - separated?: object
 
               **분리된 이름**
 
               <ParamTree>
-                - `first` <mark style="color:green;">**string**</mark>
+                - first?: string
 
                   **이름**
 
-                - `last` <mark style="color:green;">**string**</mark>
+                - last?: string
 
                   **성**
               </ParamTree>
           </ParamTree>
 
-      - `phoneNumber` <mark style="color:green;">**string**</mark>
+      - phoneNumber?: string
 
         **구매자 연락처**
     </ParamTree>
@@ -970,79 +971,79 @@ const response = await axios({
 ### 주요 파라미터
 
 <ParamTree>
-  - `paymentId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - paymentId: string
 
     **결제 주문 번호**
 
     - 고객사에서 채번하여 사용하는 주문번호로 고유한 값이여야 합니다.
     - URL path에 포함하여 요청해야 합니다.
 
-  - `billingKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - billingKey: string
 
     **빌링키 결제에 사용할 빌링키**
 
-  - `orderName`  <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - orderName: string
 
     **주문명**
 
-  - `amount` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+  - amount: object
 
     **결제 금액**
 
     <ParamTree>
-      - `total` <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
+      - total: number
 
         **총 결제 금액**
 
         결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
 
-      - `taxFree` <mark style="color:purple;">**number**</mark>
+      - taxFree?: number
 
         **면세액**
 
         결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
     </ParamTree>
 
-  - `currency` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - currency: string
 
     **결제 통화**
 
     결제통화로 원화 결제 시 `KRW`로 입력해야 합니다.
 
-  - `customer` <mark style="color:blue;">**object**</mark>
+  - customer?: object
 
     **고객 정보**
 
     <ParamTree>
-      - `name` <mark style="color:blue;">**object**</mark>
+      - name?: object
 
         **고객 이름**
 
         <ParamTree>
-          - `full` <mark style="color:green;">**string**</mark>
+          - full?: string
 
             **한 줄 이름 형식 (ex. 김포트)**
 
-          - `separated` <mark style="color:blue;">**object**</mark>
+          - separated?: object
 
             **분리된 이름**
 
             <ParamTree>
-              - `first` <mark style="color:green;">**string**</mark>
+              - first?: string
 
                 **이름**
 
-              - `last` <mark style="color:green;">**string**</mark>
+              - last?: string
 
                 **성**
             </ParamTree>
         </ParamTree>
 
-      - `phoneNumber` <mark style="color:green;">**string**</mark>
+      - phoneNumber?: string
 
         **구매자 연락처**
 
-      - `email` <mark style="color:green;">**string**</mark>
+      - email?: string
 
         **구매자 이메일**
     </ParamTree>
@@ -1080,91 +1081,91 @@ const response = await axios({
 ### 주요 파라미터
 
 <ParamTree>
-  - `paymentId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - paymentId: string
 
     **결제 주문 번호**
 
     - 고객사에서 채번하여 사용하는 주문번호로 고유한 값이여야 합니다.
     - URL path에 포함하여 요청해야 합니다.
 
-  - `payment` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+  - payment: object
 
     **빌링키 결제 요청 입력정보**
 
     <ParamTree>
-      - `billingKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - billingKey: string
 
         **빌링키 결제에 사용할 빌링키**
 
-      - `orderName`  <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - orderName: string
 
         **주문명**
 
-      - `amount` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+      - amount: object
 
         **결제 금액**
 
         <ParamTree>
-          - `total` <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
+          - total: number
 
             **총 결제 금액**
 
             결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
 
-          - `taxFree` <mark style="color:purple;">**number**</mark>
+          - taxFree?: number
 
             **면세액**
 
             결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
         </ParamTree>
 
-      - `currency` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - currency: string
 
         **결제 통화**
 
         결제통화로 원화 결제 시 `KRW`로 입력해야 합니다.
     </ParamTree>
 
-  - `timeToPay` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - timeToPay: string
 
     **결제 예정 시점**
 
-  - `customer`  <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+  - customer: object
 
     **고객 정보**
 
     <ParamTree>
-      - `name` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+      - name: object
 
         **고객 이름**
 
         - 한국결제네트웍스(KPN)의 경우 full 혹은 separated를 필수로 입력해야 합니다.
 
           <ParamTree>
-            - `full` <mark style="color:green;">**string**</mark>
+            - full?: string
 
               **한 줄 이름 형식 (ex. 김포트)**
 
-            - `separated` <mark style="color:blue;">**object**</mark>
+            - separated?: object
 
               **분리된 이름**
 
               <ParamTree>
-                - `first` <mark style="color:green;">**string**</mark>
+                - first?: string
 
                   **이름**
 
-                - `last` <mark style="color:green;">**string**</mark>
+                - last?: string
 
                   **성**
               </ParamTree>
           </ParamTree>
 
-      - `phoneNumber` <mark style="color:green;">**string**</mark>
+      - phoneNumber?: string
 
         **구매자 연락처**
 
-      - `email` <mark style="color:green;">**string**</mark>
+      - email?: string
 
         **구매자 이메일**
     </ParamTree>

--- a/src/routes/(root)/opi/ko/integration/pg/v2/ksnet.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v2/ksnet.mdx
@@ -172,37 +172,47 @@ KSNET 기준으로 작성한 예시 코드는 아래와 같습니다.
 ## 주요 파라미터
 
 <ParamTree>
-  - `storeId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - storeId: string
+
     고객사의 상점을 식별하는 고유한 값입니다.
 
-  - `paymentId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - paymentId: string
+
     고객사가 채번하는 주문 고유 번호로 매번 고유하게 채번되어야 합니다.
 
-  - `orderName` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - orderName: string
+
     주문명으로 고객사에서 자유롭게 입력합니다.
 
-  - `channelKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - channelKey: string
+
     콘솔 결제 연동 화면에서 채널 연동 시 생성된 채널 키로 호출하고자 하는 채널을 지정합니다.
 
-  - `totalAmount` <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
+  - totalAmount: number
+
     결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를
     고려한 number 형식만 허용됩니다.
 
-  - `currency` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - currency: string
+
     결제통화로 원화 결제를 원할 시 `KRW`로 입력해야 합니다. KSNET의 경우 `KRW`와 `USD`를 지원합니다.
 
-  - `payMethod` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - payMethod: string
+
     결제수단을 구분하는 코드로 원하는 결제수단 값을 입력해야 합니다.
 
-  - `customer.fullName` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - customer.fullName: string
+
     구매자 이름으로 KSNET의 경우 필수로 입력해야 합니다.
 
-  - `taxFreeAmount` <mark style="color:purple;">**number**</mark>
+  - taxFreeAmount?: number
+
     면세 금액으로 KSNET과 상점아이디 계약시 복합과세로 계약한 경우 면세 처리를 위해 면세금액을
     반드시 입력해야 합니다. 면세금액 미 입력 시 면세금액은 0원으로 자동 처리되며, 결제 요청 금액은
     모두 과세 처리 되오니 이 점 유의하시기 바랍니다.
 
-  - `card.cardCompany` <mark style="color:green;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - card.cardCompany: string
+
     카드사 다이렉트 호출 시 결제대행사의 통합결제창을 거치지 않고, 지정한 카드사의 결제화면이 호출됩니다.
     카드사별로 지원하는 기능이 상이함으로, 카드 다이렉트 호출 유의사항을 확인해 주세요.
 </ParamTree>

--- a/src/routes/(root)/opi/ko/integration/pg/v2/ksnet.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v2/ksnet.mdx
@@ -7,6 +7,7 @@ versionVariants:
 ---
 
 import Details from "~/components/gitbook/Details";
+import ParamTree from "~/components/gitbook/ParamTree";
 import Tabs from "~/components/gitbook/Tabs";
 
 ## 채널 설정하기
@@ -170,39 +171,41 @@ KSNET 기준으로 작성한 예시 코드는 아래와 같습니다.
 
 ## 주요 파라미터
 
-- `storeId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-  - 고객사의 상점을 식별하는 고유한 값입니다.
+<ParamTree>
+  - `storeId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+    고객사의 상점을 식별하는 고유한 값입니다.
 
-- `paymentId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-  - 고객사가 채번하는 주문 고유 번호로 매번 고유하게 채번되어야 합니다.
+  - `paymentId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+    고객사가 채번하는 주문 고유 번호로 매번 고유하게 채번되어야 합니다.
 
-- `orderName` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-  - 주문명으로 고객사에서 자유롭게 입력합니다.
+  - `orderName` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+    주문명으로 고객사에서 자유롭게 입력합니다.
 
-- `channelKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-  - 콘솔 결제 연동 화면에서 채널 연동 시 생성된 채널 키로 호출하고자 하는 채널을 지정합니다.
+  - `channelKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+    콘솔 결제 연동 화면에서 채널 연동 시 생성된 채널 키로 호출하고자 하는 채널을 지정합니다.
 
-- `totalAmount` <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
-  - 결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를
+  - `totalAmount` <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
+    결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를
     고려한 number 형식만 허용됩니다.
 
-- `currency` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-  - 결제통화로 원화 결제를 원할 시 `KRW`로 입력해야 합니다. KSNET의 경우 `KRW`와 `USD`를 지원합니다.
+  - `currency` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+    결제통화로 원화 결제를 원할 시 `KRW`로 입력해야 합니다. KSNET의 경우 `KRW`와 `USD`를 지원합니다.
 
-- `payMethod` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-  - 결제수단을 구분하는 코드로 원하는 결제수단 값을 입력해야 합니다.
+  - `payMethod` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+    결제수단을 구분하는 코드로 원하는 결제수단 값을 입력해야 합니다.
 
-- `customer.fullName` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-  - 구매자 이름으로 KSNET의 경우 필수로 입력해야 합니다.
+  - `customer.fullName` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+    구매자 이름으로 KSNET의 경우 필수로 입력해야 합니다.
 
-- `taxFreeAmount` <mark style="color:purple;">**number**</mark>
-  - 면세 금액으로 KSNET과 상점아이디 계약시 복합과세로 계약한 경우 면세 처리를 위해 면세금액을
+  - `taxFreeAmount` <mark style="color:purple;">**number**</mark>
+    면세 금액으로 KSNET과 상점아이디 계약시 복합과세로 계약한 경우 면세 처리를 위해 면세금액을
     반드시 입력해야 합니다. 면세금액 미 입력 시 면세금액은 0원으로 자동 처리되며, 결제 요청 금액은
     모두 과세 처리 되오니 이 점 유의하시기 바랍니다.
 
-- `card.cardCompany` <mark style="color:green;">**\***</mark> <mark style="color:green;">**string**</mark>
-  - 카드사 다이렉트 호출 시 결제대행사의 통합결제창을 거치지 않고, 지정한 카드사의 결제화면이 호출됩니다.
-  - 카드사별로 지원하는 기능이 상이함으로, 카드 다이렉트 호출 유의사항을 확인해 주세요.
+  - `card.cardCompany` <mark style="color:green;">**\***</mark> <mark style="color:green;">**string**</mark>
+    카드사 다이렉트 호출 시 결제대행사의 통합결제창을 거치지 않고, 지정한 카드사의 결제화면이 호출됩니다.
+    카드사별로 지원하는 기능이 상이함으로, 카드 다이렉트 호출 유의사항을 확인해 주세요.
+</ParamTree>
 
 ## 유의할 파라미터 - SDK
 

--- a/src/routes/(root)/opi/ko/integration/pg/v2/nice-v2.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v2/nice-v2.mdx
@@ -7,6 +7,7 @@ versionVariants:
 ---
 
 import Details from "~/components/gitbook/Details";
+import ParamTree from "~/components/gitbook/ParamTree";
 import Tabs from "~/components/gitbook/Tabs";
 
 ## 채널 설정하기
@@ -59,14 +60,18 @@ import Tabs from "~/components/gitbook/Tabs";
 
 ### 주요 파라미터
 
-- `storeId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-  - 포트원 계정에 생성된 상점을 식별하는 고유한 값으로 관리자 콘솔에서 확인할 수 있습니다.
+<ParamTree>
+  - `storeId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
-- `paymentId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-  - 고객사에서 채번하는 주문 고유 번호로 매번 고유하게 채번되어야 합니다.
+    포트원 계정에 생성된 상점을 식별하는 고유한 값으로 관리자 콘솔에서 확인할 수 있습니다.
 
-- `orderName` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-  - 주문명으로 고객사에서 **40Byte** 이내로 자유롭게 입력합니다.
+  - `paymentId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+
+    고객사에서 채번하는 주문 고유 번호로 매번 고유하게 채번되어야 합니다.
+
+  - `orderName` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+
+    주문명으로 고객사에서 **40Byte** 이내로 자유롭게 입력합니다.
 
     <mark style="color:red;">**\***</mark>**특수문자 유의사항**
 
@@ -74,55 +79,68 @@ import Tabs from "~/components/gitbook/Tabs";
     - 사용 불가 : **% & | $ - + = \[ ]**
     - 사용 가능하나 권장하지 않음 : **( )**
 
-- `channelKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-  - 콘솔 결제 연동 화면에서 채널 연동 시 생성된 채널 키로 호출하고자 하는 채널을 지정합니다.
+  - `channelKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
-- `totalAmount` <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
-  - 결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
+    콘솔 결제 연동 화면에서 채널 연동 시 생성된 채널 키로 호출하고자 하는 채널을 지정합니다.
 
-- `currency` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-  - 결제통화로 원화 결제 시 `KRW`로 입력해야 합니다. 나이스페이먼츠의 경우 `KRW`와 `USD`를 지원합니다.
+  - `totalAmount` <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
 
-- `payMethod` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-  - 결제수단으로 결제하고자 하는 결제수단의 값을 입력해야 합니다.
+    결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
 
-- `taxFreeAmount` <mark style="color:purple;">**number**</mark>
-  - 면세금액으로 나이스페이먼츠와 상점아이디 계약시 지정금액 혹은 복합과세 방식으로 계약한 경우 면세 처리를 위해 면세금액을 반드시 입력해야 합니다.
+  - `currency` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
-면세금액 미 입력 시 면세금액은 0원으로 자동 처리되며, 결제 요청 금액은 모두 과세 처리 되오니 이 점 유의하시기 바랍니다.
+    결제통화로 원화 결제 시 `KRW`로 입력해야 합니다. 나이스페이먼츠의 경우 `KRW`와 `USD`를 지원합니다.
+
+  - `payMethod` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+
+    결제수단으로 결제하고자 하는 결제수단의 값을 입력해야 합니다.
+
+  - `taxFreeAmount` <mark style="color:purple;">**number**</mark>
+
+    면세금액으로 나이스페이먼츠와 상점아이디 계약시 지정금액 혹은 복합과세 방식으로 계약한 경우 면세 처리를 위해 면세금액을 반드시 입력해야 합니다.
+
+    면세금액 미 입력 시 면세금액은 0원으로 자동 처리되며, 결제 요청 금액은 모두 과세 처리 되오니 이 점 유의하시기 바랍니다.
+</ParamTree>
 
 ### 유의할 파라미터
 
 - `virtualAccount.accountExpiry`
-  - 가상계좌 발급 시 입금 기한은 필수로 입력해야 합니다.
+
+  가상계좌 발급 시 입금 기한은 필수로 입력해야 합니다.
 
 - `card.installment.monthOption.fixedMonth`
-  - 나이스페이먼츠는 **카드사 다이렉트 호출시 고정 할부 개월수를 필수로 입력**해야 합니다. 결제
-    금액이 할부 지원 금액 미만(대부분 50,000원이상 할부지원이나 카드사에 따라 상이함)인 경우 **할부
-    개월수를 0(일시불)으로 전달**해야 합니다.
+
+  나이스페이먼츠는 **카드사 다이렉트 호출시 고정 할부 개월수를 필수로 입력**해야 합니다. 결제
+  금액이 할부 지원 금액 미만(대부분 50,000원이상 할부지원이나 카드사에 따라 상이함)인 경우 **할부
+  개월수를 0(일시불)으로 전달**해야 합니다.
 
 - `productType`
-  - 휴대폰 소액 결제 시 실물/컨텐츠 여부(`productType`) 파라미터는 필수 입력입니다. 입력하지 않는
-    경우 "나이스페이 V2 휴대폰 소액결제시 상품 유형 파라미터는 필수 입력입니다." 라는 에러 메시지가
-    리턴되면서 결제창 호출에 실패하오니 유의하시기 바랍니다. 또한 상점아이디 설정과 실물/컨텐츠
-    여부가 불일치할 경우 "CPID미설정 오류입나다."라는 메시지가 리턴되며 결제창 호출에 실패하니
-    유의하시기 바랍니다.
+
+  휴대폰 소액 결제 시 실물/컨텐츠 여부(`productType`) 파라미터는 필수 입력입니다. 입력하지 않는
+  경우 "나이스페이 V2 휴대폰 소액결제시 상품 유형 파라미터는 필수 입력입니다." 라는 에러 메시지가
+  리턴되면서 결제창 호출에 실패하오니 유의하시기 바랍니다. 또한 상점아이디 설정과 실물/컨텐츠
+  여부가 불일치할 경우 "CPID미설정 오류입나다."라는 메시지가 리턴되며 결제창 호출에 실패하니
+  유의하시기 바랍니다.
 
 - `giftCertificate.certificateType`
-  - 나이스페이먼츠는 컬쳐랜드만 지원하므로 상품권 결제시 항상 `CULTURELAND`로 지정해주어야 합니다.
+
+  나이스페이먼츠는 컬쳐랜드만 지원하므로 상품권 결제시 항상 `CULTURELAND`로 지정해주어야 합니다.
 
 - `bypass.nice_v2.MallUserID`
-  - 나이스페이먼츠 상품권 결제시 고객사 구매자 ID를 의미하는 MalluserID는 필수로 입력해주어야 합니다.
+
+  나이스페이먼츠 상품권 결제시 고객사 구매자 ID를 의미하는 MalluserID는 필수로 입력해주어야 합니다.
 
 - `easyPay.availablePayMethods`
-  - 나이스페이먼츠를 통한 간편결제 결제 요청 시 다른 간편결제 수단과 다르게 네이버페이와 SSG페이의
-    경우 어떤 방식으로 결제하느냐에 따라 availablePayMethods을 입력해야 합니다..
-    - 네이버페이의 경우 카드 결제인 경우 `CARD`, 포인트 혹은 머니 결제인 경우 `CHARGE` 로 입력해야
-      합니다.
 
-    - SSG페이의 경우 계좌 결제인 경우 `TRANSFER`로 입력해야 하며, SSG페이는 계좌 결제 시에만
-      다이렉트 호출이 가능합니다. 카드 혹은 머니 결제를 이용하시는 경우 `availablePayMethods`를
-      제외한채 호출하시길 바랍니다.
+  나이스페이먼츠를 통한 간편결제 결제 요청 시 다른 간편결제 수단과 다르게 네이버페이와 SSG페이의
+  경우 어떤 방식으로 결제하느냐에 따라 availablePayMethods을 입력해야 합니다.
+
+  - 네이버페이의 경우 카드 결제인 경우 `CARD`, 포인트 혹은 머니 결제인 경우 `CHARGE` 로 입력해야
+    합니다.
+
+  - SSG페이의 경우 계좌 결제인 경우 `TRANSFER`로 입력해야 하며, SSG페이는 계좌 결제 시에만
+    다이렉트 호출이 가능합니다. 카드 혹은 머니 결제를 이용하시는 경우 `availablePayMethods`를
+    제외한채 호출하시길 바랍니다.
 
 ## API 수기(키인)결제 요청하기
 
@@ -173,67 +191,88 @@ import Tabs from "~/components/gitbook/Tabs";
 
 ### 주요 파라미터
 
-- `paymentId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-  - 고객사에서 채번하는 주문 고유 번호로 매번 고유하게 채번되어야 하며, URL path에 포함돼야 합니다.
+<ParamTree>
+  - `paymentId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
-- `channelKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-  - 콘솔 결제 연동 화면에서 채널 연동 시 생성된 채널 키로 호출하고자 하는 채널을 지정합니다.
+    고객사에서 채번하는 주문 고유 번호로 매번 고유하게 채번되어야 하며, URL path에 포함돼야 합니다.
 
-- `orderName` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-  - 주문명으로 고객사에서 자유롭게 입력합니다.
+  - `channelKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
-- `amount` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
-  - 결제 금액에 대한 정보를 담고있는 객체입니다.
+    콘솔 결제 연동 화면에서 채널 연동 시 생성된 채널 키로 호출하고자 하는 채널을 지정합니다.
 
-  - `total` <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
-    - 결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
+  - `orderName` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
-  - `taxFree` <mark style="color:purple;">**number**</mark>
-    - 면세 금액으로 나이스페이먼츠과 상점아이디 계약시 지정금액 혹은 복합과세 방식으로 계약한 경우 면세 처리를 위해 면세금액을 반드시 입력해야 합니다.
+    주문명으로 고객사에서 자유롭게 입력합니다.
+
+  - `amount` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+
+    결제 금액에 대한 정보를 담고있는 객체입니다.
+
+    - `total` <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
+
+      결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
+
+    - `taxFree` <mark style="color:purple;">**number**</mark>
+
+      면세 금액으로 나이스페이먼츠과 상점아이디 계약시 지정금액 혹은 복합과세 방식으로 계약한 경우 면세 처리를 위해 면세금액을 반드시 입력해야 합니다.
       면세금액 미 입력 시 면세금액은 0원으로 자동 처리되며, 결제 요청 금액은 모두 과세 처리 되오니 이 점 유의하시기 바랍니다.
 
-- `currency` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-  - 결제통화로 원화 결제를 원할 시 `KRW`로 입력해야 합니다.
+    - `currency` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
-- `method` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
-  - 결제 수단에 대한 정보를 담고있는 객체입니다.
+      결제통화로 원화 결제를 원할 시 `KRW`로 입력해야 합니다.
 
-  - `card` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
-    - `credential` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
-      - `number` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-        - 카드번호로 10자리 이상 20자리 이하의 숫자만 입력해야 합니다.
+  - `method` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
 
-      - `expiryMonth` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-        - 카드 유효기간의 월로 2자리 숫자만 입력해야 합니다.
+    결제 수단에 대한 정보를 담고있는 객체입니다.
 
-      - `expiryYear` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-        - 카드 유효기간의 년도로 2자리 숫자만 입력해야 합니다.
+    - `card` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+      - `credential` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+        - `number` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
-      - `birthOrBusinessRegistrationNumber` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-        - 카드 소지자의 생년월일 혹은 사업자 등록번호로 6자리 숫자만 입력해야 합니다.
+          카드번호로 10자리 이상 20자리 이하의 숫자만 입력해야 합니다.
 
-      - `passwordTwoDigits` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-        - 카드 비밀번호 앞 2자리로 2자리 숫자만 입력해야 합니다.
+        - `expiryMonth` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
-    - `installmentMonth` <mark style="color:purple;">**number**</mark>
-      - 카드 할부 개월수로 0(일시불) 혹은 2\~12개월까지의 숫자만 입력해야 합니다.
+          카드 유효기간의 월로 2자리 숫자만 입력해야 합니다.
 
-    - `useFreeInterestFromMerchant` <mark style="color:orange;">**boolean**</mark>
-      - 고객사 부담 무이자 설정으로 `true` 혹은 `false`만 입력
+        - `expiryYear` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
-    - `useCardPoint` <mark style="color:orange;">**boolean**</mark>
-      - 카드 포인트 사용 설정으로 `true` 혹은 `false`만 입력
+          카드 유효기간의 년도로 2자리 숫자만 입력해야 합니다.
+
+        - `birthOrBusinessRegistrationNumber` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+
+          카드 소지자의 생년월일 혹은 사업자 등록번호로 6자리 숫자만 입력해야 합니다.
+
+        - `passwordTwoDigits` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+
+          카드 비밀번호 앞 2자리로 2자리 숫자만 입력해야 합니다.
+
+      - `installmentMonth` <mark style="color:purple;">**number**</mark>
+
+        카드 할부 개월수로 0(일시불) 혹은 2\~12개월까지의 숫자만 입력해야 합니다.
+
+      - `useFreeInterestFromMerchant` <mark style="color:orange;">**boolean**</mark>
+
+        고객사 부담 무이자 설정으로 `true` 혹은 `false`만 입력
+
+      - `useCardPoint` <mark style="color:orange;">**boolean**</mark>
+
+        카드 포인트 사용 설정으로 `true` 혹은 `false`만 입력
+</ParamTree>
 
 ### 유의할 파라미터
 
 - `method.card.InstallmentMonth`
-  - 카드 할부 개월수로 0(일시불) 혹은 2\~12개월까지의 숫자만 입력해야 합니다. 입력하지 않은 경우 일시불로 처리됩니다.
+
+  카드 할부 개월수로 0(일시불) 혹은 2\~12개월까지의 숫자만 입력해야 합니다. 입력하지 않은 경우 일시불로 처리됩니다.
 
 - `method.useFreeInterestFromMerchant`
-  - 고객사 부담 무이자 설정으로 `true` 혹은 `false`만 입력.
+
+  고객사 부담 무이자 설정으로 `true` 혹은 `false`만 입력.
 
 - `method.card.useCardPoint`
-  - 카드 할부 개월수로 0(일시불) 혹은 2\~12개월까지의 숫자만 입력해야 합니다. 입력하지 않은 경우 일시불로 처리됩니다.
+
+  카드 할부 개월수로 0(일시불) 혹은 2\~12개월까지의 숫자만 입력해야 합니다. 입력하지 않은 경우 일시불로 처리됩니다.
 
 ## API 빌링키 발급 및 예약/반복 결제 요청하기
 
@@ -300,58 +339,78 @@ import Tabs from "~/components/gitbook/Tabs";
 
 ### 빌링키 발급 주요 파라미터
 
-- `channelKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-  - 콘솔 결제 연동 화면에서 채널 연동 시 생성된 채널 키로 호출하고자 하는 채널을 지정합니다.
+<ParamTree>
+  - `channelKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
-- `method` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
-  - 결제 수단에 대한 정보를 담고있는 객체입니다.
+    콘솔 결제 연동 화면에서 채널 연동 시 생성된 채널 키로 호출하고자 하는 채널을 지정합니다.
 
-  - `card` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
-    - `credential` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
-      - `number` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-        - 카드번호로 10자리 이상 20자리 이하의 숫자만 입력해야 합니다.
+  - `method` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
 
-      - `expiryMonth` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-        - 카드 유효기간의 월로 2자리 숫자만 입력해야 합니다.
+    결제 수단에 대한 정보를 담고있는 객체입니다.
 
-      - `expiryYear` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-        - 카드 유효기간의 년도로 2자리 숫자만 입력해야 합니다.
+    - `card` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+      - `credential` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+        - `number` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
-      - `birthOrBusinessRegistrationNumber` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-        - 카드 소지자의 생년월일 혹은 사업자 등록번호로 6자리 숫자만 입력해야 합니다.
+          카드번호로 10자리 이상 20자리 이하의 숫자만 입력해야 합니다.
 
-      - `passwordTwoDigits` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-        - 카드 비밀번호 앞 2자리로 2자리 숫자만 입력해야 합니다.
+        - `expiryMonth` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+
+          카드 유효기간의 월로 2자리 숫자만 입력해야 합니다.
+
+        - `expiryYear` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+
+          카드 유효기간의 년도로 2자리 숫자만 입력해야 합니다.
+
+        - `birthOrBusinessRegistrationNumber` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+
+          카드 소지자의 생년월일 혹은 사업자 등록번호로 6자리 숫자만 입력해야 합니다.
+
+        - `passwordTwoDigits` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+
+          카드 비밀번호 앞 2자리로 2자리 숫자만 입력해야 합니다.
+</ParamTree>
 
 ### API 예약/반복 결제 주요 파라미터
 
-- `paymentId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-  - 고객사에서 채번하는 주문 고유 번호로 매번 고유하게 채번되어야 하며, URL path에 포함돼야 합니다.
+<ParamTree>
+  - `paymentId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
-- `payment` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
-  - 결제 정보를 담고있는 객체입니다.
+    고객사에서 채번하는 주문 고유 번호로 매번 고유하게 채번되어야 하며, URL path에 포함돼야 합니다.
 
-  - `bilingKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-    - 결제를 진행할 빌링키
+  - `payment` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
 
-  - `orderName` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-    - 주문명
+    결제 정보를 담고있는 객체입니다.
 
-  - `amount` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
-    - 결제 금액에 대한 정보를 담고있는 객체입니다.
+    - `bilingKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
-    - `total` <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
-      - 결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
+      결제를 진행할 빌링키
 
-    - `taxFree` <mark style="color:purple;">**number**</mark>
-      - 면세 금액으로 (신)나이스페이먼츠과 상점아이디 계약시 지정금액 혹은 복합과세 방식으로 계약한 경우 면세 처리를 위해 면세금액을 반드시 입력해야 합니다.
+    - `orderName` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+
+      주문명
+
+    - `amount` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+
+      결제 금액에 대한 정보를 담고있는 객체입니다.
+
+      - `total` <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
+
+        결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
+
+      - `taxFree` <mark style="color:purple;">**number**</mark>
+
+        면세 금액으로 (신)나이스페이먼츠과 상점아이디 계약시 지정금액 혹은 복합과세 방식으로 계약한 경우 면세 처리를 위해 면세금액을 반드시 입력해야 합니다.
         면세금액 미 입력 시 면세금액은 0원으로 자동 처리되며, 결제 요청 금액은 모두 과세 처리 되오니 이 점 유의하시기 바랍니다.
 
-  - `currency` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-    - 결제통화로 원화 결제를 원할 시 `KRW`로 입력해야 합니다. (신)나이스페이먼츠의 경우 빌링키로 결제시 `KRW`만 지원합니다.
+    - `currency` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
-- `timeToPay` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-  - 결제를 시도할 시각으로 ISO8601 형식으로 입력해야 합니다.
+      결제통화로 원화 결제를 원할 시 `KRW`로 입력해야 합니다. (신)나이스페이먼츠의 경우 빌링키로 결제시 `KRW`만 지원합니다.
+
+  - `timeToPay` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+
+    결제를 시도할 시각으로 ISO8601 형식으로 입력해야 합니다.
+</ParamTree>
 
 ## 연동 유의사항
 

--- a/src/routes/(root)/opi/ko/integration/pg/v2/nice-v2.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v2/nice-v2.mdx
@@ -61,15 +61,15 @@ import Tabs from "~/components/gitbook/Tabs";
 ### 주요 파라미터
 
 <ParamTree>
-  - `storeId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - storeId: string
 
     포트원 계정에 생성된 상점을 식별하는 고유한 값으로 관리자 콘솔에서 확인할 수 있습니다.
 
-  - `paymentId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - paymentId: string
 
     고객사에서 채번하는 주문 고유 번호로 매번 고유하게 채번되어야 합니다.
 
-  - `orderName` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - orderName: string
 
     주문명으로 고객사에서 **40Byte** 이내로 자유롭게 입력합니다.
 
@@ -79,23 +79,23 @@ import Tabs from "~/components/gitbook/Tabs";
     - 사용 불가 : **% & | $ - + = \[ ]**
     - 사용 가능하나 권장하지 않음 : **( )**
 
-  - `channelKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - channelKey: string
 
     콘솔 결제 연동 화면에서 채널 연동 시 생성된 채널 키로 호출하고자 하는 채널을 지정합니다.
 
-  - `totalAmount` <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
+  - totalAmount: number
 
     결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
 
-  - `currency` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - currency: string
 
     결제통화로 원화 결제 시 `KRW`로 입력해야 합니다. 나이스페이먼츠의 경우 `KRW`와 `USD`를 지원합니다.
 
-  - `payMethod` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - payMethod: string
 
     결제수단으로 결제하고자 하는 결제수단의 값을 입력해야 합니다.
 
-  - `taxFreeAmount` <mark style="color:purple;">**number**</mark>
+  - taxFreeAmount?: number
 
     면세금액으로 나이스페이먼츠와 상점아이디 계약시 지정금액 혹은 복합과세 방식으로 계약한 경우 면세 처리를 위해 면세금액을 반드시 입력해야 합니다.
 
@@ -192,70 +192,70 @@ import Tabs from "~/components/gitbook/Tabs";
 ### 주요 파라미터
 
 <ParamTree>
-  - `paymentId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - paymentId: string
 
     고객사에서 채번하는 주문 고유 번호로 매번 고유하게 채번되어야 하며, URL path에 포함돼야 합니다.
 
-  - `channelKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - channelKey: string
 
     콘솔 결제 연동 화면에서 채널 연동 시 생성된 채널 키로 호출하고자 하는 채널을 지정합니다.
 
-  - `orderName` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - orderName: string
 
     주문명으로 고객사에서 자유롭게 입력합니다.
 
-  - `amount` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+  - amount: object
 
     결제 금액에 대한 정보를 담고있는 객체입니다.
 
-    - `total` <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
+    - total: number
 
       결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
 
-    - `taxFree` <mark style="color:purple;">**number**</mark>
+    - taxFree?: number
 
       면세 금액으로 나이스페이먼츠과 상점아이디 계약시 지정금액 혹은 복합과세 방식으로 계약한 경우 면세 처리를 위해 면세금액을 반드시 입력해야 합니다.
       면세금액 미 입력 시 면세금액은 0원으로 자동 처리되며, 결제 요청 금액은 모두 과세 처리 되오니 이 점 유의하시기 바랍니다.
 
-    - `currency` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+    - currency: string
 
       결제통화로 원화 결제를 원할 시 `KRW`로 입력해야 합니다.
 
-  - `method` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+  - method: object
 
     결제 수단에 대한 정보를 담고있는 객체입니다.
 
-    - `card` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
-      - `credential` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
-        - `number` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+    - card: object
+      - credential: object
+        - number: string
 
           카드번호로 10자리 이상 20자리 이하의 숫자만 입력해야 합니다.
 
-        - `expiryMonth` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+        - expiryMonth: string
 
           카드 유효기간의 월로 2자리 숫자만 입력해야 합니다.
 
-        - `expiryYear` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+        - expiryYear: string
 
           카드 유효기간의 년도로 2자리 숫자만 입력해야 합니다.
 
-        - `birthOrBusinessRegistrationNumber` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+        - birthOrBusinessRegistrationNumber: string
 
           카드 소지자의 생년월일 혹은 사업자 등록번호로 6자리 숫자만 입력해야 합니다.
 
-        - `passwordTwoDigits` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+        - passwordTwoDigits: string
 
           카드 비밀번호 앞 2자리로 2자리 숫자만 입력해야 합니다.
 
-      - `installmentMonth` <mark style="color:purple;">**number**</mark>
+      - installmentMonth?: number
 
         카드 할부 개월수로 0(일시불) 혹은 2\~12개월까지의 숫자만 입력해야 합니다.
 
-      - `useFreeInterestFromMerchant` <mark style="color:orange;">**boolean**</mark>
+      - useFreeInterestFromMerchant?: boolean
 
         고객사 부담 무이자 설정으로 `true` 혹은 `false`만 입력
 
-      - `useCardPoint` <mark style="color:orange;">**boolean**</mark>
+      - useCardPoint?: boolean
 
         카드 포인트 사용 설정으로 `true` 혹은 `false`만 입력
 </ParamTree>
@@ -340,33 +340,33 @@ import Tabs from "~/components/gitbook/Tabs";
 ### 빌링키 발급 주요 파라미터
 
 <ParamTree>
-  - `channelKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - channelKey: string
 
     콘솔 결제 연동 화면에서 채널 연동 시 생성된 채널 키로 호출하고자 하는 채널을 지정합니다.
 
-  - `method` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+  - method: object
 
     결제 수단에 대한 정보를 담고있는 객체입니다.
 
-    - `card` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
-      - `credential` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
-        - `number` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+    - card: object
+      - credential: object
+        - number: string
 
           카드번호로 10자리 이상 20자리 이하의 숫자만 입력해야 합니다.
 
-        - `expiryMonth` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+        - expiryMonth: string
 
           카드 유효기간의 월로 2자리 숫자만 입력해야 합니다.
 
-        - `expiryYear` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+        - expiryYear: string
 
           카드 유효기간의 년도로 2자리 숫자만 입력해야 합니다.
 
-        - `birthOrBusinessRegistrationNumber` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+        - birthOrBusinessRegistrationNumber: string
 
           카드 소지자의 생년월일 혹은 사업자 등록번호로 6자리 숫자만 입력해야 합니다.
 
-        - `passwordTwoDigits` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+        - passwordTwoDigits: string
 
           카드 비밀번호 앞 2자리로 2자리 숫자만 입력해야 합니다.
 </ParamTree>
@@ -374,40 +374,40 @@ import Tabs from "~/components/gitbook/Tabs";
 ### API 예약/반복 결제 주요 파라미터
 
 <ParamTree>
-  - `paymentId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - paymentId: string
 
     고객사에서 채번하는 주문 고유 번호로 매번 고유하게 채번되어야 하며, URL path에 포함돼야 합니다.
 
-  - `payment` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+  - payment: object
 
     결제 정보를 담고있는 객체입니다.
 
-    - `bilingKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+    - bilingKey: string
 
       결제를 진행할 빌링키
 
-    - `orderName` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+    - orderName: string
 
       주문명
 
-    - `amount` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+    - amount: object
 
       결제 금액에 대한 정보를 담고있는 객체입니다.
 
-      - `total` <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
+      - total: number
 
         결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
 
-      - `taxFree` <mark style="color:purple;">**number**</mark>
+      - taxFree?: number
 
         면세 금액으로 (신)나이스페이먼츠과 상점아이디 계약시 지정금액 혹은 복합과세 방식으로 계약한 경우 면세 처리를 위해 면세금액을 반드시 입력해야 합니다.
         면세금액 미 입력 시 면세금액은 0원으로 자동 처리되며, 결제 요청 금액은 모두 과세 처리 되오니 이 점 유의하시기 바랍니다.
 
-    - `currency` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+    - currency: string
 
       결제통화로 원화 결제를 원할 시 `KRW`로 입력해야 합니다. (신)나이스페이먼츠의 경우 빌링키로 결제시 `KRW`만 지원합니다.
 
-  - `timeToPay` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - timeToPay: string
 
     결제를 시도할 시각으로 ISO8601 형식으로 입력해야 합니다.
 </ParamTree>

--- a/src/routes/(root)/opi/ko/integration/pg/v2/paypal-v2.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v2/paypal-v2.mdx
@@ -657,7 +657,7 @@ STC 기능을 사용하기 위해 다음 정보를 확인해 주세요.
 
   <Details.Content>
     <ParamTree>
-      - `orderName` <mark style="color:red;">\*</mark> <mark style="color:green;">**string**</mark>
+      - orderName: string
 
         **주문명**
 
@@ -675,7 +675,7 @@ STC 기능을 사용하기 위해 다음 정보를 확인해 주세요.
           <Figure src="/gitbook-assets/ko/image (52).png" caption="예시) 회원 결제 화면 2" />
         </div>
 
-      - `customer.phoneNumber` <mark style="color:green;">**string**</mark>
+      - customer.phoneNumber?: string
 
         **구매자 연락처**
 
@@ -687,16 +687,16 @@ STC 기능을 사용하기 위해 다음 정보를 확인해 주세요.
 
         <Figure src="/gitbook-assets/ko/image (6) (1).png" caption="예시) 결제창 내 구매자 연락처 입력 화면" />
 
-      - `products` <mark style="color:blue;">**object\[]**</mark>
+      - products?: object\[]
 
         **구매 상품 상세 정보**
 
         <ParamTree>
-          - `name` <mark style="color:red;">\*</mark> <mark style="color:green;">**string**</mark>
+          - name: string
 
             **상품명**
 
-          - `amount` <mark style="color:red;">\*</mark> <mark style="color:purple;">**number**</mark>
+          - amount: number
 
             **상품 단위 가격**
 
@@ -705,7 +705,7 @@ STC 기능을 사용하기 위해 다음 정보를 확인해 주세요.
             - 1.50 만큼 달러(USD) 결제를 하는 경우, scale factor가 2이기 때문에 **1.50 \* (10의 2승) = 150**을 전달해야 합니다.
             - 이렇게 전달 된 값은 실제로 PG사에 결제를 요청할때 currency에 따라 올바른 값으로 변환되기 때문에 반드시 currency값을 필수로 입력해야 합니다.
 
-          - `quantity` <mark style="color:red;">\*</mark> <mark style="color:purple;">**number**</mark>
+          - quantity: number
 
             상품 수량
         </ParamTree>
@@ -745,7 +745,7 @@ STC 기능을 사용하기 위해 다음 정보를 확인해 주세요.
 
         <Figure src={image11} width="360" caption="예시) 결제창 내 구매 상품 상세 정보 화면" />
 
-      - `currency` <mark style="color:red;">\*</mark> <mark style="color:green;">**string**</mark>
+      - currency: string
 
         **결제 통화**
 
@@ -753,24 +753,24 @@ STC 기능을 사용하기 위해 다음 정보를 확인해 주세요.
 
         <Figure src="/gitbook-assets/ko/image (9).png" caption="사용 가능한 결제 통화" />
 
-      - `customer` <mark style="color:blue;">**object**</mark>
+      - customer?: object
 
         **고객 정보**
 
         <ParamTree>
-          - `fullName` <mark style="color:green;">**string**</mark>
+          - fullName?: string
 
             **구매자 전체 이름**
 
             `fullName`과 `firstName` / `lastName`이 모두 입력된 경우 `fullName`으로 기록됩니다.
 
-          - `firstName` <mark style="color:green;">**string**</mark>
+          - firstName?: string
 
             **구매자 이름**
 
             `firstName`을 입력하는 경우 `lastName`도 필수로 입력해야 합니다. `fullName`이 없고, `firstName`과 `lastName`을 입력한 경우 `{firstName} {lastName}`으로 저장됩니다.
 
-          - `lastName` <mark style="color:green;">**string**</mark>
+          - lastName?: string
 
             **구매자 성**
 
@@ -784,24 +784,24 @@ STC 기능을 사용하기 위해 다음 정보를 확인해 주세요.
 
         <Figure src="/gitbook-assets/ko/image (13).png" />
 
-      - `bypass` <mark style="color:blue;">**oneof object**</mark>
+      - bypass?: oneof object
 
         **PG사 결제창 호출 시 PG사로 그대로 bypass할 파라미터들의 모음**
 
         <ParamTree>
-          - `paypal_v2` <mark style="color:blue;">**object**</mark>
+          - paypal\_v2?: object
 
             **페이팔에서 제공하는 파라미터 모음**
 
             <ParamTree>
-              - `style` <mark style="color:green;">**string**</mark>
+              - style?: string
 
                 **페이팔 버튼 커스텀마이징**
 
                 페이팔 결제 버튼을 커스텀마이징 할 경우 자세한 내용은 페이팔에서 제공하는 문서([https://developer.paypal.com/sdk/js/reference/#link-style](http://developer.paypal.com/sdk/js/reference/#link-style))를 참고하세요.
 
                 <ParamTree>
-                  - `layout` <mark style="color:green;">**string**</mark>
+                  - layout?: string
 
                     **페이팔 버튼 렌더링 방향**
 
@@ -830,26 +830,26 @@ STC 기능을 사용하기 위해 다음 정보를 확인해 주세요.
                       <Figure src="/gitbook-assets/ko/image (1) (1).png" caption="예시) horizontal style 버튼 표시 화면" />
                     </div>
 
-                  - `color` <mark style="color:green;">**string**</mark>
+                  - color?: string
 
                     **페이팔 버튼 색상**
 
                     - `gold`, `blue`, `silver`, `white`, `black` 중 선택할 수 있습니다.
                     - 기본적으로는 `gold`로 표시됩니다.
 
-                  - `height` <mark style="color:purple;">**number**</mark>
+                  - height?: number
 
                     **페이팔 버튼 크기**
 
                     크기 변경은 25\~55 사이의 값으로만 지정할 수 있습니다.
 
-                  - `shape` <mark style="color:green;">**string**</mark>
+                  - shape?: string
 
                     **페이팔 버튼 모양**
 
                     `rect`(사각 모양)과 `pill`(둥근 모양) 중에 선택할 수 있으며, 기본적으로 `rect` 모양으로 표시됩니다.
 
-                  - `label` <mark style="color:green;">**string**</mark>
+                  - label?: string
 
                     **페이팔 버튼 라벨**
 
@@ -857,20 +857,20 @@ STC 기능을 사용하기 위해 다음 정보를 확인해 주세요.
                     - 기본적으로 `paypal`로 표시됩니다.
                     - `installment`는 결제 국가가 `MX`혹은 `BR`인 경우에만 유효합니다.
 
-                  - `period` <mark style="color:green;">**string**</mark>
+                  - period?: string
 
                     **페이팔 버튼에 할부 결제 표시**
 
                     `label` 파라미터가 `installment`인 경우 버튼에 표시됩니다.
 
-                  - `tagline` <mark style="color:orange;">**boolean**</mark>
+                  - tagline?: boolean
 
                     **페이팔 버튼에 제공되는 추가 설명**
 
                     해당 파라미터를 사용하시기 위해서는 `layout` 파라미터를 `horizontal`로 지정해야 사용하실 수 있습니다.
                 </ParamTree>
 
-              - `enable-funding` <mark style="color:green;">**string**</mark>
+              - enable-funding?: string
 
                 **렌더링할 페이팔 결제 버튼 지정**
 
@@ -899,7 +899,7 @@ STC 기능을 사용하기 위해 다음 정보를 확인해 주세요.
                   <Figure src="/gitbook-assets/ko/image (81).png" caption="예시) 접속 국가: 벨기에, enable-funding: “paylater” 설정 시 화면" />
                 </div>
 
-              - `disable-funding` <mark style="color:green;">**string**</mark>
+              - disable-funding?: string
 
                 **렌더링에서 제외할 페이팔 결제 버튼 지정**
 
@@ -912,19 +912,19 @@ STC 기능을 사용하기 위해 다음 정보를 확인해 주세요.
                   <Figure src="/gitbook-assets/ko/image (25).png" caption="예시) 접속 국가: 이탈리아, enable-funding: 'paylater', disable-funding: 'mybank' 설정 시 화면" />
                 </div>
 
-              - `purchase_units` <mark style="color:blue;">**object\[]**</mark>
+              - purchase\_units?: object\[]
 
                 **페이팔 주문 상세 정보**
 
                 - 각각의 element에 배송 정보를 담을 수 있습니다.
                 - 포트원을 통해 페이팔을 연동하는 고객사는 **`purchase_units`의 길이가 항상 0 또는 1이어야** 합니다.
 
-              - `shipping` <mark style="color:blue;">**object**</mark>
+              - shipping?: object
 
                 **상품 배송지 정보**
 
                 <ParamTree>
-                  - `address` <mark style="color:blue;">**object**</mark>
+                  - address?: object
 
                     **상품 수령 주소**
 
@@ -935,15 +935,15 @@ STC 기능을 사용하기 위해 다음 정보를 확인해 주세요.
                     </div>
 
                     <ParamTree>
-                      - `address_line_1` <mark style="color:red;">\*</mark><mark style="color:green;">**string**</mark>
+                      - address\_line\_1: string
 
                         **도로명 주소, ex) `200 N Spring St`**
 
-                      - `address_line_2` <mark style="color:green;">**string**</mark>
+                      - address\_line\_2?: string
 
                         **번지 혹은 건물 호수, ex) `Los Angeles City Hall 1`**
 
-                      - `admin_area_1` <mark style="color:green;">**string**</mark>
+                      - admin\_area\_1?: string
 
                         **주와 같은 큰 단위의 주소, ex) `CA`, `NY`**
 
@@ -952,15 +952,15 @@ STC 기능을 사용하기 위해 다음 정보를 확인해 주세요.
                         - province(Canada)
                         - 특별시/광역시/도(Korea)
 
-                      - `admin_area_2` <mark style="color:green;">**string**</mark>
+                      - admin\_area\_2?: string
 
                         **도시, 마을 등 중간 단위의 주소, ex) `Los Angeles`**
 
-                      - `postal_code` <mark style="color:green;">**string**</mark>
+                      - postal\_code?: string
 
                         **우편 번호**
 
-                      - `country_code` <mark style="color:red;">\*</mark> <mark style="color:green;">**string**</mark>
+                      - country\_code: string
 
                         **국가 코드, ex) `KR`**
                     </ParamTree>
@@ -1022,19 +1022,19 @@ STC 기능을 사용하기 위해 다음 정보를 확인해 주세요.
                     </Details>
                 </ParamTree>
 
-              - `payer` <mark style="color:blue;">**object**</mark>
+              - payer?: object
 
                 **구매자 상세정보**
 
-              - `tax_info` <mark style="color:blue;">**object**</mark>
+              - tax\_info?: object
 
                 **구매자 세금 정보**
 
-              - `tax_id` <mark style="color:green;">**string**</mark>
+              - tax\_id?: string
 
                 **구매자 세금 ID**
 
-              - `tax_id_type` <mark style="color:green;">**string**</mark>
+              - tax\_id\_type?: string
 
                 **구매자 세금 유형**
 
@@ -1049,20 +1049,20 @@ STC 기능을 사용하기 위해 다음 정보를 확인해 주세요.
                 });
                 ```
 
-              - `address` <mark style="color:blue;">**object**</mark>
+              - address?: object
 
                 **구매자의 결제 금액 청구지 주소 정보(billing address)**
 
                 <ParamTree>
-                  - `address_line_1` <mark style="color:green;">**string**</mark>
+                  - address\_line\_1?: string
 
                     **도로명 주소, ex) `200 N Spring St`**
 
-                  - `address_line_2` <mark style="color:green;">**string**</mark>
+                  - address\_line\_2?: string
 
                     **번지 혹은 건물 호수, ex) `Los Angeles City Hall 1`**
 
-                  - `admin_area_1` <mark style="color:green;">**string**</mark>
+                  - admin\_area\_1?: string
 
                     **주와 같은 큰 단위의 주소, ex) `CA`, `NY`**
 
@@ -1071,15 +1071,15 @@ STC 기능을 사용하기 위해 다음 정보를 확인해 주세요.
                     - province(Canada)
                     - 특별시/광역시/도(Korea)
 
-                  - `admin_area_2` <mark style="color:green;">**string**</mark>
+                  - admin\_area\_2?: string
 
                     **도시, 마을 등 중간 단위의 주소, ex) `Los Angeles`**
 
-                  - `postal_code` <mark style="color:green;">**string**</mark>
+                  - postal\_code?: string
 
                     **우편 번호**
 
-                  - `country_code`  <mark style="color:red;">\*</mark> <mark style="color:green;">**string**</mark>
+                  - country\_code: string
 
                     **국가 코드, ex) `KR`**
                 </ParamTree>
@@ -1260,13 +1260,13 @@ STC 기능을 사용하기 위해 다음 정보를 확인해 주세요.
 
   <Details.Content>
     <ParamTree>
-      - `taxFreeAmount` <mark style="color:purple;">**number**</mark>
+      - taxFreeAmount?: number
 
         **면세 금액**
 
         페이팔은 면세/복합과세를 지원하지 않기 때문에 taxFreeAmount 입력한 경우 “taxFreeAmount must be 0 in Paypal!”이라는 에러 메시지가 리턴되면서 결제창이 호출되지 않습니다.
 
-      - `country` <mark style="color:green;">**string**</mark>
+      - country?: string
 
         **결제 국가**
 
@@ -1274,12 +1274,12 @@ STC 기능을 사용하기 위해 다음 정보를 확인해 주세요.
         - 예시) `country : US`를 입력하여 결제창을 호출했지만 구매자가 접속한 환경이 “KR(한국)”인 경우 한국에 지원되는 결제 버튼만 렌더링됩니다.
         - 페이팔 sandbox 모드인 경우 입력한 국가 정보로 전달됩니다.
 
-      - `customer` <mark style="color:blue;">**object**</mark>
+      - customer?: object
 
         **고객 정보**
 
         <ParamTree>
-          - `address` <mark style="color:blue;">**object**</mark>
+          - address?: object
 
             **구매자 주소**
 
@@ -1287,13 +1287,13 @@ STC 기능을 사용하기 위해 다음 정보를 확인해 주세요.
             - `bypass.paypal_v2.payer.address`, `bypass.paypal_v2.purchase_units\[].shipping.address` 파라미터에 대한 자세한 사항은 **파라미터 사용 시 유의사항** 을 참고하시기 바랍니다.
         </ParamTree>
 
-      - `redirectUrl` <mark style="color:green;">**string**</mark>
+      - redirectUrl?: string
 
         **리디력션 방식에서 결제 프로세스 완료 후 이동될 고객사 URL**
 
         페이팔의 경우 PC와 모바일 모두 팝업으로 결제창이 렌더링되기 때문에 결제 프로세스 종료시 콜백 함수가 호촐됩니다. 따라서 redirectUrl 파라미터는 무시됩니다.
 
-      - `appScheme` <mark style="color:green;">**string**</mark>
+      - appScheme?: string
 
         **모바일 결제 후 고객사 앱으로 복귀를 위한 URL scheme**
 
@@ -1317,49 +1317,49 @@ STC 기능을 사용하기 위해 다음 정보를 확인해 주세요.
 
         페이팔의 경우 도서 문화비 항목을 지원하지 않아 해당 파라미터는 무시됩니다.
 
-      - `offerPeriod` <mark style="color:green;">**string**</mark>
+      - offerPeriod?: string
 
         **서비스 제공 기간**
 
         페이팔은 결제창 내 제공 기간 정보 노출을 지원하지 않아 해당 파라미터가 무시됩니다.
 
-      - `storeDetails` <mark style="color:blue;">**object**</mark>
+      - storeDetails?: object
 
         **상점 정보**
 
         페이팔은 상점 세부 정보를 지원하지 않아 해당 파라미터가 무시됩니다.
 
-      - `card` <mark style="color:blue;">**object**</mark>
+      - card?: object
 
         **카드 결제에 대한 상세 옵션**
 
         페이팔의 경우 결제 요청 시 결제 수단은 항상 `paypal`로 지정되며, 카드 결제 시 사용되는 옵션 설정을 지원하지 않아 해당 파라미터를 사용할 수 없습니다.
 
-      - `virtualAccount` <mark style="color:blue;">**object**</mark>
+      - virtualAccount?: object
 
         **가상계좌 발급에 대한 상세 옵션**
 
         페이팔의 경우 결제 요청 시 결제 수단은 항상 `paypal`로 지정되며, 가상계좌 발급 시 사용되는 옵션 설정을 지원하지 않아 해당 파라미터를 사용할 수 없습니다.
 
-      - `transfer` <mark style="color:blue;">**object**</mark>
+      - transfer?: object
 
         **계좌이체 결제에 대한 상세 옵션**
 
         페이팔의 경우 결제 요청 시 결제 수단은 항상 `paypal`로 지정되며, 계좌이체 결제 시 사용되는 옵션 설정을 지원하지 않아 해당 파라미터를 사용할 수 없습니다.
 
-      - `mobile` <mark style="color:blue;">**object**</mark>
+      - mobile?: object
 
         **휴대폰 소액결제에 대한 상세 옵션**
 
         페이팔의 경우 결제 요청 시 결제 수단은 항상 `paypal`로 지정되며, 휴대폰 소액결제 시 사용되는 옵션 설정을 지원하지 않아 해당 파라미터를 사용할 수 없습니다.
 
-      - `giftCertificate` <mark style="color:blue;">**object**</mark>
+      - giftCertificate?: object
 
         **상품권 결제에 대한 상세 옵션**
 
         페이팔의 경우 결제 요청 시 결제 수단은 항상 `paypal`로 지정되며, 상품권 결제 시 사용되는 옵션 설정을 지원하지 않아 해당 파라미터를 사용할 수 없습니다.
 
-      - `easyPay` <mark style="color:blue;">**object**</mark>
+      - easyPay?: object
 
         **간편결제 결제에 대한 상세 옵션**
 
@@ -1558,7 +1558,7 @@ STC 기능을 사용하기 위해 다음 정보를 확인해 주세요.
 
   <Details.Content>
     <ParamTree>
-      - `orderName` <mark style="color:red;">\*</mark> <mark style="color:green;">**string**</mark>
+      - orderName: string
 
         **주문명**
 
@@ -1566,23 +1566,23 @@ STC 기능을 사용하기 위해 다음 정보를 확인해 주세요.
 
         <Figure src="/gitbook-assets/ko/paypal-rt/paypal-rt-name.png" caption="예시) 빌링키 발급 시 화면" />
 
-      - `bypass` <mark style="color:blue;">**oneof object**</mark>
+      - bypass?: oneof object
 
         **PG사 결제창 호출 시 PG사로 그대로 bypass할 파라미터들의 모음**
 
         <ParamTree>
-          - `paypal_v2` <mark style="color:blue;">**object**</mark>
+          - paypal\_v2?: object
 
             **페이팔에서 제공하는 파라미터 모음**
 
             <ParamTree>
-              - `style` <mark style="color:green;">**string**</mark>
+              - style?: string
 
                 **페이팔 버튼 커스텀마이징**
 
                 페이팔 버튼을 커스텀마이징 할 경우 자세한 내용은 페이팔에서 제공하는 문서([https://developer.paypal.com/sdk/js/reference/#link-style](http://developer.paypal.com/sdk/js/reference/#link-style))를 참고하세요.
 
-              - `layout` <mark style="color:green;">**string**</mark>
+              - layout?: string
 
                 **페이팔 버튼 렌더링 방향**
 
@@ -1611,26 +1611,26 @@ STC 기능을 사용하기 위해 다음 정보를 확인해 주세요.
                   <Figure src="/gitbook-assets/ko/image (1) (1).png" caption="예시) horizontal style 버튼 표시 화면" />
                 </div>
 
-              - `color` <mark style="color:green;">**string**</mark>
+              - color?: string
 
                 **페이팔 버튼 색상**
 
                 - `gold`, `blue`, `silver`, `white`, `black` 중 선택할 수 있습니다.
                 - 기본적으로는 `gold`로 표시됩니다.
 
-              - `height` <mark style="color:purple;">**number**</mark>
+              - height?: number
 
                 **페이팔 버튼 크기**
 
                 크기 변경은 25\~55 사이의 값으로만 지정할 수 있습니다.
 
-              - `shape` <mark style="color:green;">**string**</mark>
+              - shape?: string
 
                 **페이팔 버튼 모양**
 
                 `rect`(사각 모양)과 `pill`(둥근 모양) 중에 선택할 수 있으며, 기본적으로 `rect` 모양으로 표시됩니다.
 
-              - `label` <mark style="color:green;">**string**</mark>
+              - label?: string
 
                 **페이팔 버튼 라벨**
 
@@ -1638,40 +1638,40 @@ STC 기능을 사용하기 위해 다음 정보를 확인해 주세요.
                 - 기본적으로 `paypal`로 표시됩니다.
                 - `installment`는 결제 국가가 `MX`혹은 `BR`인 경우에만 유효합니다.
 
-              - `period` <mark style="color:green;">**string**</mark>
+              - period?: string
 
                 **페이팔 버튼에 할부 결제 표시**
 
                 `label:installment`인 경우 버튼에 표시됩니다.
 
-              - `tagline` <mark style="color:orange;">**boolean**</mark>
+              - tagline?: boolean
 
                 **페이팔 버튼에 제공되는 추가 설명**
 
                 해당 파라미터를 사용하시기 위해서는 `bypass.paypal_v2.style.layout`을 horizontal로 지정해야 사용하실 수 있습니다.
 
-              - `shipping_address` <mark style="color:blue;">**object**</mark>
+              - shipping\_address?: object
 
                 **주문 상품의 배송 주소**
 
                 <ParamTree>
-                  - `recipient_name` <mark style="color:green;">**string**</mark>
+                  - recipient\_name?: string
 
                     **수령인 이름**
 
-                  - `line1` <mark style="color:red;">\*</mark><mark style="color:green;">**string**</mark>
+                  - line1: string
 
                     **도로명 주소, ex) `200 N Spring St`**
 
-                  - `line2` <mark style="color:green;">**string**</mark>
+                  - line2?: string
 
                     **번지 혹은 건물 호수, ex) `Los Angeles City Hall 1`**
 
-                  - `city` <mark style="color:red;">\*</mark><mark style="color:green;">**string**</mark>
+                  - city: string
 
                     **도시, 마을 등 중간 단위의 주소, ex) `Los Angeles`**
 
-                  - `state` <mark style="color:green;">**string**</mark>
+                  - state?: string
 
                     **주와 같은 큰 단위의 주소, ex) `CA`, `NY`**
 
@@ -1680,11 +1680,11 @@ STC 기능을 사용하기 위해 다음 정보를 확인해 주세요.
                     - province(Canada)
                     - 특별시/광역시/도(Korea)
 
-                  - `postal_code` <mark style="color:green;">**string**</mark>
+                  - postal\_code?: string
 
                     **우편 번호**
 
-                  - `country_code` <mark style="color:red;">\*</mark><mark style="color:green;">**string**</mark>
+                  - country\_code: string
 
                     **국가 코드, ex) `KR`**
 
@@ -1731,19 +1731,19 @@ STC 기능을 사용하기 위해 다음 정보를 확인해 주세요.
 
   <Details.Content>
     <ParamTree>
-      - `totalAmount` <mark style="color:purple;">**number**</mark>
+      - totalAmount?: number
 
         **총 결제 금액**
 
         빌링키 발급 시 지원하지 않는 파라미터로 발급 시 무조건 0으로 저장됩니다.
 
-      - `taxFreeAmount` <mark style="color:purple;">**number**</mark>
+      - taxFreeAmount?: number
 
         **면세 금액**
 
         페이팔은 면세/복합과세를 지원하지 않기 때문에 해당 파라미터는 지원하지 않습니다.
 
-      - `country` <mark style="color:green;">**string**</mark>
+      - country?: string
 
         **결제 국가**
 
@@ -1751,18 +1751,18 @@ STC 기능을 사용하기 위해 다음 정보를 확인해 주세요.
         - 예시) `country : US`를 입력하여 결제창을 호출했지만 구매자가 접속한 환경이 “KR(한국)”인 경우 한국에 지원되는 결제 버튼만 렌더링됩니다.
         - 페이팔 sandbox 모드인 경우 입력한 국가 정보로 전달됩니다.
 
-      - `currency` <mark style="color:green;">**string**</mark>
+      - currency?: string
 
         **결제 통화**
 
         빌링키 발급 시 결제가 되지 않기 때문에 해당 파라미터는 무시됩니다.
 
-      - `customer` <mark style="color:blue;">**object**</mark>
+      - customer?: object
 
         **고객 정보**
 
         <ParamTree>
-          - `address` <mark style="color:blue;">**object**</mark>
+          - address?: object
 
             **구매자 주소**
 
@@ -1770,13 +1770,13 @@ STC 기능을 사용하기 위해 다음 정보를 확인해 주세요.
             - `bypass.paypal_v2.shipping_address` 파라미터에 대한 자세한 사항은 **파라미터 사용 시 유의사항** 을 참고하시기 바랍니다.
         </ParamTree>
 
-      - `redirectUrl` <mark style="color:green;">**string**</mark>
+      - redirectUrl?: string
 
         **리디력션 방식에서 결제 프로세스 완료 후 이동될 고객사 URL**
 
         페이팔의 경우 PC와 모바일 모두 팝업으로 빌링키 발급창이 렌더링되기 때문에 프로세스 종료시 콜백 함수가 호촐됩니다. 따라서 redirectUrl 파라미터는 무시됩니다.
 
-      - `appScheme` <mark style="color:green;">**string**</mark>
+      - appScheme?: string
 
         **모바일 결제 후 고객사 앱으로 복귀를 위한 URL scheme**
 
@@ -1800,13 +1800,13 @@ STC 기능을 사용하기 위해 다음 정보를 확인해 주세요.
 
         페이팔의 경우 도서 문화비 항목을 지원하지 않아 해당 파라미터는 무시됩니다.
 
-      - `offerPeriod` <mark style="color:green;">**string**</mark>
+      - offerPeriod?: string
 
         **서비스 제공 기간**
 
         페이팔은 결제창 내 제공 기간 정보 노출을 지원하지 않아 해당 파라미터가 무시됩니다.
 
-      - `storeDetails` <mark style="color:blue;">**object**</mark>
+      - storeDetails?: object
 
         **상점 정보**
 

--- a/src/routes/(root)/opi/ko/integration/pg/v2/smartro-v2.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v2/smartro-v2.mdx
@@ -99,43 +99,43 @@ import Tabs from "~/components/gitbook/Tabs";
 ### 주요 파라미터
 
 <ParamTree>
-  - `storeId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - storeId: string
 
     **스토어 아이디**
 
     포트원 계정에 생성된 상점을 식별하는 고유한 값으로 관리자 콘솔에서 확인할 수 있습니다.
 
-  - `paymentId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - paymentId: string
 
     **고객사 주문 고유 번호**
 
     고객사에서 채번하는 주문 고유 번호로 매번 고유하게 채번되어야 합니다. 이미 승인 완료된 `paymentId`로 결제를 시도하는 경우 에러가 발생합니다.
 
-  - `orderName` <mark style="color:red;">\*</mark> <mark style="color:green;">**string**</mark>
+  - orderName: string
 
     **주문명**
 
     주문명으로 고객사에서 자유롭게 입력합니다.
 
-  - `channelKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - channelKey: string
 
     **채널 키**
 
     포트원 콘솔 내 \[결제연동] > \[채널관리] 화면에서 채널 추가 시 생성되는 값입니다. 결제 호출 시 채널을 지정할 때 사용됩니다.
 
-  - `totalAmount` <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
+  - totalAmount: number
 
     **결제 금액**
 
     결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
 
-  - `currency` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - currency: string
 
     **결제 통화**
 
     결제통화로 원화 결제 시 `KRW`로 입력해야 합니다.
 
-  - `payMethod` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - payMethod: string
 
     **결제수단 구분코드**
 
@@ -147,47 +147,47 @@ import Tabs from "~/components/gitbook/Tabs";
     - 휴대폰 소액결제 : `MOBILE`
     - 간편 결제 : `EASY_PAY`
 
-  - `customer` <mark style="color:blue;">**object**</mark>
+  - customer?: object
 
     **고객 정보**
 
     <ParamTree>
-      - `customerId` <mark style="color:green;">**string**</mark>
+      - customerId?: string
 
         **구매자 고유 ID**
 
         - 스마트로의 경우 간편결제로 결제 요청시 필수로 입력해야 합니다.
         - 20자 이하로만 입력 가능합니다.
 
-      - `phoneNumber` <mark style="color:green;">**string**</mark>
+      - phoneNumber?: string
 
         **구매자 연락처**
 
         - 스마트로의 경우 결제창 호출 시 필수로 입력합니다.
     </ParamTree>
 
-  - `bypass` <mark style="color:blue;">**oneof object**</mark>
+  - bypass?: oneof object
 
     **PG사 결제창 호출 시 PG사로 그대로 bypass할 파라미터들의 모음**
 
     <ParamTree>
-      - `smartro_v2` <mark style="color:blue;">**object**</mark>
+      - smartro\_v2?: object
 
         **스마트로에서 제공하는 파라미터 모음**
 
         <ParamTree>
-          - `GoodsCnt` <mark style="color:purple;">**number**</mark>
+          - GoodsCnt?: number
 
             **결제 상품 품목 갯수**
 
-          - `SkinColor` <mark style="color:green;">**string**</mark>
+          - SkinColor?: string
 
             **UI 색상 스타일**
 
             - 미 설정시 기본으로 `RED`로 적용됩니다.
             - `RED`, `GREEN`, `BLUE`, `PURPLE`를 선택할 수 있습니다.
 
-          - `OpenType` <mark style="color:green;">**string**</mark>
+          - OpenType?: string
 
             **해외 카드 사용 설정**
 
@@ -237,37 +237,37 @@ import Tabs from "~/components/gitbook/Tabs";
 ### 주요 파라미터
 
 <ParamTree>
-  - `storeId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - storeId: string
 
     **스토어 아이디**
 
     포트원 계정에 생성된 상점을 식별하는 고유한 값으로 관리자 콘솔에서 확인할 수 있습니다.
 
-  - `channelKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - channelKey: string
 
     **채널 키**
 
     포트원 콘솔 내 \[결제연동] > \[채널관리] 화면에서 채널 추가 시 생성되는 값입니다. 결제 호출 시 채널을 지정할 때 사용됩니다.
 
-  - `billingKeyMethod` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - billingKeyMethod: string
 
     **빌링키 발급수단**
 
     스마트로는 카드 이외 발급 수단은 지원하지 않아 `CARD`로 설정해야 합니다.
 
-  - `issueId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - issueId: string
 
     **빌링키 발급 건 고유 ID**
 
     - 고객사에서 채번하여 사용해야 합니다.
     - 스마트로의 경우 필수 입력해야 하며, 특수문자는 사용이 불가합니다.
 
-  - `customer` <mark style="color:blue;">**object**</mark>
+  - customer?: object
 
     **고객 정보**
 
     <ParamTree>
-      - `customerId` <mark style="color:green;">**string**</mark>
+      - customerId?: string
 
         **구매자 고유 ID**
 
@@ -275,24 +275,24 @@ import Tabs from "~/components/gitbook/Tabs";
         - 20자 이하로만 입력 가능합니다.
     </ParamTree>
 
-  - `bypass` <mark style="color:blue;">**oneof object**</mark>
+  - bypass?: oneof object
 
     **PG사 결제창 호출 시 PG사로 그대로 bypass할 파라미터들의 모음**
 
     <ParamTree>
-      - `smartro_v2` <mark style="color:blue;">**object**</mark>
+      - smartro\_v2?: object
 
         **스마트로에서 제공하는 파라미터 모음**
 
         <ParamTree>
-          - `SkinColor` <mark style="color:green;">**string**</mark>
+          - SkinColor?: string
 
             **UI 색상 스타일**
 
             - 미 설정시 기본으로 `RED`로 적용됩니다.
             - `RED`, `GREEN`, `BLUE`, `PURPLE`를 선택할 수 있습니다.
 
-          - `IsPwdPass` <mark style="color:green;">**string**</mark>
+          - IsPwdPass?: string
 
             **결제 비밀번호 등록 Skip 여부**
 
@@ -623,83 +623,83 @@ import Tabs from "~/components/gitbook/Tabs";
 #### 주요 파라미터
 
 <ParamTree>
-  - `paymentId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - paymentId: string
 
     **고객사 주문 고유 번호**
 
     고객사에서 채번하는 주문 고유 번호로 매번 고유하게 채번되어야 합니다. 이미 승인 완료된 `paymentId`로 결제를 시도하는 경우 에러가 발생합니다.
 
-  - `orderName` <mark style="color:red;">\*</mark> <mark style="color:green;">**string**</mark>
+  - orderName: string
 
     **주문명**
 
     주문명으로 고객사에서 자유롭게 입력합니다.
 
-  - `channelKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - channelKey: string
 
     **채널 키**
 
     포트원 콘솔 내 \[결제연동] > \[채널관리] 화면에서 채널 추가 시 생성되는 값입니다. 결제 호출 시 채널을 지정할 때 사용됩니다.
 
-  - `amount` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+  - amount: object
 
     **결제 금액**
 
     <ParamTree>
-      - `total` <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
+      - total: number
 
         **총 결제 금액**
 
         결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
     </ParamTree>
 
-  - `currency` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - currency: string
 
     **결제 통화**
 
     결제통화로 원화 결제 시 `KRW`로 입력해야 합니다.
 
-  - `method` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+  - method: object
 
     **결제수단 정보**
 
     스마트로의 경우 가상계좌만 지원합니다.
 
     <ParamTree>
-      - `virtualAccount` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+      - virtualAccount: object
 
         **가상계좌 결제 시 파라미터**
 
         <ParamTree>
-          - `bank` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+          - bank: string
 
             **발급 은행**
 
             - 은행코드는 ENUM으로 정의되어 있습니다.
             - [BANK ENUM 바로가기](/api/rest-v2/type-def#Bank)
 
-          - `expiry` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+          - expiry: object
 
             **입금 만료 기한**
 
             <ParamTree>
-              - `validHours` <mark style="color:purple;">**integer**</mark>
+              - validHours?: integer
 
                 **유효 시간**
 
-              - `dueDate` <mark style="color:green;">**string**</mark>
+              - dueDate?: string
 
                 **만료 시점**
 
                 시간은 ISO8601 형식으로 입력해야 합니다.
             </ParamTree>
 
-          - `option` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+          - option: object
 
             **가상계좌 발급 방식**
 
             <ParamTree>
-              - `type` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+              - type: string
 
                 **가상계좌 발급 유형**
 
@@ -709,12 +709,12 @@ import Tabs from "~/components/gitbook/Tabs";
                 - 고정식 가상계좌 : `FIXED`
                 - 회전식 가상계좌는 일반적으로 사용되는 방식이며 PG사에서 직접 채번한 가상계좌번호를 사용합니다.
 
-              - `fixed` <mark style="color:blue;">**object**</mark>
+              - fixed?: object
 
                 **고정식 가상계좌 발급 유형**
 
                 <ParamTree>
-                  - `pgAccountId` <mark style="color:green;">**string**</mark>
+                  - pgAccountId?: string
 
                     **고정식 가상계좌 ID**
 
@@ -725,12 +725,12 @@ import Tabs from "~/components/gitbook/Tabs";
                 </ParamTree>
             </ParamTree>
 
-          - `cashReceipt` <mark style="color:blue;">**object**</mark>
+          - cashReceipt?: object
 
             **현금영수증 정보**
 
             <ParamTree>
-              - `type` <mark style="color:green;">**string**</mark>
+              - type?: string
 
                 **발급 유형**
 
@@ -740,7 +740,7 @@ import Tabs from "~/components/gitbook/Tabs";
                 - 지출증빙용 : `CORPORATE`
                 - 미발행 : `NO_RECEIPT`
 
-              - `customerIdentityNumber` <mark style="color:green;">**string**</mark>
+              - customerIdentityNumber?: string
 
                 **현금영수증 식별 번호**
 
@@ -748,50 +748,50 @@ import Tabs from "~/components/gitbook/Tabs";
                 - 지출증빈인 경우 사업자등록번호를 입력해야 합니다.
             </ParamTree>
 
-          - `remitteeName` <mark style="color:green;">**string**</mark>
+          - remitteeName?: string
 
             **예금주명**
         </ParamTree>
 
-      - `customer` <mark style="color:blue;">**object**</mark>
+      - customer?: object
 
         **고객 정보**
 
         <ParamTree>
-          - `name` <mark style="color:blue;">**object**</mark>
+          - name?: object
 
             **고객 이름**
 
             <ParamTree>
-              - `full` <mark style="color:green;">**string**</mark>
+              - full?: string
 
                 **한 줄 이름 형식 (ex. 김포트)**
 
-              - `separated` <mark style="color:blue;">**object**</mark>
+              - separated?: object
 
                 **분리된 이름**
 
                 <ParamTree>
-                  - `first` <mark style="color:green;">**string**</mark>
+                  - first?: string
 
                     **이름**
 
-                  - `last` <mark style="color:green;">**string**</mark>
+                  - last?: string
 
                     **성**
                 </ParamTree>
             </ParamTree>
 
-          - `phoneNumber` <mark style="color:green;">**string**</mark>
+          - phoneNumber?: string
 
             **구매자 연락처**
 
-          - `email` <mark style="color:green;">**string**</mark>
+          - email?: string
 
             **구매자 이메일**
         </ParamTree>
 
-      - `productCount` <mark style="color:purple;">**integer**</mark>
+      - productCount?: integer
 
         **상품 개수**
     </ParamTree>
@@ -835,56 +835,56 @@ import Tabs from "~/components/gitbook/Tabs";
 #### 빌링키 발급 주요 파라미터
 
 <ParamTree>
-  - `channelKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - channelKey: string
 
     **채널 키**
 
     포트원 콘솔 내 \[결제연동] > \[채널관리] 화면에서 채널 추가 시 생성되는 값입니다. 결제 호출 시 채널을 지정할 때 사용됩니다.
 
-  - `method` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+  - method: object
 
     **결제수단 정보**
 
     스마트로의 경우 가상계좌만 지원합니다.
 
-    - `card` <mark style="color:blue;">**object**</mark>
+    - card?: object
 
       **카드 결제 시 파라미터**
 
       <ParamTree>
-        - `credential` <mark style="color:green;">**string**</mark>
+        - credential?: string
 
           **인증 관련 정보**
 
           <ParamTree>
-            - `number` <mark style="color:blue;">**object**</mark>
+            - number?: object
 
               **카드 번호**
 
-            - `expiryYear` <mark style="color:blue;">**object**</mark>
+            - expiryYear?: object
 
               **유효 기간 만료 연도 (YY 형식 ex. 24)**
 
-            - `expiryMonth` <mark style="color:green;">**string**</mark>
+            - expiryMonth?: string
 
               **유효기간 만료 월 (MM 형식 ex. 05)**
 
-            - `birthOrBusinessRegistrationNumber` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+            - birthOrBusinessRegistrationNumber: string
 
               **생년월일 또는 사업자 등록 번호**
 
-            - `passwordTwoDigits` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+            - passwordTwoDigits: string
 
               **비밀번호 앞 두자리**
           </ParamTree>
       </ParamTree>
 
-  - `customer` <mark style="color:blue;">**object**</mark>
+  - customer?: object
 
     **고객 정보**
 
     <ParamTree>
-      - `customerId` <mark style="color:green;">**string**</mark>
+      - customerId?: string
 
         **구매자 고유 ID**
 
@@ -928,78 +928,78 @@ import Tabs from "~/components/gitbook/Tabs";
 #### 빌링키 단건 결제 주요 파라미터
 
 <ParamTree>
-  - `paymentId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - paymentId: string
 
     **결제 주문 번호**
 
     - 고객사에서 채번하여 사용하는 주문번호로 고유한 값이여야 합니다.
     - URL path에 포함하여 요청해야 합니다.
 
-  - `billingKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - billingKey: string
 
     **빌링키 결제에 사용할 빌링키**
 
-  - `orderName`  <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - orderName: string
 
     **주문명**
 
-  - `amount` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+  - amount: object
 
     **결제 금액**
 
     <ParamTree>
-      - `total` <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
+      - total: number
 
         **총 결제 금액**
 
         결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
     </ParamTree>
 
-  - `currency` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - currency: string
 
     **결제 통화**
 
     결제통화로 원화 결제 시 `KRW`로 입력해야 합니다.
 
-  - `customer` <mark style="color:blue;">**object**</mark>
+  - customer?: object
 
     **고객 정보**
 
     <ParamTree>
-      - `name` <mark style="color:red;">**\***</mark><mark style="color:blue;">**object**</mark>
+      - name: object
 
         **고객 이름**
 
         <ParamTree>
-          - `full` <mark style="color:green;">**string**</mark>
+          - full?: string
 
             **한 줄 이름 형식 (ex. 김포트)**
 
-          - `separated` <mark style="color:blue;">**object**</mark>
+          - separated?: object
 
             **분리된 이름**
 
             <ParamTree>
-              - `first` <mark style="color:green;">**string**</mark>
+              - first?: string
 
                 **이름**
 
-              - `last` <mark style="color:green;">**string**</mark>
+              - last?: string
 
                 **성**
             </ParamTree>
         </ParamTree>
 
-      - `phoneNumber` <mark style="color:red;">**\***</mark><mark style="color:green;">**string**</mark>
+      - phoneNumber: string
 
         **구매자 연락처**
 
-      - `email` <mark style="color:red;">**\***</mark><mark style="color:green;">**string**</mark>
+      - email: string
 
         **구매자 이메일**
     </ParamTree>
 
-  - `productCount` <mark style="color:purple;">**integer**</mark>
+  - productCount?: integer
 
     **상품 개수**
 </ParamTree>
@@ -1039,46 +1039,46 @@ import Tabs from "~/components/gitbook/Tabs";
 #### 빌링키 예약 결제 주요 파라미터
 
 <ParamTree>
-  - `paymentId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - paymentId: string
 
     **결제 주문 번호**
 
     - 고객사에서 채번하여 사용하는 주문번호로 고유한 값이여야 합니다.
     - URL path에 포함하여 요청해야 합니다.
 
-  - `payment` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+  - payment: object
 
     **빌링키 결제 요청 입력정보**
 
     <ParamTree>
-      - `billingKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - billingKey: string
 
         **빌링키 결제에 사용할 빌링키**
 
-      - `orderName`  <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - orderName: string
 
         **주문명**
 
-      - `amount` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+      - amount: object
 
         **결제 금액**
 
         <ParamTree>
-          - `total` <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
+          - total: number
 
             **총 결제 금액**
 
             결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
         </ParamTree>
 
-      - `currency` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - currency: string
 
         **결제 통화**
 
         결제통화로 원화 결제 시 `KRW`로 입력해야 합니다.
     </ParamTree>
 
-  - `timeToPay` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - timeToPay: string
 
     **결제 예정 시점**
 </ParamTree>

--- a/src/routes/(root)/opi/ko/integration/pg/v2/tosspay-v2.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v2/tosspay-v2.mdx
@@ -52,43 +52,43 @@ function requestPayment() {
 ### 주요 파라미터
 
 <ParamTree>
-  - `storeId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - storeId: string
 
     **스토어 아이디**
 
     포트원 계정에 생성된 상점을 식별하는 고유한 값으로 관리자 콘솔에서 확인할 수 있습니다.
 
-  - `channelKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - channelKey: string
 
     **채널 키**
 
     포트원 콘솔 내 \[연동 관리] > \[연동 정보] > \[채널 관리] 화면에서 채널 추가 시 생성되는 값입니다. 결제 호출 시 채널을 지정할 때 사용됩니다.
 
-  - `paymentId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - paymentId: string
 
     **고객사 주문 고유 번호**
 
     고객사에서 채번하는 주문 고유 번호로 매번 고유하게 채번되어야 합니다. 이미 승인 완료된 `paymentId`로 결제를 시도하는 경우 에러가 발생합니다.
 
-  - `orderName` <mark style="color:red;">\*</mark> <mark style="color:green;">**string**</mark>
+  - orderName: string
 
     **주문명**
 
     주문명으로 고객사에서 자유롭게 입력합니다.
 
-  - `totalAmount` <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
+  - totalAmount: number
 
     **결제 금액**
 
     결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
 
-  - `currency` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - currency: string
 
     **결제 통화**
 
     결제통화로 원화 결제 시 `KRW`로 입력해야 합니다.
 
-  - `payMethod` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - payMethod: string
 
     **결제수단 구분코드**
 
@@ -96,17 +96,17 @@ function requestPayment() {
 
     간편 결제의 경우 `EASY_PAY`로 입력해야 합니다.
 
-  - `bypass` <mark style="color:blue;">**object**</mark>
+  - bypass?: object
 
     **PG사 결제창 호출 시 PG사로 그대로 bypass할 파라미터들의 모음**
 
     <ParamTree>
-      - `tosspay_v2` <mark style="color:blue;">**object**</mark>
+      - tosspay\_v2?: object
 
         **토스페이에서 제공하는 파라미터**
 
         <ParamTree>
-          - `expiredTime` <mark style="color:green;">**string**</mark>
+          - expiredTime?: string
 
             **결제 만료 기한**
 
@@ -114,7 +114,7 @@ function requestPayment() {
 
             입력하지 않을 경우, 기본값인 15분으로 설정됩니다. 최대 60분까지 설정할 수 있습니다.
 
-          - `cashReceiptTradeOption` <mark style="color:green;">**string**</mark>
+          - cashReceiptTradeOption?: string
 
             **현금영수증 발급 대상 타입**
 
@@ -174,36 +174,37 @@ function requestIssueBillingKey() {
 ### 주요 파라미터
 
 <ParamTree>
-  - `storeId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - storeId: string
 
     **스토어 아이디**
 
     포트원 계정에 생성된 상점을 식별하는 고유한 값으로 관리자 콘솔에서 확인할 수 있습니다.
 
-  - `channelKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - channelKey: string
 
     **채널 키**
 
     포트원 콘솔 내 \[연동 관리] > \[연동 정보] > \[채널 관리] 화면에서 채널 추가 시 생성되는 값입니다. 결제 호출 시 채널을 지정할 때 사용됩니다.
 
-  - `billingKeyMethod` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - billingKeyMethod: string
 
     **빌링키 발급수단**
 
     토스페이는 빌링키 발급 수단으로 간편결제(토스페이)만을 지원하므로 해당 파라미터는 `EASY_PAY`로 고정해야 합니다.
 
-  - `customer` <mark style="color:blue;">**object**</mark>
+  - customer?: object
 
     **고객 정보**
 
     <ParamTree>
-      - `customerId` <mark style="color:green;">**string**</mark>
+      - customerId?: string
+
         **구매자 고유 ID**
 
         - 토스페이의 경우 구매자 ID를 필수로 입력해야 합니다.
     </ParamTree>
 
-  - `redirectUrl` <mark style="color:green;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - redirectUrl: string
 
     **빌링키 발급 후 이동할 URL**
 
@@ -271,73 +272,73 @@ const response = await axios({
 ### 주요 파라미터
 
 <ParamTree>
-  - `paymentId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - paymentId: string
 
     **결제 주문 번호**
 
     - 고객사에서 채번하여 사용하는 주문번호로 고유한 값이여야 합니다.
     - URL path에 포함하여 요청해야 합니다.
 
-  - `billingKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - billingKey: string
 
     **빌링키 결제에 사용할 빌링키**
 
-  - `orderName`  <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - orderName: string
 
     **주문명**
 
-  - `amount` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+  - amount: object
 
     **결제 금액**
 
     <ParamTree>
-      - `total` <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
+      - total: number
 
         **총 결제 금액**
 
       결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
     </ParamTree>
 
-  - `currency` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - currency: string
 
     **결제 통화**
 
     결제통화로 원화 결제 시 `KRW`로 입력해야 합니다.
 
-  - `customer` <mark style="color:blue;">**object**</mark>
+  - customer?: object
 
     **고객 정보**
 
     <ParamTree>
-      - `name` <mark style="color:blue;">**object**</mark>
+      - name?: object
 
         **고객 이름**
 
         <ParamTree>
-          - `full` <mark style="color:green;">**string**</mark>
+          - full?: string
 
             **한 줄 이름 형식 (ex. 김포트)**
 
-          - `separated` <mark style="color:blue;">**object**</mark>
+          - separated?: object
 
             **분리된 이름**
 
             <ParamTree>
-              - `first` <mark style="color:green;">**string**</mark>
+              - first?: string
 
                 **이름**
 
-              - `last` <mark style="color:green;">**string**</mark>
+              - last?: string
 
                 **성**
             </ParamTree>
         </ParamTree>
 
-      - `phoneNumber` <mark style="color:green;">**string**</mark>
+      - phoneNumber?: string
 
         **구매자 연락처**
 
-      - `email` <mark style="color:green;">**string**</mark>
+      - email?: string
 
         **구매자 이메일**
     </ParamTree>
@@ -375,91 +376,91 @@ const response = await axios({
 ### 주요 파라미터
 
 <ParamTree>
-  - `paymentId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - paymentId: string
 
     **결제 주문 번호**
 
     - 고객사에서 채번하여 사용하는 주문번호로 고유한 값이여야 합니다.
     - URL path에 포함하여 요청해야 합니다.
 
-  - `payment` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+  - payment: object
 
     **빌링키 결제 요청 입력정보**
 
     <ParamTree>
-      - `billingKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - billingKey: string
 
         **빌링키 결제에 사용할 빌링키**
 
-      - `orderName`  <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - orderName: string
 
         **주문명**
 
-      - `amount` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+      - amount: object
 
         **결제 금액**
 
         <ParamTree>
-          - `total` <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
+          - total: number
 
             **총 결제 금액**
 
             결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
 
-          - `taxFree` <mark style="color:purple;">**number**</mark>
+          - taxFree?: number
 
             **면세액**
 
             결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
         </ParamTree>
 
-      - `currency` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - currency: string
 
         **결제 통화**
 
         결제통화로 원화 결제 시 `KRW`로 입력해야 합니다.
     </ParamTree>
 
-  - `timeToPay` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - timeToPay: string
 
     **결제 예정 시점**
 
-  - `customer`  <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+  - customer: object
 
     **고객 정보**
 
     <ParamTree>
-      - `name` <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+      - name: object
 
         **고객 이름**
 
         - 토스페이의 경우 full 혹은 separated를 필수로 입력해야 합니다.
 
           <ParamTree>
-            - `full` <mark style="color:green;">**string**</mark>
+            - full?: string
 
               **한 줄 이름 형식 (ex. 김포트)**
 
-            - `separated` <mark style="color:blue;">**object**</mark>
+            - separated?: object
 
               **분리된 이름**
 
               <ParamTree>
-                - `first` <mark style="color:green;">**string**</mark>
+                - first?: string
 
                   **이름**
 
-                - `last` <mark style="color:green;">**string**</mark>
+                - last?: string
 
                   **성**
               </ParamTree>
           </ParamTree>
 
-      - `phoneNumber` <mark style="color:green;">**string**</mark>
+      - phoneNumber?: string
 
         **구매자 연락처**
 
-      - `email` <mark style="color:green;">**string**</mark>
+      - email?: string
 
         **구매자 이메일**
     </ParamTree>

--- a/src/routes/(root)/opi/ko/integration/pg/v2/tosspayments.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v2/tosspayments.mdx
@@ -8,6 +8,7 @@ versionVariants:
 
 import Figure from "~/components/Figure";
 import Details from "~/components/gitbook/Details";
+import ParamTree from "~/components/gitbook/ParamTree";
 import Tabs from "~/components/gitbook/Tabs";
 
 import image1 from "../_assets/tosspayments/tosspayments_1.webp";
@@ -144,26 +145,35 @@ import image5 from "../_assets/tosspayments/tosspayments_5.png";
 
 ## 주요 파라미터
 
-- `storeId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-  - 고객사의 상점을 식별하는 고유한 값입니다.
+<ParamTree>
+  - `storeId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
-- `paymentId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-  - 고객사가 채번하는 주문 고유 번호로 매번 고유하게 채번되어야 합니다.
+    고객사의 상점을 식별하는 고유한 값입니다.
 
-- `orderName` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-  - 주문명으로 고객사에서 자유롭게 입력합니다.
+  - `paymentId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
-- `channelKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-  - 콘솔의 결제 연동 메뉴에 표시되는 채널 키를 입력해야 합니다.
+    고객사가 채번하는 주문 고유 번호로 매번 고유하게 채번되어야 합니다.
 
-- `totalAmount` <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
-  - 결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
+  - `orderName` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
 
-- `currency` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-  - 결제통화로 원화 결제를 원할 시 `KRW`로 입력해야 합니다.
+    주문명으로 고객사에서 자유롭게 입력합니다.
 
-- `payMethod` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
-  - 결제수단을 구분하는 코드로 원하는 결제수단 값을 입력해야 합니다.
+  - `channelKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+
+    콘솔의 결제 연동 메뉴에 표시되는 채널 키를 입력해야 합니다.
+
+  - `totalAmount` <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
+
+    결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
+
+  - `currency` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+
+    결제통화로 원화 결제를 원할 시 `KRW`로 입력해야 합니다.
+
+  - `payMethod` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+
+    결제수단을 구분하는 코드로 원하는 결제수단 값을 입력해야 합니다.
+</ParamTree>
 
 ## 유의할 파라미터 - SDK
 

--- a/src/routes/(root)/opi/ko/integration/pg/v2/tosspayments.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v2/tosspayments.mdx
@@ -146,31 +146,31 @@ import image5 from "../_assets/tosspayments/tosspayments_5.png";
 ## 주요 파라미터
 
 <ParamTree>
-  - `storeId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - storeId: string
 
     고객사의 상점을 식별하는 고유한 값입니다.
 
-  - `paymentId` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - paymentId: string
 
     고객사가 채번하는 주문 고유 번호로 매번 고유하게 채번되어야 합니다.
 
-  - `orderName` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - orderName: string
 
     주문명으로 고객사에서 자유롭게 입력합니다.
 
-  - `channelKey` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - channelKey: string
 
     콘솔의 결제 연동 메뉴에 표시되는 채널 키를 입력해야 합니다.
 
-  - `totalAmount` <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
+  - totalAmount: number
 
     결제 금액으로 결제를 원하는 통화(currency)별 scale factor(소수점 몇번째 자리까지 유효한지)를 고려한 number 형식만 허용됩니다.
 
-  - `currency` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - currency: string
 
     결제통화로 원화 결제를 원할 시 `KRW`로 입력해야 합니다.
 
-  - `payMethod` <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - payMethod: string
 
     결제수단을 구분하는 코드로 원하는 결제수단 값을 입력해야 합니다.
 </ParamTree>

--- a/src/routes/(root)/sdk/ko/v1-sdk/javascript-sdk/payrq.mdx
+++ b/src/routes/(root)/sdk/ko/v1-sdk/javascript-sdk/payrq.mdx
@@ -149,23 +149,23 @@ PG사별 지원되는 결제수단이 모두 상이합니다.
 상품을 나타내는 아래의 객체들을 갖는 **배열**을 전달해주세요.
 
 <ParamTree>
-  - **`id`** <mark style="color:green;">**string**</mark>
+  - id?: string
 
     상품 고유 ID
 
-  - **`name`** <mark style="color:green;">**string**</mark>
+  - name?: string
 
     상품명
 
-  - **`code`** <mark style="color:green;">**string**</mark>
+  - code?: string
 
     상품 코드
 
-  - **`unitPrice`** <mark style="color:purple;">**number**</mark>
+  - unitPrice?: number
 
     상품 단위 가격
 
-  - **`quantity`** <mark style="color:purple;">**number**</mark>
+  - quantity?: number
 
     수량
 </ParamTree>

--- a/src/routes/(root)/sdk/ko/v2-sdk/billing-key-request.mdx
+++ b/src/routes/(root)/sdk/ko/v2-sdk/billing-key-request.mdx
@@ -11,14 +11,15 @@ import ParamTree from "~/components/gitbook/ParamTree";
 
 ## 빌링키 발급 요청 파라미터 정의
 
-### **`storeId`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+<ParamTree>
+### storeId: string
 
 **상점 ID**
 
 - 포트원에서 채번하는 상점 ID입니다.
 - 관리자콘솔의 결제 연동 페이지에서 확인하실 수 있습니다.
 
-### **`channelKey`** <mark style="color:green;">**string**</mark>
+### channelKey?: string
 
 **채널 키**
 
@@ -26,7 +27,7 @@ import ParamTree from "~/components/gitbook/ParamTree";
 
 `pgProvider` 파라미터가 없는 경우에 필수로 존재해야 합니다. 두 파라미터가 모두 존재하는 경우 `channelKey`를 적용하니 둘 중 하나만 제공해주세요.
 
-## **`billingKeyMethod`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+## billingKeyMethod: string
 
 **빌링키 발급수단 구분코드**
 
@@ -44,17 +45,17 @@ PG사별 지원되는 발급수단이 모두 상이합니다.
   </Details.Content>
 </Details>
 
-### **`issueName`** <mark style="color:green;">**string**</mark>
+### issueName?: string
 
 **빌링키 발급 시 결제창에 표시되는 제목**
 
 KG이니시스, 카카오페이, 네이버페이, 나이스페이먼츠, 스마트로, 토스페이, 웰컴페이먼츠에서만 지원합니다.
 
-### **`issueId`** <mark style="color:green;">**string**</mark>
+### issueId?: string
 
 **고객사에서 채번하는 빌링키 발급 건 고유 ID**
 
-### **`displayAmount`** <mark style="color:green;">**number**</mark>
+### displayAmount?: number
 
 **빌링키 발급창에 띄워줄 금액**
 
@@ -62,13 +63,13 @@ KG이니시스, 네이버페이, 웰컴페이먼츠에서만 지원합니다. �
 
 해당 파라미터를 입력할 경우 `currency` 필드도 함께 입력해야 합니다.
 
-### **`currency`** <mark style="color:green;">**string**</mark>
+### currency?: string
 
 **빌링키 발급창에 띄워줄 금액의 화폐**
 
 해당 파라미터를 입력할 경우 `displayAmount` 필드도 함께 입력해야 합니다.
 
-### **`customer`** <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+### customer: object
 
 **고객 정보**
 
@@ -115,7 +116,7 @@ KG이니시스, 네이버페이, 웰컴페이먼츠에서만 지원합니다. �
     **구매자 출생년도** ex. `"1990"` 같은 형식으로 입력해주세요.
 </ParamTree>
 
-### **`windowType`** <mark style="color:blue;">**object**</mark>
+### windowType?: object
 
 **결제 환경 별 제공되는 결제창 유형**
 
@@ -135,14 +136,14 @@ KG이니시스, 네이버페이, 웰컴페이먼츠에서만 지원합니다. �
     **모바일에서의 결제창 유형** `IFRAME`, `REDIRECTION`, `POPUP` 중 하나를 입력해주세요.
 </ParamTree>
 
-### **`noticeUrls`** <mark style="color:green;">**string\[]**</mark>
+### noticeUrls?: string\[]
 
 **웹훅(Webhook) 수신 주소**
 
 - 포트원 관리자 콘솔에 설정한 웹훅 주소 대신 사용할 웹훅 주소를 빌링키 발급시마다 설정할 수 있습니다.
 - 해당 값 설정시 관리자 콘솔에 설정한 주소로는 웹훅발송이 되지 않는점 유의하시기 바랍니다.
 
-### **`redirectUrl`** <mark style="color:green;">**string**</mark>
+### redirectUrl?: string
 
 **리디렉션 방식에서 결제 프로세스 완료 후 이동될 고객사 URL**
 
@@ -150,14 +151,14 @@ KG이니시스, 네이버페이, 웰컴페이먼츠에서만 지원합니다. �
 - 대부분의 모바일 결제환경에서 결제창 호출시 필수 항목입니다.
 - 리다이렉트 환경에서 해당 필드 누락시 에러가 발생합니다.
 
-### **`appScheme`** <mark style="color:green;">**string**</mark>
+### appScheme?: string
 
 **모바일 결제 후 고객사 앱으로 복귀를 위한 URL scheme**
 
 - WebView 환경 결제시 필수설정 항목 입니다.
 - ISP/앱카드 앱에서 결제정보인증 후 기존 앱으로 복귀할 때 사용합니다.
 
-### **`locale`** <mark style="color:green;">**string**</mark>
+### locale?: string
 
 **결제창 언어** (지원되지 않은 일부 PG사 존재)
 
@@ -170,7 +171,7 @@ KG이니시스, 네이버페이, 웰컴페이먼츠에서만 지원합니다. �
   </Details.Content>
 </Details>
 
-### **`offerPeriod`** <mark style="color:blue;">**string**</mark>
+### offerPeriod?: string
 
 서비스 제공 기간
 
@@ -196,21 +197,21 @@ range(기간 범위)와 interval(제공 주기) 중 하나를 입력해주세요
     제공 주기 (`${number}d | ${number}m | ${number}y` 형태로 입력할 수 있습니다.)
 </ParamTree>
 
-### **`customData`** <mark style="color:blue;">**object**</mark>
+### customData?: object
 
 **결제 정보와 함께 관리하고 싶은 고객사 커스텀 JSON 데이터**
 
-### **`popup`** <mark style="color:blue;">**object**</mark>
+### popup?: object
 
 **결제창이 팝업 방식일 경우 결제창에 적용할 속성**
 
 <ParamTree>
-  - **`center`** <mark style="color:orange;">**boolean**</mark>
+  - center?: boolean
 
     `true`로 설정하면 결제창이 브라우저 화면의 정중앙에 표시됩니다.
 </ParamTree>
 
-### **`bypass`** <mark style="color:blue;">**oneof object**</mark>
+### bypass?: oneof object
 
 **PG사 빌링키 발급 창 호출 시 PG사로 그대로 bypass할 값들의 모음**
 
@@ -258,7 +259,7 @@ range(기간 범위)와 interval(제공 주기) 중 하나를 입력해주세요
     </ParamTree>
 </ParamTree>
 
-### **`card`** <mark style="color:blue;">**object**</mark>
+### card?: object
 
 `billingKeyMethod`가 `CARD`인 경우에만 허용됩니다.
 
@@ -303,7 +304,7 @@ range(기간 범위)와 interval(제공 주기) 중 하나를 입력해주세요
     </Details>
 </ParamTree>
 
-### **`mobile`** <mark style="color:blue;">**object**</mark>
+### mobile?: object
 
 `billingKeyMethod`가 `MOBILE`인 경우에만 허용됩니다.
 
@@ -332,7 +333,7 @@ range(기간 범위)와 interval(제공 주기) 중 하나를 입력해주세요
     </Details>
 </ParamTree>
 
-### **`easyPay`** <mark style="color:blue;">**object**</mark>
+### easyPay?: object
 
 `billingKeyMethod`가 `EASY_PAY`인 경우에만 허용됩니다.
 
@@ -364,4 +365,5 @@ range(기간 범위)와 interval(제공 주기) 중 하나를 입력해주세요
         - LGPAY (LGPAY)
       </Details.Content>
     </Details>
+</ParamTree>
 </ParamTree>

--- a/src/routes/(root)/sdk/ko/v2-sdk/billing-key-request.mdx
+++ b/src/routes/(root)/sdk/ko/v2-sdk/billing-key-request.mdx
@@ -73,44 +73,44 @@ KG이니시스, 네이버페이, 웰컴페이먼츠에서만 지원합니다. �
 **고객 정보**
 
 <ParamTree>
-  - **`customerId`** <mark style="color:green;">**string**</mark>
+  - customerId?: string
 
     **구매자 고유 ID**
 
-  - **`fullName`** <mark style="color:green;">**string**</mark>
+  - fullName?: string
 
     **구매자 전체 이름** `fullName`과 `firstName` / `lastName`이 모두 입력된 경우 `fullName`으로 기록됩니다.
 
-  - **`firstName`** <mark style="color:green;">**string**</mark>
+  - firstName?: string
 
     **구매자 이름** `firstName`을 입력하는 경우 `lastName`도 필수로 입력해야 합니다.
     `fullName`이 없고, `firstName`과 `lastName`이 존재하는 경우 `{firstName} {lastName}`으로 저장됩니다.
 
-  - **`lastName`** <mark style="color:green;">**string**</mark>
+  - lastName?: string
 
     **구매자 성** `lastName`을 입력하는 경우 `firstName`도 필수로 입력해야 합니다.
 
-  - **`phoneNumber`** <mark style="color:green;">**string**</mark>
+  - phoneNumber?: string
 
     **구매자 연락처**
 
-  - **`email`** <mark style="color:green;">**string**</mark>
+  - email?: string
 
     **구매자 이메일 주소** 유효한 이메일 주소를 입력해주세요.
 
-  - **`address`** <mark style="color:green;">**string**</mark>
+  - address?: string
 
     **구매자 주소**
 
-  - **`zipcode`** <mark style="color:green;">**string**</mark>
+  - zipcode?: string
 
     **구매자 우편번호**
 
-  - **`gender`** <mark style="color:green;">**string**</mark>
+  - gender?: string
 
     **구매자 성별** `MALE`, `FEMALE`, `OTHER` 중 하나를 입력해주세요.
 
-  - **`birthYear`** <mark style="color:green;">**string**</mark>
+  - birthYear?: string
 
     **구매자 출생년도** ex. `"1990"` 같은 형식으로 입력해주세요.
 </ParamTree>
@@ -126,11 +126,11 @@ KG이니시스, 네이버페이, 웰컴페이먼츠에서만 지원합니다. �
 </div>
 
 <ParamTree>
-  - **`pc`** <mark style="color:green;">**string**</mark>
+  - pc?: string
 
     **PC에서의 결제창 유형** `IFRAME`, `REDIRECTION`, `POPUP` 중 하나를 입력해주세요.
 
-  - **`mobile`** <mark style="color:green;">**string**</mark>
+  - mobile?: string
 
     **모바일에서의 결제창 유형** `IFRAME`, `REDIRECTION`, `POPUP` 중 하나를 입력해주세요.
 </ParamTree>
@@ -177,21 +177,21 @@ KG이니시스, 네이버페이, 웰컴페이먼츠에서만 지원합니다. �
 range(기간 범위)와 interval(제공 주기) 중 하나를 입력해주세요.
 
 <ParamTree>
-  - **`range`** <mark style="color:green;">**object**</mark>
+  - range?: object
 
     기간 범위
 
     <ParamTree>
-      - **`from`** <mark style="color:purple;">**string**</mark>
+      - from?: string
 
         시작 시점
 
-      - **`to`** <mark style="color:purple;">**string**</mark>
+      - to?: string
 
         종료 시점
     </ParamTree>
 
-  - **`interval`** <mark style="color:green;">**string**</mark>
+  - interval?: string
 
     제공 주기 (`${number}d | ${number}m | ${number}y` 형태로 입력할 수 있습니다.)
 </ParamTree>
@@ -215,40 +215,40 @@ range(기간 범위)와 interval(제공 주기) 중 하나를 입력해주세요
 **PG사 빌링키 발급 창 호출 시 PG사로 그대로 bypass할 값들의 모음**
 
 <ParamTree>
-  - **`kakaopay`** <mark style="color:blue;">**object**</mark>
+  - kakaopay?: object
 
     카카오페이 bypass 파라미터
 
     <ParamTree>
-      - **`custom_message`** <mark style="color:green;">**string**</mark>
+      - custom\_message?: string
 
         카카오페이 결제창에 띄워줄 사용자 정의 문구
     </ParamTree>
 
-  - **`smartro_v2`** <mark style="color:blue;">**object**</mark>
+  - smartro\_v2?: object
 
     스마트로 V2 bypass 파라미터
 
     <ParamTree>
-      - **`SkinColor`** <mark style="color:green;">**string**</mark>
+      - SkinColor?: string
 
         UI 스타일 (기본값: `"RED"`)
 
         `"RED"`, `"GREEN"`, `"BLUE"`, `"PURPLE"` 중 하나의 값으로 입력해주세요.
 
-      - **`IsPwdPass`** <mark style="color:green;">**string**</mark>
+      - IsPwdPass?: string
 
         결제 비밀번호 등록 Skip 여부 (`"Y"`: 비밀번호 설정 미사용, `"N"`(기본값): 비밀번호 설정 사용)
 
         `"Y"`, `"N"` 중 하나의 값으로 입력해주세요.
     </ParamTree>
 
-  - **`inicis_v2`** <mark style="color:blue;">**object**</mark>
+  - inicis\_v2?: object
 
     이니시스 bypass 파라미터
 
     <ParamTree>
-      - **`carduse`** <mark style="color:green;">**'percard' | 'cocard'**</mark>
+      - carduse?: 'percard' | 'cocard'
 
         개인/법인카드 사용 선택 옵션
 
@@ -269,7 +269,7 @@ range(기간 범위)와 interval(제공 주기) 중 하나를 입력해주세요
 </div>
 
 <ParamTree>
-  - **`cardCompany`** <mark style="color:green;">**string**</mark>
+  - cardCompany?: string
 
     **카드사 다이렉트 호출 시 필요한 카드사 식별 값**
 
@@ -314,7 +314,7 @@ range(기간 범위)와 interval(제공 주기) 중 하나를 입력해주세요
 </div>
 
 <ParamTree>
-  - **`carrier`** <mark style="color:green;">**string**</mark>
+  - carrier?: string
 
     **휴대폰 소액결제 시 필요한 통신사 식별 값**
 
@@ -343,7 +343,7 @@ range(기간 범위)와 interval(제공 주기) 중 하나를 입력해주세요
 </div>
 
 <ParamTree>
-  - **`easyPayProvider`** <mark style="color:green;">**string**</mark>
+  - easyPayProvider?: string
 
     **간편결제 수단**
 

--- a/src/routes/(root)/sdk/ko/v2-sdk/billing-key-response.mdx
+++ b/src/routes/(root)/sdk/ko/v2-sdk/billing-key-response.mdx
@@ -6,40 +6,44 @@ versionVariants:
   v1: /sdk/ko/v1-sdk/javascript-sdk/payrt
 ---
 
+import ParamTree from "~/components/gitbook/ParamTree";
+
 ## 빌링키 발급 응답 파라미터 정의
 
-### **`transactionType`** <mark style="color:green;">**string**</mark>
+<ParamTree>
+### transactionType?: string
 
 **트랜잭션 유형**
 
 - 빌링키 발급의 경우 무조건 `ISSUE_BILLING_KEY`로 전달됩니다.
 
-### **`billingKey`** <mark style="color:green;">**string**</mark>
+### billingKey?: string
 
 **빌링키**
 
 - 빌링 결제를 일으킬 때 사용하는 포트원 빌링키입니다.
 
-### **`code`** <mark style="color:green;">**string**</mark>
+### code?: string
 
 **오류 코드**
 
 - 실패한 경우 오류 코드입니다.
 
-### **`message`** <mark style="color:green;">**string**</mark>
+### message?: string
 
 **오류 메시지**
 
 - 실패한 경우 오류 메시지입니다.
 
-### **`pgCode`** <mark style="color:green;">**string**</mark>
+### pgCode?: string
 
 **PG 오류 코드**
 
 - PG에서 오류 코드를 내려 주는 경우 이 오류 코드를 그대로 반환합니다.
 
-### **`pgMessage`** <mark style="color:green;">**string**</mark>
+### pgMessage?: string
 
 **PG 오류 메시지**
 
 - PG에서 오류 메시지를 내려 주는 경우 이 오류 메시지를 그대로 반환합니다.
+</ParamTree>

--- a/src/routes/(root)/sdk/ko/v2-sdk/identity-verification-request.mdx
+++ b/src/routes/(root)/sdk/ko/v2-sdk/identity-verification-request.mdx
@@ -38,45 +38,45 @@ import ParamTree from "~/components/gitbook/ParamTree";
 **고객 정보**
 
 <ParamTree>
-  - **`customerId`** <mark style="color:green;">**string**</mark>
+  - customerId?: string
 
     **구매자 고유 ID**
 
-  - **`fullName`** <mark style="color:green;">**string**</mark>
+  - fullName?: string
 
     **구매자 전체 이름**
 
     `fullName`과 `firstName` / `lastName`이 모두 입력된 경우 `fullName`으로 기록됩니다.
 
-  - **`firstName`** <mark style="color:green;">**string**</mark>
+  - firstName?: string
 
     **구매자 이름**
 
     `firstName`을 입력하는 경우 `lastName`도 필수로 입력해야 합니다. `fullName`이 없고,
     `firstName`과 `lastName`이 존재하는 경우 `{firstName} {lastName}`으로 저장됩니다.
 
-  - **`lastName`** <mark style="color:green;">**string**</mark>
+  - lastName?: string
 
     **구매자 성**
 
     `lastName`을 입력하는 경우 `firstName`도 필수로 입력해야 합니다.
 
-  - **`phoneNumber`** <mark style="color:green;">**string**</mark>
+  - phoneNumber?: string
 
     **구매자 연락처**
 
-  - **`email`** <mark style="color:green;">**string**</mark>
+  - email?: string
 
     **구매자 이메일 주소**
 
     유효한 이메일 주소를 입력해주세요.
 
-  - **`address`** <mark style="color:green;">**object**</mark>
+  - address?: object
 
     **구매자 주소**
 
     <ParamTree>
-      - **`country`** <mark style="color:purple;">**string**</mark>
+      - country?: string
 
         **국가**
 
@@ -336,46 +336,46 @@ import ParamTree from "~/components/gitbook/ParamTree";
           </Details.Content>
         </Details>
 
-      - **`addressLine1`** <mark style="color:red;">**\***</mark> <mark style="color:purple;">**string**</mark>
+      - addressLine1: string
 
         **일반주소**
 
-      - **`addressLine2`** <mark style="color:red;">**\***</mark> <mark style="color:purple;">**string**</mark>
+      - addressLine2: string
 
         **상세주소**
 
-      - **`city`** <mark style="color:purple;">**string**</mark>
+      - city?: string
 
         **도시**
 
-      - **`province`** <mark style="color:purple;">**string**</mark>
+      - province?: string
 
         **주, 도, 시**
     </ParamTree>
 
-  - **`zipcode`** <mark style="color:green;">**string**</mark>
+  - zipcode?: string
 
     **구매자 우편번호**
 
-  - **`gender`** <mark style="color:green;">**string**</mark>
+  - gender?: string
 
     **구매자 성별**
 
     `MALE`, `FEMALE`, `OTHER` 중 하나를 입력해주세요.
 
-  - **`birthYear`** <mark style="color:green;">**string**</mark>
+  - birthYear?: string
 
     **구매자 출생년도**
 
     ex. `"1990"` 같은 형식으로 입력해주세요.
 
-  - **`birthMonth`** <mark style="color:green;">**string**</mark>
+  - birthMonth?: string
 
     **구매자 출생월**
 
     ex. `"12"`, `"07"` 같은 형식으로 입력해주세요.
 
-  - **`birthDay`** <mark style="color:green;">**string**</mark>
+  - birthDay?: string
 
     **구매자 출생일**
 
@@ -393,11 +393,11 @@ import ParamTree from "~/components/gitbook/ParamTree";
 </div>
 
 <ParamTree>
-  - **`pc`** <mark style="color:green;">**string**</mark>
+  - pc?: string
 
     **PC에서의 본인인증 창 유형** `IFRAME`, `REDIRECTION`, `POPUP` 중 하나를 입력해주세요.
 
-  - **`mobile`** <mark style="color:green;">**string**</mark>
+  - mobile?: string
 
     **모바일에서의 본인인증 창 유형** `IFRAME`, `REDIRECTION`, `POPUP` 중 하나를 입력해주세요.
 </ParamTree>
@@ -429,12 +429,12 @@ import ParamTree from "~/components/gitbook/ParamTree";
 **PG사 본인인증 창 호출 시 PG사로 그대로 bypass할 값들의 모음**
 
 <ParamTree>
-  - **`danal`** <mark style="color:blue;">**object**</mark>
+  - danal?: object
 
     **다날 bypass 파라미터**
 
     <ParamTree>
-      - **`CPTITLE`** <mark style="color:green;">**string**</mark>
+      - CPTITLE?: string
 
         **고객사 서비스 URL 혹은 본인확인 기능 사용 경로**
 
@@ -443,13 +443,13 @@ import ParamTree from "~/components/gitbook/ParamTree";
         - 웹 서비스 URL 자체가 존재하지 않는 경우 서비스 이름 (app 이름) 입력. Ex) `마켓A`
         - 해당 값을 넘기지 않을 경우 `포트원`으로 default 값을 채웁니다.
 
-      - **`AGELIMIT`** <mark style="color:green;">**number**</mark>
+      - AGELIMIT?: number
 
         **본인인증을 진행할 수 있는 최소 나이**
 
         해당 값을 채워서 요청할 경우 본인인증을 진행할 수 있는 최소 나이를 설정할 수 있습니다.
 
-      - **`IsCarrier`** <mark style="color:green;">**string**</mark>
+      - IsCarrier?: string
 
         **통신사 정보**
 
@@ -460,12 +460,12 @@ import ParamTree from "~/components/gitbook/ParamTree";
         여러 개의 통신사를 활성화시키려면 위 값들을 semicolon(`;`) 으로 이어야 합니다. ex) `SKT;KTF`
     </ParamTree>
 
-  - **`inicisUnified`** <mark style="color:blue;">**object**</mark>
+  - inicisUnified?: object
 
     **KG이니시스 bypass 파라미터**
 
     <ParamTree>
-      - **`directAgency`** <mark style="color:green;">**string**</mark>
+      - directAgency?: string
 
         **단독 노출할 인증 업체 코드**
 
@@ -492,7 +492,7 @@ import ParamTree from "~/components/gitbook/ParamTree";
           </Details.Content>
         </Details>
 
-      - **`flgFixedUser`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+      - flgFixedUser: string
 
         **인증 창에서 고객 정보를 미리 채울지 여부**
 
@@ -500,7 +500,7 @@ import ParamTree from "~/components/gitbook/ParamTree";
 
         `Y`인 경우 이름, 연락처, 출생년도, 출생월, 출생일을 필수로 입력해야 합니다.
 
-      - **`logoUrl`** <mark style="color:green;">**string**</mark>
+      - logoUrl?: string
 
         **인증 창에 표시할 로고 URL**
 
@@ -508,6 +508,5 @@ import ParamTree from "~/components/gitbook/ParamTree";
         최적 크기는 가로 164px, 세로 28px입니다.
 
         HTTP URL인 경우 로고가 표시되지 않을 수 있습니다.
-        
     </ParamTree>
 </ParamTree>

--- a/src/routes/(root)/sdk/ko/v2-sdk/identity-verification-request.mdx
+++ b/src/routes/(root)/sdk/ko/v2-sdk/identity-verification-request.mdx
@@ -11,21 +11,22 @@ import ParamTree from "~/components/gitbook/ParamTree";
 
 ## 본인인증 요청 파라미터 정의
 
-### **`storeId`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+<ParamTree>
+### storeId: string
 
 **상점 ID**
 
 - 포트원에서 채번하는 상점 ID입니다.
 - 관리자콘솔의 결제 연동 페이지에서 확인하실 수 있습니다.
 
-### **`identityVerificationId`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+### identityVerificationId: string
 
 **본인인증건 고유 번호**
 
 - 고객사가 채번하는 본인인증 건에 대한 고유 번호입니다.
 - 이미 본인인증이 완료된 `identityVerificationId`로 다시 본인인증을 시도하는 경우 에러가 발생합니다.
 
-### **`channelKey`** <mark style="color:green;">**string**</mark>
+### channelKey?: string
 
 **채널 키**
 
@@ -33,7 +34,7 @@ import ParamTree from "~/components/gitbook/ParamTree";
 
 `pgProvider` 파라미터가 없는 경우에 필수로 존재해야 합니다. 두 파라미터가 모두 존재하는 경우 `channelKey`를 적용하니 둘 중 하나만 제공해주세요.
 
-### **`customer`** <mark style="color:blue;">**object**</mark>
+### customer?: object
 
 **고객 정보**
 
@@ -382,7 +383,7 @@ import ParamTree from "~/components/gitbook/ParamTree";
     ex. `"25"`, `"08"` 같은 형식으로 입력해주세요.
 </ParamTree>
 
-### **`windowType`** <mark style="color:blue;">**object**</mark>
+### windowType?: object
 
 **환경별 제공되는 본인인증 창 유형**
 
@@ -402,7 +403,7 @@ import ParamTree from "~/components/gitbook/ParamTree";
     **모바일에서의 본인인증 창 유형** `IFRAME`, `REDIRECTION`, `POPUP` 중 하나를 입력해주세요.
 </ParamTree>
 
-### **`redirectUrl`** <mark style="color:green;">**string**</mark>
+### redirectUrl?: string
 
 **리디렉션 방식에서 본인인증 프로세스 완료 후 이동될 고객사 URL**
 
@@ -410,21 +411,21 @@ import ParamTree from "~/components/gitbook/ParamTree";
 - 대부분의 모바일 환경에서 본인인증 창 호출시 필수 항목입니다.
 - 리다이렉트 환경에서 해당 필드 누락시 에러가 발생합니다.
 
-### **`customData`** <mark style="color:blue;">**object**</mark>
+### customData?: object
 
 **결제 정보와 함께 관리하고 싶은 고객사 커스텀 JSON 데이터**
 
-### **`popup`** <mark style="color:blue;">**object**</mark>
+### popup?: object
 
 **본인인증 창이 팝업 방식일 경우 본인인증 창에 적용할 속성**
 
 <ParamTree>
-  - **`center`** <mark style="color:orange;">**boolean**</mark>
+  - center?: boolean
 
     `true`로 설정하면 본인인증 창이 브라우저 화면의 정중앙에 표시됩니다.
 </ParamTree>
 
-### **`bypass`** <mark style="color:blue;">**oneof object**</mark>
+### bypass?: oneof object
 
 **PG사 본인인증 창 호출 시 PG사로 그대로 bypass할 값들의 모음**
 
@@ -509,4 +510,5 @@ import ParamTree from "~/components/gitbook/ParamTree";
 
         HTTP URL인 경우 로고가 표시되지 않을 수 있습니다.
     </ParamTree>
+</ParamTree>
 </ParamTree>

--- a/src/routes/(root)/sdk/ko/v2-sdk/identity-verification-response.mdx
+++ b/src/routes/(root)/sdk/ko/v2-sdk/identity-verification-response.mdx
@@ -6,46 +6,50 @@ versionVariants:
   v1: /sdk/ko/v1-sdk/javascript-sdk/cft-rt
 ---
 
+import ParamTree from "~/components/gitbook/ParamTree";
+
 ## 본인인증 응답 파라미터 정의
 
-### **`transactionType`** <mark style="color:green;">**string**</mark>
+<ParamTree>
+### transactionType?: string
 
 **트랜잭션 유형**
 
 - 본인인증의 경우 경우 항상 `IDENTITY_VERIFICATION`으로 전달됩니다.
 
-### **`identityVerificationId`** <mark style="color:green;">**string**</mark>
+### identityVerificationId?: string
 
 **본인인증 ID**
 
 - 본인인증 요청에 전달된 본인인증 ID입니다.
 
-### **`identityVerificationTxId`** <mark style="color:green;">**string**</mark>
+### identityVerificationTxId?: string
 
 **본인인증 시도 고유 번호**
 
 - 포트원에서 채번하는 본인인증 시도 고유 번호입니다.
 
-### **`code`** <mark style="color:green;">**string**</mark>
+### code?: string
 
 **오류 코드**
 
 - 실패한 경우 오류 코드입니다.
 
-### **`message`** <mark style="color:green;">**string**</mark>
+### message?: string
 
 **에러 메시지**
 
 - 실패한 경우 오류 메시지입니다.
 
-### **`pgCode`** <mark style="color:green;">**string**</mark>
+### pgCode?: string
 
 **PG 오류 코드**
 
 - PG에서 오류 코드를 내려 주는 경우 이 오류 코드를 그대로 반환합니다.
 
-### **`pgMessage`** <mark style="color:green;">**string**</mark>
+### pgMessage?: string
 
 **PG 오류 메시지**
 
 - PG에서 오류 메시지를 내려 주는 경우 이 오류 메시지를 그대로 반환합니다.
+</ParamTree>

--- a/src/routes/(root)/sdk/ko/v2-sdk/payment-request.mdx
+++ b/src/routes/(root)/sdk/ko/v2-sdk/payment-request.mdx
@@ -283,45 +283,45 @@ PG사별 지원되는 결제수단이 모두 상이합니다.
 **고객 정보**
 
 <ParamTree>
-  - **`customerId`** <mark style="color:green;">**string**</mark>
+  - customerId?: string
 
     **구매자 고유 ID**
 
-  - **`fullName`** <mark style="color:green;">**string**</mark>
+  - fullName?: string
 
     **구매자 전체 이름**
 
     `fullName`과 `firstName` / `lastName`이 모두 입력된 경우 `fullName`으로 기록됩니다.
 
-  - **`firstName`** <mark style="color:green;">**string**</mark>
+  - firstName?: string
 
     **구매자 이름**
 
     `firstName`을 입력하는 경우 `lastName`도 필수로 입력해야 합니다. `fullName`이 없고,
     `firstName`과 `lastName`이 존재하는 경우 `{firstName} {lastName}`으로 저장됩니다.
 
-  - **`lastName`** <mark style="color:green;">**string**</mark>
+  - lastName?: string
 
     **구매자 성**
 
     `lastName`을 입력하는 경우 `firstName`도 필수로 입력해야 합니다.
 
-  - **`phoneNumber`** <mark style="color:green;">**string**</mark>
+  - phoneNumber?: string
 
     **구매자 연락처**
 
-  - **`email`** <mark style="color:green;">**string**</mark>
+  - email?: string
 
     **구매자 이메일 주소**
 
     유효한 이메일 주소를 입력해주세요.
 
-  - **`address`** <mark style="color:green;">**object**</mark>
+  - address?: object
 
     **구매자 주소**
 
     <ParamTree>
-      - **`country`** <mark style="color:purple;">**string**</mark>
+      - country?: string
 
         **국가**
 
@@ -581,46 +581,46 @@ PG사별 지원되는 결제수단이 모두 상이합니다.
           </Details.Content>
         </Details>
 
-      - **`addressLine1`** <mark style="color:red;">**\***</mark> <mark style="color:purple;">**string**</mark>
+      - addressLine1: string
 
         **일반주소**
 
-      - **`addressLine2`** <mark style="color:red;">**\***</mark> <mark style="color:purple;">**string**</mark>
+      - addressLine2: string
 
         **상세주소**
 
-      - **`city`** <mark style="color:purple;">**string**</mark>
+      - city?: string
 
         **도시**
 
-      - **`province`** <mark style="color:purple;">**string**</mark>
+      - province?: string
 
         **주, 도, 시**
     </ParamTree>
 
-  - **`zipcode`** <mark style="color:green;">**string**</mark>
+  - zipcode?: string
 
     **구매자 우편번호**
 
-  - **`gender`** <mark style="color:green;">**string**</mark>
+  - gender?: string
 
     **구매자 성별**
 
     `MALE`, `FEMALE`, `OTHER` 중 하나를 입력해주세요.
 
-  - **`birthYear`** <mark style="color:green;">**string**</mark>
+  - birthYear?: string
 
     **구매자 출생년도**
 
     ex. `"1990"` 같은 형식으로 입력해주세요.
 
-  - **`birthMonth`** <mark style="color:green;">**string**</mark>
+  - birthMonth?: string
 
     **구매자 출생월**
 
     ex. `"12"`, `"07"` 같은 형식으로 입력해주세요.
 
-  - **`birthDay`** <mark style="color:green;">**string**</mark>
+  - birthDay?: string
 
     **구매자 출생일**
 
@@ -638,11 +638,11 @@ PG사별 지원되는 결제수단이 모두 상이합니다.
 </div>
 
 <ParamTree>
-  - **`pc`** <mark style="color:green;">**string**</mark>
+  - pc?: string
 
     **PC에서의 결제창 유형** `IFRAME`, `REDIRECTION`, `POPUP` 중 하나를 입력해주세요.
 
-  - **`mobile`** <mark style="color:green;">**string**</mark>
+  - mobile?: string
 
     **모바일에서의 결제창 유형** `IFRAME`, `REDIRECTION`, `POPUP` 중 하나를 입력해주세요.
 </ParamTree>
@@ -694,21 +694,21 @@ PG사별 지원되는 결제수단이 모두 상이합니다.
 **구매 상품 상세 정보**
 
 <ParamTree>
-  - **`id`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - id: string
 
     **상품 ID**
 
-  - **`name`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+  - name: string
 
     **상품명**
 
-  - **`code`** <mark style="color:green;">**string**</mark>
+  - code?: string
 
     **상품 코드**
 
     - 토스페이먼츠의 경우 필수로 입력해주세요.
 
-  - **`amount`** <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
+  - amount: number
 
     **상품 단위 가격**
 
@@ -719,11 +719,11 @@ PG사별 지원되는 결제수단이 모두 상이합니다.
 
     이렇게 전달 된 값은 실제로 PG사에 결제를 요청할때 currency에 따라 올바른 값으로 변환되기 때문에 반드시 currency값을 필수로 입력해야 합니다.
 
-  - **`quantity`** <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
+  - quantity: number
 
     **상품 수량**
 
-  - **`tag`** <mark style="color:green;">**string**</mark>
+  - tag?: string
 
     **상품 태그**
 </ParamTree>
@@ -766,83 +766,83 @@ PG사별 지원되는 결제수단이 모두 상이합니다.
 **PG사 결제창 호출 시 PG사로 그대로 bypass할 값들의 모음**
 
 <ParamTree>
-  - **`tosspayments`** <mark style="color:blue;">**object**</mark>
+  - tosspayments?: object
 
     토스페이먼츠 bypass 파라미터
 
     <ParamTree>
-      - **`discountCode`** <mark style="color:green;">**string**</mark>
+      - discountCode?: string
 
         토스페이먼츠 \<-> 고객사 계약에 따라 프로모션 적용이 가능한 코드
 
-      - **`useInternationalCardOnly`** <mark style="color:orange;">**boolean**</mark>
+      - useInternationalCardOnly?: boolean
 
         해외 카드로만 결제가 가능하도록 할 지 여부
     </ParamTree>
 
-  - **`kakaopay`** <mark style="color:blue;">**object**</mark>
+  - kakaopay?: object
 
     카카오페이 bypass 파라미터
 
     <ParamTree>
-      - **`custom_message`** <mark style="color:green;">**string**</mark>
+      - custom\_message?: string
 
         카카오페이 결제창에 띄워줄 사용자 정의 문구
     </ParamTree>
 
-  - **`smartro_v2`** <mark style="color:blue;">**object**</mark>
+  - smartro\_v2?: object
 
     스마트로 V2 bypass 파라미터
 
     <ParamTree>
-      - **`GoodsCnt`** <mark style="color:green;">**number**</mark>
+      - GoodsCnt?: number
 
         결제 상품 품목 개수
 
-      - **`SkinColor`** <mark style="color:green;">**string**</mark>
+      - SkinColor?: string
 
         UI 스타일 (기본값: `"RED"`)
 
         `"RED"`, `"GREEN"`, `"BLUE"`, `"PURPLE"` 중 하나의 값으로 입력해주세요.
 
-      - **`OpenType`** <mark style="color:green;">**string**</mark>
+      - OpenType?: string
 
         해외 카드만 결제를 허용할지 여부(기본값: `"KR"`)
 
         `"KR"`, `"EN"` 중 하나의 값으로 입력해주세요.
     </ParamTree>
 
-  - **`naverpay`** <mark style="color:blue;">**object**</mark>
+  - naverpay?: object
 
     네이버페이 bypass 파라미터
 
     <ParamTree>
-      - **`useCfmYmdt`** <mark style="color:green;">**string**</mark>
+      - useCfmYmdt?: string
 
         이용완료일 (YYYYMMDD)
 
-      - **`productItems`** <mark style="color:green;">**object\[]**</mark>
+      - productItems?: object\[]
 
         상품 정보
 
         <ParamTree>
-          - **`categoryType`** <mark style="color:red;">**\***</mark> <mark style="color:purple;">**string**</mark>
+          - categoryType: string
 
             결제 상품 유형
 
-          - **`categoryId`** <mark style="color:red;">**\***</mark> <mark style="color:purple;">**string**</mark>
+          - categoryId: string
 
             결제 상품 분류
 
-          - **`uid`** <mark style="color:red;">**\***</mark> <mark style="color:purple;">**string**</mark>
+          - uid: string
 
             결제 상품 식별값
 
-          - **`name`** <mark style="color:red;">**\***</mark> <mark style="color:purple;">**string**</mark>
+          - name: string
 
             상품명
 
-          - **`payReferrer`** <mark style="color:purple;">**string**</mark>
+          - payReferrer?: string
 
             결제 상품 유입경로
 
@@ -863,64 +863,64 @@ PG사별 지원되는 결제수단이 모두 상이합니다.
               </Details.Content>
             </Details>
 
-          - **`startDate`** <mark style="color:purple;">**string**</mark>
+          - startDate?: string
 
             시작일(YYYYMMDD)
 
-          - **`endDate`** <mark style="color:purple;">**string**</mark>
+          - endDate?: string
 
             종료일(YYYYMMDD)
 
-          - **`sellerId`** <mark style="color:purple;">**string**</mark>
+          - sellerId?: string
 
             하위 판매자 식별키
 
-          - **`count`** <mark style="color:red;">**\***</mark> <mark style="color:purple;">**string**</mark>
+          - count: string
 
             결제 상품 개수
         </ParamTree>
 
-      - **`deliveryFee`** <mark style="color:green;">**number**</mark>
+      - deliveryFee?: number
 
         배송비
     </ParamTree>
 
-  - **`nice_v2`** <mark style="color:blue;">**object**</mark>
+  - nice\_v2?: object
 
     (신)나이스페이먼츠 bypass 파라미터
 
     <ParamTree>
-      - **`LogoImage`** <mark style="color:green;">**string**</mark>
+      - LogoImage?: string
 
         결제창 로고 이미지 URL
 
-      - **`NPDisableScroll`** <mark style="color:green;">**string**</mark>
+      - NPDisableScroll?: string
 
         결제창 스크롤 미사용 여부 (PC Only, Y: 미사용 / N(default): 사용)
 
-      - **`SkinType`** <mark style="color:green;">**string**</mark>
+      - SkinType?: string
 
         결제창 스킨 색상 설정
 
         `"red", "green", "purple", "gray", "dark"` 중 하나의 값으로 입력해주세요.
 
-      - **`UserCI`** <mark style="color:green;">**string**</mark>
+      - UserCI?: string
 
         문화 상품권 결제시 결제 고객 사용자 인증 CI 정보. 아이디/비밀번호 외 추가로 CI 인증이 필요한 경우 사용.
 
-      - **`MallUserID`** <mark style="color:green;">**string**</mark>
+      - MallUserID?: string
 
         상점 사용자 아이디. 문화 상품권 결제시 경우 필수 입력
 
-      - **`DirectCouponYN`** <mark style="color:green;">**string**</mark>
+      - DirectCouponYN?: string
 
         신용카드 쿠폰 자동 적용 여부 (Y: 사전 등록된 선 할인 쿠폰을 자동 적용 / N: 쿠폰 미적용(기본값))
 
-      - **`DirectShowOpt`** <mark style="color:green;">**string**</mark>
+      - DirectShowOpt?: string
 
         다이렉트 호출 결제 수단 (BANK: 계좌이체/CELLPHONE: 휴대폰 소액결제)
 
-      - **`CardShowOpt`** <mark style="color:green;">**string**</mark>
+      - CardShowOpt?: string
 
         카드사 별 호출 방식
 
@@ -931,20 +931,20 @@ PG사별 지원되는 결제수단이 모두 상이합니다.
         - 노출 유형: 1(안심클릭), 2(간편결제), 3(앱 카드 직접 호출)
         - 카드 코드: 02(국민), 04(삼성), 06(신한), 07(현대), 08(롯데), 12(NH), 15(우리)만 가능
 
-      - **`PaycoClientId`** <mark style="color:green;">**string**</mark>
+      - PaycoClientId?: string
 
         페이코 계정 자동 로그인 기능 사용하기 위해 페이코에서 고객사에 발급한 ClientId
 
-      - **`PaycoAccessToken`** <mark style="color:green;">**string**</mark>
+      - PaycoAccessToken?: string
 
         페이코 계정 자동 로그인 기능 사용을 위한 접속 토큰
 
-      - **`SamsungPayType`** <mark style="color:green;">**string**</mark>
+      - SamsungPayType?: string
 
         삼성페이 고객사 유형 (01: 삼성페이 內 쇼핑 / 99: 기타 (기본값))
     </ParamTree>
 
-  - **`inicis_v2`** <mark style="color:blue;">**object**</mark>
+  - inicis\_v2?: object
 
     이니시스 bypass 파라미터
 
@@ -953,67 +953,67 @@ PG사별 지원되는 결제수단이 모두 상이합니다.
     **PC용 파라미터**
 
     <ParamTree>
-      - **`logo_url`** <mark style="color:green;">**string**</mark>
+      - logo\_url?: string
 
         결제창에 삽입할 메인 로고 url
 
         결제창 중앙 상단에 표시됩니다.
         이미지 권장 사이즈는 89\*18 입니다.
 
-      - **`logo_2nd`** <mark style="color:green;">**string**</mark>
+      - logo\_2nd?: string
 
         결제창에 삽입할 서브 로고 url
 
         결제창 우측 상단에 표시됩니다.
         이미지 권장 사이즈는 64\*13 입니다.
 
-      - **`parentemail`** <mark style="color:green;">**string**</mark>
+      - parentemail?: string
 
         보호자 이메일 주소
 
         14세 미만 고객의 경우 필수 입력입니다.
         "@", "." 외의 특수문자는 입력 불가합니다.
 
-      - **`Ini_SSGPAY_MDN`** <mark style="color:green;">**string**</mark>
+      - Ini\_SSGPAY\_MDN?: string
 
         SSGPAY 결제요청 시 PUSH 전송 휴대폰번호
 
         `-` 없이 숫자만 허용합니다.
 
-      - **`acceptmethod`** <mark style="color:green;">**string\[]**</mark>
+      - acceptmethod?: string\[]
 
         추가 옵션
 
         아래 string 중 원하는 옵션들을 골라 array 형태로 입력합니다.
 
         <ParamTree>
-          - **`SKIN(${string})`** <mark style="color:green;">**string**</mark>
+          - SKIN($\{string})?: string
 
             결제창 색상
 
             `string` 부분에는 `#`으로 시작하는 여섯자리 Hex 값을 입력합니다. (ex. `SKIN(#C1272C)`)
 
-          - **`below1000`** <mark style="color:green;">**string**</mark>
+          - below1000?: string
 
             (카드결제 & 간편결제 시) 1000원 미만 결제 허용 옵션
 
-          - **`ocb`** <mark style="color:green;">**string**</mark>
+          - ocb?: string
 
             (카드결제 시) 카드 메인화면에 OCB 적립을 위한 카드번호 창 표시옵션 (별도 계약시 이용 가능)
 
-          - **`paypopup`** <mark style="color:green;">**string**</mark>
+          - paypopup?: string
 
             (카드결제 시) 안심클릭계열 신용카드 POPUP 형태 표시옵션
 
-          - **`hidebar`** <mark style="color:green;">**string**</mark>
+          - hidebar?: string
 
             (카드결제 시) 프로그레스바 미노출 옵션
 
-          - **`noeasypay`** <mark style="color:green;">**string**</mark>
+          - noeasypay?: string
 
             (카드결제 시) 간편결제 미노출 옵션
 
-          - **`slimquota(${string})`** <mark style="color:green;">**string**</mark>
+          - slimquota($\{string})?: string
 
             부분 무이자 설정 (별도 계약시 이용 가능)
 
@@ -1021,7 +1021,7 @@ PG사별 지원되는 결제수단이 모두 상이합니다.
             카드사 코드는 [이니시스 통합 코드](https://manual.inicis.com/pay/code.html) 페이지에서
             "결제요청 시 카드코드" 섹션을 참고하시기 바랍니다.
 
-          - **`mallpoint(${string})`** <mark style="color:green;">**string**</mark>
+          - mallpoint($\{string})?: string
 
             몰포인트 (별도 계약시 이용 가능)
 
@@ -1034,48 +1034,48 @@ PG사별 지원되는 결제수단이 모두 상이합니다.
     **모바일용 파라미터**
 
     <ParamTree>
-      - **`P_CARD_OPTION`** <mark style="color:green;">**string**</mark>
+      - P\_CARD\_OPTION?: string
 
         신용카드 우선선택 옵션
 
         설정한 카드코드에 해당하는 카드가 선택된 채로 Display 됩니다.
         `selcode=카드코드` 형식으로 입력합니다. (ex. `selcode=14`)
 
-      - **`P_MNAME`** <mark style="color:green;">**string**</mark>
+      - P\_MNAME?: string
 
         가맹점 이름
 
-      - **`P_RESERVED`** <mark style="color:green;">**string\[]**</mark>
+      - P\_RESERVED?: string\[]
 
         추가 옵션
 
         아래 string 중 원하는 옵션들을 골라 array 형태로 입력합니다.
 
         <ParamTree>
-          - **`below1000=Y`** <mark style="color:green;">**string**</mark>
+          - below1000=Y?: string
 
             (카드결제 & 간편결제 시) 1000원 미만 결제 허용 옵션
 
-          - **`noeasypay=Y`** <mark style="color:green;">**string**</mark>
+          - noeasypay=Y?: string
 
             (카드결제 시) 간편결제 미노출 옵션
 
-          - **`global_visa3d=Y`** <mark style="color:green;">**string**</mark>
+          - global\_visa3d=Y?: string
 
             해외카드 노출 옵션
 
-          - **`apprun_check=Y`** <mark style="color:green;">**string**</mark>
+          - apprun\_check=Y?: string
 
             (android의 경우) custom url scheme 대신 intent schema(intent://) 호출
         </ParamTree>
     </ParamTree>
 
-  - **`kpn`** <mark style="color:blue;">**object**</mark>
+  - kpn?: object
 
     KPN bypass 파라미터
 
     <ParamTree>
-      - `CardSelect` <mark style="color:green;">**enum\[]**</mark>
+      - CardSelect?: enum\[]
 
         **일부 렌더링할 결제방식 목록**
         특정 카드사로 구별되지 않는 결제수단을 지정할 때 사용합니다.
@@ -1359,21 +1359,21 @@ PG사별 지원되는 결제수단이 모두 상이합니다.
 range(기간 범위)와 interval(제공 주기) 중 하나를 입력해주세요.
 
 <ParamTree>
-  - **`range`** <mark style="color:green;">**object**</mark>
+  - range?: object
 
     기간 범위
 
     <ParamTree>
-      - **`from`** <mark style="color:purple;">**string**</mark>
+      - from?: string
 
         시작 시점
 
-      - **`to`** <mark style="color:purple;">**string**</mark>
+      - to?: string
 
         종료 시점
     </ParamTree>
 
-  - **`interval`** <mark style="color:green;">**string**</mark>
+  - interval?: string
 
     제공 주기 (`${number}d | ${number}m | ${number}y` 형태로 입력할 수 있습니다.)
 </ParamTree>
@@ -1383,19 +1383,19 @@ range(기간 범위)와 interval(제공 주기) 중 하나를 입력해주세요
 상점 정보
 
 <ParamTree>
-  - **`ceoFullName`** <mark style="color:green;">**string**</mark>
+  - ceoFullName?: string
 
     상점 대표자 이름
 
-  - **`phoneNumber`** <mark style="color:green;">**string**</mark>
+  - phoneNumber?: string
 
     상점 연락처
 
-  - **`address`** <mark style="color:green;">**string**</mark>
+  - address?: string
 
     상점 주소
 
-  - **`zipcode`** <mark style="color:green;">**string**</mark>
+  - zipcode?: string
 
     상점 우편번호
 </ParamTree>
@@ -1409,7 +1409,7 @@ range(기간 범위)와 interval(제공 주기) 중 하나를 입력해주세요
 카드 결제 시, 카드 결제에 대한 세부 정보
 
 <ParamTree>
-  - **`cardCompany`** <mark style="color:green;">**string**</mark>
+  - cardCompany?: string
 
     **카드사 다이렉트 호출 시 필요한 카드사 식별 값**
 
@@ -1442,40 +1442,40 @@ range(기간 범위)와 interval(제공 주기) 중 하나를 입력해주세요
       </Details.Content>
     </Details>
 
-  - **`availableCards`** <mark style="color:blue;">**string\[]**</mark>
+  - availableCards?: string\[]
 
     **일부 카드사만 노출 설정**
 
     일부 카드사만을 선택 가능하게 하고 싶은 경우 사용하는 옵션입니다. 상단의 카드사 식별 값 항목을 참고해주세요.
 
-  - **`useFreeInterestFromMall`** <mark style="color:orange;">**boolean**</mark>
+  - useFreeInterestFromMall?: boolean
 
     **상점분담 무이자 활성화 여부**
 
-  - **`installment`** <mark style="color:blue;">**object**</mark>
+  - installment?: object
 
     **할부 설정**
 
     <ParamTree>
-      - **`freeInstallmentPlans`** <mark style="color:blue;">**object\[]**</mark>
+      - freeInstallmentPlans?: object\[]
 
         **무이자 할부 설정**
 
         고객사가 부담하는 무이자 할부 설정입니다.
 
         <ParamTree>
-          - **`cardCompany`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+          - cardCompany: string
 
             **무이자 할부를 제공하는 카드사 식별 값**
 
             상단의 카드사 식별 값 항목을 참고해주세요.
 
-          - **`months`** <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number\[]**</mark>
+          - months: number\[]
 
             **무이자 할부를 제공하는 개월 수**
         </ParamTree>
 
-      - **`monthOption`** <mark style="color:blue;">**object**</mark>
+      - monthOption?: object
 
         **할부 개월 수 설정**
 
@@ -1484,23 +1484,23 @@ range(기간 범위)와 interval(제공 주기) 중 하나를 입력해주세요
         `fixedMonth`와 `availableMonthList` 중 하나만 제공해주세요.
 
         <ParamTree>
-          - **`fixedMonth`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**number**</mark>
+          - fixedMonth: number
 
             **구매자가 선택할 수 없도록 고정된 할부 개월수**
 
             구매자가 할부 개월 수를 선택할 수 있도록 하려면 `availableMonthList`를 사용해주세요.
 
-          - **`availableMonthList`** <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number\[]**</mark>
+          - availableMonthList: number\[]
 
             **구매자가 선택할 수 있는 할부 개월수 리스트**
         </ParamTree>
     </ParamTree>
 
-  - **`useCardPoint`** <mark style="color:orange;">**boolean**</mark>
+  - useCardPoint?: boolean
 
     **카드사 포인트 사용 여부**
 
-  - **`useAppCardOnly`** <mark style="color:orange;">**boolean**</mark>
+  - useAppCardOnly?: boolean
 
     **앱 카드만 허용할지 여부**
 </ParamTree>
@@ -1514,7 +1514,7 @@ range(기간 범위)와 interval(제공 주기) 중 하나를 입력해주세요
 가상계좌 발급시 가상계좌 상세 옵션
 
 <ParamTree>
-  - **`cashReceiptType`** <mark style="color:green;">**string**</mark>
+  - cashReceiptType?: string
 
     **결제창에서 발급 가능한 현금영수증 발급 유형(소득공제용, 지출증빙용, 미발행)**
 
@@ -1528,25 +1528,25 @@ range(기간 범위)와 interval(제공 주기) 중 하나를 입력해주세요
       </Details.Content>
     </Details>
 
-  - **`customerIdentifier`** <mark style="color:green;">**string**</mark>
+  - customerIdentifier?: string
 
     **현금영수증 발행 대상 식별 정보**
 
-  - **`fixedOption`** <mark style="color:green;">**oneof object**</mark>
+  - fixedOption?: oneof object
 
     **고정식 가상계좌 설정**
 
     <ParamTree>
-      - **`pgAccountId`** <mark style="color:purple;">**string**</mark>
+      - pgAccountId?: string
 
         PG사로부터 사전에 가상계좌에 대한 ID를 발급받아 사용하는 경우의 가상계좌 ID
 
-      - **`accountNumber`** <mark style="color:purple;">**string**</mark>
+      - accountNumber?: string
 
         고정식으로 사용할 가상계좌 번호
     </ParamTree>
 
-  - **`bankCode`** <mark style="color:green;">**string**</mark>
+  - bankCode?: string
 
     **가상계좌 은행 다이렉트 호출시 은행 코드**
 
@@ -1629,14 +1629,14 @@ range(기간 범위)와 interval(제공 주기) 중 하나를 입력해주세요
       </Details.Content>
     </Details>
 
-  - **`accountExpiry`** <mark style="color:blue;">**object**</mark>
+  - accountExpiry?: object
 
     **가상계좌 입금 만료기한**
 
     `validHours`와 `dueDate` 중 하나만 입력해주세요.
 
     <ParamTree>
-      - **`validHours`** <mark style="color:blue;">**number**</mark>
+      - validHours?: number
 
         **가상계좌 입금 유효 시간**
 
@@ -1644,7 +1644,7 @@ range(기간 범위)와 interval(제공 주기) 중 하나를 입력해주세요
 
         예) 3을 전달하면 지금으로부터 3시간 후가 만료 기한으로 지정 됨
 
-      - **`dueDate`** <mark style="color:blue;">**string**</mark>
+      - dueDate?: string
 
         **가상계좌 입금 유효 시각**
 
@@ -1664,7 +1664,7 @@ range(기간 범위)와 interval(제공 주기) 중 하나를 입력해주세요
 가상계좌 발급시 가상계좌 상세 옵션
 
 <ParamTree>
-  - **`cashReceiptType`** <mark style="color:green;">**string**</mark>
+  - cashReceiptType?: string
 
     **결제창에서 발급 가능한 현금영수증 발급 유형(소득공제용, 지출증빙용, 미발행)**
 
@@ -1678,11 +1678,11 @@ range(기간 범위)와 interval(제공 주기) 중 하나를 입력해주세요
       </Details.Content>
     </Details>
 
-  - **`customerIdentifier`** <mark style="color:green;">**string**</mark>
+  - customerIdentifier?: string
 
     **현금영수증 발행 대상 식별 정보**
 
-  - **`bankCode`** <mark style="color:green;">**string**</mark>
+  - bankCode?: string
 
     **계좌이체 은행 다이렉트 호출시 은행 코드**
 
@@ -1775,7 +1775,7 @@ range(기간 범위)와 interval(제공 주기) 중 하나를 입력해주세요
 휴대폰 소액결제시 휴대폰 소액결제 상세 옵션
 
 <ParamTree>
-  - **`carrier`** <mark style="color:green;">**string**</mark>
+  - carrier?: string
 
     **휴대폰 소액결제 통신사 바로 호출을 위한 통신사 구분 값**
 
@@ -1792,7 +1792,7 @@ range(기간 범위)와 interval(제공 주기) 중 하나를 입력해주세요
       </Details.Content>
     </Details>
 
-  - **`availableCarriers`** <mark style="color:green;">**string\[]**</mark>
+  - availableCarriers?: string\[]
 
     **일부 통신사만 노출 설정**
     일부 통신사만을 선택 가능하게 하고 싶은 경우 사용하는 옵션입니다. 상단의 통신사 구분 값 항목을 참고해주세요.
@@ -1807,7 +1807,7 @@ range(기간 범위)와 interval(제공 주기) 중 하나를 입력해주세요
 상품권 결제시 상품권 결제 상세 옵션
 
 <ParamTree>
-  - **`giftCertificateType`** <mark style="color:green;">**string**</mark>
+  - giftCertificateType?: string
 
     **상품권 결제시, 상품권을 특정할 수 있는 값**
 
@@ -1831,7 +1831,7 @@ range(기간 범위)와 interval(제공 주기) 중 하나를 입력해주세요
 간편결제시, 간편 결제에 대한 세부 정보
 
 <ParamTree>
-  - **`easyPayProvider`** <mark style="color:green;">**string**</mark>
+  - easyPayProvider?: string
 
     **간편결제 수단**
 
@@ -1853,44 +1853,44 @@ range(기간 범위)와 interval(제공 주기) 중 하나를 입력해주세요
       </Details.Content>
     </Details>
 
-  - **`useFreeInterestFromMall`** <mark style="color:orange;">**boolean**</mark>
+  - useFreeInterestFromMall?: boolean
 
     **상점분담 무이자 활성화 여부**
 
-  - **`useCardPoint`** <mark style="color:orange;">**boolean**</mark>
+  - useCardPoint?: boolean
 
     **카드사 포인트 사용 여부**
 
-  - **`availableCards`** <mark style="color:blue;">**string\[]**</mark>
+  - availableCards?: string\[]
 
     **일부 카드사만 노출 설정**
 
     일부 카드사만을 선택 가능하게 하고 싶은 경우 사용하는 옵션입니다. `card` 섹션의 카드사 식별 값 항목을 참고해주세요.
 
-  - **`installment`** <mark style="color:blue;">**object**</mark>
+  - installment?: object
 
     **할부 설정**
 
     <ParamTree>
-      - **`freeInstallmentPlans`** <mark style="color:blue;">**object\[]**</mark>
+      - freeInstallmentPlans?: object\[]
 
         **무이자 할부 설정**
 
         고객사가 부담하는 무이자 할부 설정입니다.
 
         <ParamTree>
-          - **`cardCompany`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+          - cardCompany: string
 
             **무이자 할부를 제공하는 카드사 식별 값**
 
             상단의 카드사 식별 값 항목을 참고해주세요.
 
-          - **`months`** <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number\[]**</mark>
+          - months: number\[]
 
             **무이자 할부를 제공하는 개월 수**
         </ParamTree>
 
-      - **`monthOption`** <mark style="color:blue;">**object**</mark>
+      - monthOption?: object
 
         **할부 개월 수 설정**
 
@@ -1899,25 +1899,25 @@ range(기간 범위)와 interval(제공 주기) 중 하나를 입력해주세요
         `fixedMonth`와 `availableMonthList` 중 하나만 제공해주세요.
 
         <ParamTree>
-          - **`fixedMonth`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**number**</mark>
+          - fixedMonth: number
 
             **구매자가 선택할 수 없도록 고정된 할부 개월수**
 
             구매자가 할부 개월 수를 선택할 수 있도록 하려면 `availableMonthList`를 사용해주세요.
 
-          - **`availableMonthList`** <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number\[]**</mark>
+          - availableMonthList: number\[]
 
             **구매자가 선택할 수 있는 할부 개월수 리스트**
         </ParamTree>
     </ParamTree>
 
-  - **`cashReceiptType`** <mark style="color:green;">**string**</mark>
+  - cashReceiptType?: string
 
     **결제창에서 발급 가능한 현금영수증 발급 유형**
 
     PERSONAL: 소득공제용, CORPORATE: 지출증빙용, ANONYMOUS: 미발행
 
-  - **`customerIdentifier`** <mark style="color:green;">**string**</mark>
+  - customerIdentifier?: string
 
     **현금영수증 발행 대상 식별 정보**
 </ParamTree>

--- a/src/routes/(root)/sdk/ko/v2-sdk/payment-request.mdx
+++ b/src/routes/(root)/sdk/ko/v2-sdk/payment-request.mdx
@@ -1075,7 +1075,7 @@ PG사별 지원되는 결제수단이 모두 상이합니다.
     KPN bypass 파라미터
 
     <ParamTree>
-      - \*\*`CardSelect` <mark style="color:green;">**enum\[]**</mark>
+      - `CardSelect` <mark style="color:green;">**enum\[]**</mark>
 
         **일부 렌더링할 결제방식 목록**
         특정 카드사로 구별되지 않는 결제수단을 지정할 때 사용합니다.

--- a/src/routes/(root)/sdk/ko/v2-sdk/payment-request.mdx
+++ b/src/routes/(root)/sdk/ko/v2-sdk/payment-request.mdx
@@ -11,26 +11,27 @@ import ParamTree from "~/components/gitbook/ParamTree";
 
 ## 결제요청 파라미터 정의
 
-### **`storeId`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+<ParamTree>
+### storeId: string
 
 **스토어 아이디**
 
 - 포트원 계정에 생성된 상점을 식별하는 고유한 값으로 관리자 콘솔에서 확인할 수 있습니다.
 
-### **`paymentId`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+### paymentId: string
 
 **고객사 주문 고유 번호**
 
 - 고객사가 채번하는 주문 고유 번호입니다.
 - 이미 승인 완료 된 `paymentId`로 결제나 가상계좌 발급을 시도하는 경우 에러가 발생합니다.
 
-### **`orderName`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+### orderName: string
 
 **주문명**
 
 주문명으로 고객사에서 자유롭게 입력합니다.
 
-### **`totalAmount`** <mark style="color:red;">**\***</mark> <mark style="color:purple;">**number**</mark>
+### totalAmount: number
 
 **결제 금액**
 
@@ -40,7 +41,7 @@ import ParamTree from "~/components/gitbook/ParamTree";
 - 1.50 만큼 달러(USD) 결제를 하는 경우, scale factor가 2이기 때문에 **1.50 \* (10의 2승) = 150**을 전달해야 합니다.
 - 이렇게 전달 된 값은 실제로 PG사에 결제를 요청할때 currency에 따라 올바른 값으로 변환되기 때문에 반드시 currency값을 필수로 입력해야 합니다.
 
-### **`currency`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+### currency: string
 
 **결제 통화**
 
@@ -233,7 +234,7 @@ import ParamTree from "~/components/gitbook/ParamTree";
   </Details.Content>
 </Details>
 
-### **`payMethod`** <mark style="color:red;">**\***</mark> <mark style="color:green;">**string**</mark>
+### payMethod: string
 
 **결제수단 구분코드**
 
@@ -254,7 +255,7 @@ PG사별 지원되는 결제수단이 모두 상이합니다.
   </Details.Content>
 </Details>
 
-### **`channelKey`** <mark style="color:green;">**string**</mark>
+### channelKey?: string
 
 **채널 키**
 
@@ -262,7 +263,7 @@ PG사별 지원되는 결제수단이 모두 상이합니다.
 
 `pgProvider` 파라미터가 없는 경우에 필수로 존재해야 합니다. 두 파라미터가 모두 존재하는 경우 `channelKey`을 적용하니 둘 중 하나만 제공해주세요.
 
-### **`taxFreeAmount`** <mark style="color:purple;">**number**</mark>
+### taxFreeAmount?: number
 
 **면세 금액**
 
@@ -270,7 +271,7 @@ PG사별 지원되는 결제수단이 모두 상이합니다.
 - 미입력 시 0으로 취급됩니다.
 - 결제 금액과 동일하게 통화별 scale factor가 적용된 금액으로 전달해주세요.
 
-### **`vatAmount`** <mark style="color:purple;">**number**</mark>
+### vatAmount?: number
 
 **부가세**
 
@@ -278,7 +279,7 @@ PG사별 지원되는 결제수단이 모두 상이합니다.
 - 미입력 시 과세 금액의 1/11 로 자동 계산됩니다.
 - 결제 금액과 동일하게 통화별 scale factor가 적용된 금액으로 전달해주세요.
 
-### **`customer`** <mark style="color:red;">**\***</mark> <mark style="color:blue;">**object**</mark>
+### customer: object
 
 **고객 정보**
 
@@ -627,7 +628,7 @@ PG사별 지원되는 결제수단이 모두 상이합니다.
     ex. `"25"`, `"08"` 같은 형식으로 입력해주세요.
 </ParamTree>
 
-### **`windowType`** <mark style="color:blue;">**object**</mark>
+### windowType?: object
 
 **결제 환경 별 제공되는 결제창 유형**
 
@@ -647,7 +648,7 @@ PG사별 지원되는 결제수단이 모두 상이합니다.
     **모바일에서의 결제창 유형** `IFRAME`, `REDIRECTION`, `POPUP` 중 하나를 입력해주세요.
 </ParamTree>
 
-### **`redirectUrl`** <mark style="color:green;">**string**</mark>
+### redirectUrl?: string
 
 **리디렉션 방식에서 결제 프로세스 완료 후 이동될 고객사 URL**
 
@@ -655,7 +656,7 @@ PG사별 지원되는 결제수단이 모두 상이합니다.
 - 대부분의 모바일 결제환경에서 결제창 호출시 필수 항목입니다.
 - 리다이렉트 환경에서 해당 필드 누락시 에러가 발생합니다.
 
-### **`noticeUrls`** <mark style="color:green;">**string\[]**</mark>
+### noticeUrls?: string\[]
 
 **웹훅(Webhook) 수신 주소**
 
@@ -664,7 +665,7 @@ PG사별 지원되는 결제수단이 모두 상이합니다.
 - 포트원 관리자 콘솔에 설정한 웹훅 주소 대신 사용할 웹훅 주소를 결제시마다 설정할 수 있습니다.
 - 해당 값 설정시 관리자 콘솔에 설정한 주소로는 웹훅발송이 되지 않는점 유의하시기 바랍니다.
 
-### **`confirmUrl`** <mark style="color:green;">**string**</mark>
+### confirmUrl?: string
 
 **최종 결제 승인 요청 여부 확인 URL**
 
@@ -674,14 +675,14 @@ PG사별 지원되는 결제수단이 모두 상이합니다.
 
 - 기술지원 메일로 별도 요청이 필요합니다. ([tech.support@portone.io](mailto:tech.support@portone.io))
 
-### **`appScheme`** <mark style="color:green;">**string**</mark>
+### appScheme?: string
 
 **모바일 결제 후 고객사 앱으로 복귀를 위한 URL scheme**
 
 - WebView 환경 결제시 필수설정 항목 입니다.
 - ISP/앱카드 앱에서 결제정보인증 후 기존 앱으로 복귀할 때 사용합니다.
 
-### **`isEscrow`** <mark style="color:orange;">**boolean**</mark>
+### isEscrow?: boolean
 
 **에스크로 결제 여부**
 
@@ -689,7 +690,7 @@ PG사별 지원되는 결제수단이 모두 상이합니다.
 
 - [x] 에스크로 설정은 PG사와 협의 이후 진행되어야 하는점 주의하세요
 
-### **`products`** <mark style="color:blue;">**object\[]**</mark>
+### products?: object\[]
 
 **구매 상품 상세 정보**
 
@@ -728,13 +729,13 @@ PG사별 지원되는 결제수단이 모두 상이합니다.
     **상품 태그**
 </ParamTree>
 
-### **`isCulturalExpense`** <mark style="color:orange;">**boolean**</mark>
+### isCulturalExpense?: boolean
 
 **문화비 지출 여부**
 
 도서, 공연, 박물관 등 문화비 지출 여부
 
-### **`locale`** <mark style="color:green;">**string**</mark>
+### locale?: string
 
 **결제창 언어** (지원되지 않은 일부 PG사 존재)
 
@@ -747,21 +748,21 @@ PG사별 지원되는 결제수단이 모두 상이합니다.
   </Details.Content>
 </Details>
 
-### **`customData`** <mark style="color:blue;">**object**</mark>
+### customData?: object
 
 **결제 정보와 함께 관리하고 싶은 고객사 커스텀 JSON 데이터**
 
-### **`popup`** <mark style="color:blue;">**object**</mark>
+### popup?: object
 
 **결제창이 팝업 방식일 경우 결제창에 적용할 속성**
 
 <ParamTree>
-  - **`center`** <mark style="color:orange;">**boolean**</mark>
+  - center?: boolean
 
     `true`로 설정하면 결제창이 브라우저 화면의 정중앙에 표시됩니다.
 </ParamTree>
 
-### **`bypass`** <mark style="color:blue;">**oneof object**</mark>
+### bypass?: oneof object
 
 **PG사 결제창 호출 시 PG사로 그대로 bypass할 값들의 모음**
 
@@ -1086,7 +1087,7 @@ PG사별 지원되는 결제수단이 모두 상이합니다.
     </ParamTree>
 </ParamTree>
 
-### **`country`** <mark style="color:green;">**string**</mark>
+### country?: string
 
 **결제 국가**
 
@@ -1346,13 +1347,13 @@ PG사별 지원되는 결제수단이 모두 상이합니다.
   </Details.Content>
 </Details>
 
-### **`productType`** <mark style="color:blue;">**string**</mark>
+### productType?: string
 
 상품 유형
 
 `"PRODUCT_TYPE_REAL"`, `"PRODUCT_TYPE_DIGITAL"` 중 하나의 값을 입력해주세요.
 
-### **`offerPeriod`** <mark style="color:blue;">**string**</mark>
+### offerPeriod?: string
 
 서비스 제공 기간
 
@@ -1378,7 +1379,7 @@ range(기간 범위)와 interval(제공 주기) 중 하나를 입력해주세요
     제공 주기 (`${number}d | ${number}m | ${number}y` 형태로 입력할 수 있습니다.)
 </ParamTree>
 
-### **`storeDetails`** <mark style="color:blue;">**object**</mark>
+### storeDetails?: object
 
 상점 정보
 
@@ -1400,7 +1401,7 @@ range(기간 범위)와 interval(제공 주기) 중 하나를 입력해주세요
     상점 우편번호
 </ParamTree>
 
-### **`card`** <mark style="color:blue;">**object**</mark>
+### card?: object
 
 `payMethod`가 `CARD`인 경우에만 허용됩니다.
 
@@ -1505,7 +1506,7 @@ range(기간 범위)와 interval(제공 주기) 중 하나를 입력해주세요
     **앱 카드만 허용할지 여부**
 </ParamTree>
 
-### **`virtualAccount`** <mark style="color:blue;">**object**</mark>
+### virtualAccount?: object
 
 `payMethod`가 `VIRTUAL_ACCOUNT`인 경우에만 허용됩니다.
 
@@ -1655,7 +1656,7 @@ range(기간 범위)와 interval(제공 주기) 중 하나를 입력해주세요
     </ParamTree>
 </ParamTree>
 
-### **`transfer`** <mark style="color:blue;">**object**</mark>
+### transfer?: object
 
 `payMethod`가 `TRANSFER`인 경우에만 허용됩니다.
 
@@ -1766,7 +1767,7 @@ range(기간 범위)와 interval(제공 주기) 중 하나를 입력해주세요
     </Details>
 </ParamTree>
 
-### **`mobile`** <mark style="color:blue;">**object**</mark>
+### mobile?: object
 
 `payMethod`가 `MOBILE`인 경우에만 허용됩니다.
 
@@ -1798,7 +1799,7 @@ range(기간 범위)와 interval(제공 주기) 중 하나를 입력해주세요
     일부 통신사만을 선택 가능하게 하고 싶은 경우 사용하는 옵션입니다. 상단의 통신사 구분 값 항목을 참고해주세요.
 </ParamTree>
 
-### **`giftCertificate`** <mark style="color:blue;">**object**</mark>
+### giftCertificate?: object
 
 `payMethod`가 `GIFT_CERTIFICATE`인 경우에만 허용됩니다.
 
@@ -1822,7 +1823,7 @@ range(기간 범위)와 interval(제공 주기) 중 하나를 입력해주세요
     </Details>
 </ParamTree>
 
-### **`easyPay`** <mark style="color:blue;">**object**</mark>
+### easyPay?: object
 
 `payMethod`가 `EASY_PAY`인 경우에만 허용됩니다.
 
@@ -1920,4 +1921,5 @@ range(기간 범위)와 interval(제공 주기) 중 하나를 입력해주세요
   - customerIdentifier?: string
 
     **현금영수증 발행 대상 식별 정보**
+</ParamTree>
 </ParamTree>

--- a/src/routes/(root)/sdk/ko/v2-sdk/payment-response.mdx
+++ b/src/routes/(root)/sdk/ko/v2-sdk/payment-response.mdx
@@ -6,46 +6,50 @@ versionVariants:
   v1: /sdk/ko/v1-sdk/javascript-sdk/payrt
 ---
 
+import ParamTree from "~/components/gitbook/ParamTree";
+
 ## 결제응답 파라미터 정의
 
-### **`transactionType`** <mark style="color:green;">**string**</mark>
+<ParamTree>
+### transactionType?: string
 
 **트랜잭션 유형**
 
 - 일반결제의 경우 무조건 `PAYMENT`로 전달됩니다.
 
-### **`paymentId`** <mark style="color:green;">**string**</mark>
+### paymentId?: string
 
 **결제 ID**
 
 - 결제 요청에 전달된 결제 ID입니다.
 
-### **`txId`** <mark style="color:green;">**string**</mark>
+### txId?: string
 
 **결제 시도 고유 번호**
 
 - 포트원에서 채번하는 결제 시도 고유 번호입니다.
 
-### **`code`** <mark style="color:green;">**string**</mark>
+### code?: string
 
 **오류 코드**
 
 - 실패한 경우 오류 코드입니다.
 
-### **`message`** <mark style="color:green;">**string**</mark>
+### message?: string
 
 **오류 메시지**
 
 - 실패한 경우 오류 메시지입니다.
 
-### **`pgCode`** <mark style="color:green;">**string**</mark>
+### pgCode?: string
 
 **PG 오류 코드**
 
 - PG에서 오류 코드를 내려 주는 경우 이 오류 코드를 그대로 반환합니다.
 
-### **`pgMessage`** <mark style="color:green;">**string**</mark>
+### pgMessage?: string
 
 **PG 오류 메시지**
 
 - PG에서 오류 메시지를 내려 주는 경우 이 오류 메시지를 그대로 반환합니다.
+</ParamTree>


### PR DESCRIPTION
- 기존에 작성된 SDK 파라미터 정의 부분을 새 문법으로 변경했습니다. (migration 스크립트 사용) 
- 새 문법으로 작성된 SDK 파라미터 정의를 기존 형식으로 transform 하는 `@portone-io/remark-param-tree` 패키지를 구현했습니다.