### PR TITLE
`side-effects-cache` 재활성화

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 node-options=--max-old-space-size=6144 --experimental-strip-types
-side-effects-cache=false


### PR DESCRIPTION
- post install 스크립트가 제거되어서 더 이상 사용하지 않는 옵션임
