### PR TITLE
[v1/api] 포트원 API 하위상점 사용 시 유의사항 추가

### DIFF
--- a/src/routes/(root)/api/rest-v1/[...slug].tsx
+++ b/src/routes/(root)/api/rest-v1/[...slug].tsx
@@ -81,6 +81,15 @@ export default function ApiV1Docs() {
         </prose.p>
         <br />
         <BackwardCompatibilityContent version="v1" />
+        <prose.h3>하위 상점의 API 사용</prose.h3>
+        <prose.p>
+          하위 상점에 대해 API를 사용하려는 경우 API 호출 시 Tier 헤더(HTTP
+          Request Header)로 하위상점의 티어코드를 전달해야 합니다.
+          <br />
+          <prose.a href="/opi/ko/support/agency-and-tier">
+            [Agency & Tier 란?]
+          </prose.a>
+        </prose.p>
       </RestApi>
     </div>
   );


### PR DESCRIPTION
[V1 API 개요](https://developers.portone.io/api/rest-v1?v=v1)란에 아래와 같이 하위 상점 이용 시 티어코드 전달이 필요함을 표시 했습니다.

<img width="843" alt="image" src="https://github.com/user-attachments/assets/13c7f054-e64b-403f-92a8-3979bdd8e5e3" />
