### PR TITLE
fix: api/rest-v1/type-def?v=v1#PaymentAnnotation 에서 PaymentAnnotation을 클릭시 페이지가 터지는 버그 수정

### DIFF
--- a/src/layouts/rest-api/schema-utils/type-def.ts
+++ b/src/layouts/rest-api/schema-utils/type-def.ts
@@ -99,7 +99,7 @@ export function bakeProperties(
     const $ref = property.$ref;
     const resolvedProperty = resolveTypeDef(schema, property);
     const type = $ref ? getTypenameByRef($ref) : resolvedProperty.type;
-    const required = resolvedDef.required?.includes(name);
+    const required = resolvedDef.required?.includes?.(name);
     return {
       ...resolvedProperty,
       $ref,


### PR DESCRIPTION
https://developers.portone.io/api/rest-v1/type-def?v=v1#PaymentAnnotation
타입 정의 섹션에서 PaymentAnnotation을 펼치면 페이지가 터지는 버그를 고쳣습니다

