### PR TITLE
`scripts/mdx-to-markdown/jsx/` 리팩토링 및 미지원 태그 출력 기능 추가

### DIFF
--- a/scripts/docs-for-llms/generator.ts
+++ b/scripts/docs-for-llms/generator.ts
@@ -68,16 +68,20 @@ export function transformAllMdxToAst(
   const transformedAstMap: Record<string, Root> = {};
 
   // 각 파싱 결과의 AST 변환
+  const allUnhandledTags: Set<string> = new Set();
   for (const slug of Object.keys(fileParseMap)) {
     try {
       // AST 변환 (useMarkdownLinks 파라미터 전달)
-      const transformedAst = transformAstForMarkdown(
+      const { ast, unhandledTags } = transformAstForMarkdown(
         slug,
         fileParseMap,
         useMarkdownLinks,
       );
-      if (transformedAst) {
-        transformedAstMap[slug] = transformedAst;
+      if (ast) {
+        transformedAstMap[slug] = ast;
+      }
+      for (const tag of unhandledTags) {
+        allUnhandledTags.add(tag);
       }
     } catch (error) {
       console.error(
@@ -90,6 +94,8 @@ export function transformAllMdxToAst(
   console.log(
     `${Object.keys(transformedAstMap).length}개의 MDX 파일 AST 변환이 완료되었습니다.`,
   );
+
+  console.log(`처리되지 않은 태그: ${Array.from(allUnhandledTags).join(", ")}`);
   return transformedAstMap;
 }
 

--- a/scripts/llms-txt/generator.ts
+++ b/scripts/llms-txt/generator.ts
@@ -64,12 +64,19 @@ export function transformAllMdxToAst(
   const transformedAstMap: Record<string, Root> = {};
 
   // 각 파싱 결과의 AST 변환
+  const allUnhandledTags: Set<string> = new Set();
   for (const slug of Object.keys(fileParseMap)) {
     try {
       // AST 변환
-      const transformedAst = transformAstForMarkdown(slug, fileParseMap);
-      if (transformedAst) {
-        transformedAstMap[slug] = transformedAst;
+      const { ast, unhandledTags } = transformAstForMarkdown(
+        slug,
+        fileParseMap,
+      );
+      if (ast) {
+        transformedAstMap[slug] = ast;
+      }
+      for (const tag of unhandledTags) {
+        allUnhandledTags.add(tag);
       }
     } catch (error) {
       console.error(
@@ -82,6 +89,8 @@ export function transformAllMdxToAst(
   console.log(
     `${Object.keys(transformedAstMap).length}개의 MDX 파일 AST 변환이 완료되었습니다.`,
   );
+
+  console.log(`처리되지 않은 태그: ${Array.from(allUnhandledTags).join(", ")}`);
   return transformedAstMap;
 }
 

--- a/scripts/mdx-to-markdown/index.test.ts
+++ b/scripts/mdx-to-markdown/index.test.ts
@@ -1,16 +1,11 @@
 import type { Link, Root } from "mdast";
 import type { Node } from "unist";
 import { visit } from "unist-util-visit";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
 // Import the function to test and the MdxParseResult type
 import { transformAstForMarkdown } from "./index";
 import type { MdxParseResult } from "./mdx-parser";
-
-// Mock the necessary dependencies
-vi.mock("./jsx", () => ({
-  transformJsxComponents: vi.fn(),
-}));
 
 // Helper function to create a simple AST with a link
 function createAstWithLink(url: string, text: string = "link text"): Root {

--- a/scripts/mdx-to-markdown/index.test.ts
+++ b/scripts/mdx-to-markdown/index.test.ts
@@ -64,7 +64,7 @@ describe("transformLinks", () => {
     const useMarkdownLinks = false;
 
     // Act
-    const transformedAst = transformAstForMarkdown(
+    const { ast: transformedAst } = transformAstForMarkdown(
       slug,
       mockParseResultMap,
       useMarkdownLinks,
@@ -82,7 +82,7 @@ describe("transformLinks", () => {
     const useMarkdownLinks = true;
 
     // Act
-    const transformedAst = transformAstForMarkdown(
+    const { ast: transformedAst } = transformAstForMarkdown(
       slug,
       mockParseResultMap,
       useMarkdownLinks,
@@ -112,7 +112,7 @@ describe("transformLinks", () => {
     const slug = "test-slug";
 
     // Act
-    const transformedAst = transformAstForMarkdown(
+    const { ast: transformedAst } = transformAstForMarkdown(
       slug,
       mockParseResultMapWithExternalLink,
       true,
@@ -163,7 +163,7 @@ describe("transformLinks", () => {
     const useMarkdownLinks = true;
 
     // Act
-    const transformedAst = transformAstForMarkdown(
+    const { ast: transformedAst } = transformAstForMarkdown(
       slug,
       mockComplexParseResultMap,
       useMarkdownLinks,
@@ -195,7 +195,7 @@ describe("transformLinks", () => {
     const useMarkdownLinks = true;
 
     // Act
-    const transformedAst = transformAstForMarkdown(
+    const { ast: transformedAst } = transformAstForMarkdown(
       slug,
       mockParseResultMapWithComplexUrl,
       useMarkdownLinks,

--- a/scripts/mdx-to-markdown/index.ts
+++ b/scripts/mdx-to-markdown/index.ts
@@ -43,25 +43,22 @@ export function transformAstForMarkdown(
   transformLinks(ast, useMarkdownLinks);
 
   // JSX 컴포넌트를 마크다운으로 변환 (useMarkdownLinks 파라미터 전달)
-  const unhandledTags = transformJsxComponents(
-    ast,
-    parseResultMap,
-    useMarkdownLinks,
-  );
+  const result = transformJsxComponents(ast, parseResultMap, useMarkdownLinks);
+  const transformedAst = result.ast as Root;
 
   // 임포트 구문 제거
-  removeImports(ast);
+  removeImports(transformedAst);
 
   // YAML 노드 제거 (프론트매터는 별도로 처리)
-  removeYamlNodes(ast);
+  removeYamlNodes(transformedAst);
 
   // JSX 요소 제거 또는 자식 노드만 유지
-  simplifyJsxElements(ast);
+  simplifyJsxElements(transformedAst);
 
   // MDX 표현식 노드 처리
-  handleRemainingMdxFlowExpressions(ast);
+  handleRemainingMdxFlowExpressions(transformedAst);
 
-  return { ast, unhandledTags };
+  return { ast: transformedAst, unhandledTags: result.unhandledTags };
 }
 
 /**

--- a/scripts/mdx-to-markdown/index.ts
+++ b/scripts/mdx-to-markdown/index.ts
@@ -16,14 +16,16 @@ import { type Frontmatter, type MdxParseResult } from "./mdx-parser";
  * @param slug 변환할 MDX 파일의 slug
  * @param parseResultMap 모든 MDX 파일의 파싱 결과 맵 (slug -> MdxParseResult)
  * @param useMarkdownLinks 내부 링크를 마크다운 파일 링크로 변환할지 여부 (true: 마크다운 파일 링크, false: 웹페이지 링크)
- * @returns 변환된 AST 노드
+ * @returns {오브젝트} 변환된 AST 노드와 처리되지 않은 태그 목록을 포함한 객체
+ * @returns {Root} ast - 변환된 AST 노드
+ * @returns {Set<string>} unhandledTags - 처리되지 않은 태그 목록
  * @throws Error parseResult를 찾을 수 없는 경우 예외 발생
  */
 export function transformAstForMarkdown(
   slug: string,
   parseResultMap: Record<string, MdxParseResult>,
   useMarkdownLinks: boolean = true,
-): Root {
+): { ast: Root; unhandledTags: Set<string> } {
   // slug에 해당하는 parseResult 가져오기
   const parseResult = parseResultMap[slug];
 
@@ -41,7 +43,11 @@ export function transformAstForMarkdown(
   transformLinks(ast, useMarkdownLinks);
 
   // JSX 컴포넌트를 마크다운으로 변환 (useMarkdownLinks 파라미터 전달)
-  transformJsxComponents(ast, parseResultMap, useMarkdownLinks);
+  const unhandledTags = transformJsxComponents(
+    ast,
+    parseResultMap,
+    useMarkdownLinks,
+  );
 
   // 임포트 구문 제거
   removeImports(ast);
@@ -55,7 +61,7 @@ export function transformAstForMarkdown(
   // MDX 표현식 노드 처리
   handleRemainingMdxFlowExpressions(ast);
 
-  return ast;
+  return { ast, unhandledTags };
 }
 
 /**

--- a/scripts/mdx-to-markdown/jsx/apiLink.test.ts
+++ b/scripts/mdx-to-markdown/jsx/apiLink.test.ts
@@ -1,19 +1,42 @@
+import type { MdxJsxFlowElement } from "mdast-util-mdx";
 import { describe, expect, it } from "vitest";
 
 import { handleApiLinkComponent } from "./apiLink";
 
 describe("handleApiLinkComponent", () => {
   it("rest-v1 API 링크를 마크다운 링크로 변환한다", () => {
-    // props 객체 생성
-    const props = {
-      basepath: "/api/rest-v1",
-      section: "payment",
-      method: "post",
-      path: "/payments",
+    // MDX JSX 노드 생성
+    const node: MdxJsxFlowElement = {
+      type: "mdxJsxFlowElement",
+      name: "ApiLink",
+      attributes: [
+        {
+          type: "mdxJsxAttribute",
+          name: "basepath",
+          value: "/api/rest-v1",
+        },
+        {
+          type: "mdxJsxAttribute",
+          name: "section",
+          value: "payment",
+        },
+        {
+          type: "mdxJsxAttribute",
+          name: "method",
+          value: "post",
+        },
+        {
+          type: "mdxJsxAttribute",
+          name: "path",
+          value: "/payments",
+        },
+      ],
+      children: [],
+      data: {},
     };
 
     // handleApiLinkComponent 함수 실행
-    const result = handleApiLinkComponent(props);
+    const result = handleApiLinkComponent(node);
 
     // 결과 검증
     expect(result).toEqual({
@@ -34,17 +57,43 @@ describe("handleApiLinkComponent", () => {
   });
 
   it("rest-v2 API 링크를 마크다운 링크로 변환한다 (apiName 포함)", () => {
-    // props 객체 생성
-    const props = {
-      basepath: "/api/rest-v2",
-      section: "payment",
-      method: "get",
-      path: "/payments/{payment_id}",
-      apiName: "결제 조회 API",
+    // MDX JSX 노드 생성
+    const node: MdxJsxFlowElement = {
+      type: "mdxJsxFlowElement",
+      name: "ApiLink",
+      attributes: [
+        {
+          type: "mdxJsxAttribute",
+          name: "basepath",
+          value: "/api/rest-v2",
+        },
+        {
+          type: "mdxJsxAttribute",
+          name: "section",
+          value: "payment",
+        },
+        {
+          type: "mdxJsxAttribute",
+          name: "method",
+          value: "get",
+        },
+        {
+          type: "mdxJsxAttribute",
+          name: "path",
+          value: "/payments/{payment_id}",
+        },
+        {
+          type: "mdxJsxAttribute",
+          name: "apiName",
+          value: "결제 조회 API",
+        },
+      ],
+      children: [],
+      data: {},
     };
 
     // handleApiLinkComponent 함수 실행
-    const result = handleApiLinkComponent(props);
+    const result = handleApiLinkComponent(node);
 
     // 결과 검증
     expect(result).toEqual({
@@ -65,15 +114,33 @@ describe("handleApiLinkComponent", () => {
   });
 
   it("필수 속성이 없는 경우 기본 텍스트를 반환한다", () => {
-    // props 객체 생성 (method 속성 없음)
-    const props = {
-      basepath: "/api/rest-v1",
-      section: "payment",
-      path: "/payments",
+    // MDX JSX 노드 생성 (method 속성 없음)
+    const node: MdxJsxFlowElement = {
+      type: "mdxJsxFlowElement",
+      name: "ApiLink",
+      attributes: [
+        {
+          type: "mdxJsxAttribute",
+          name: "basepath",
+          value: "/api/rest-v1",
+        },
+        {
+          type: "mdxJsxAttribute",
+          name: "section",
+          value: "payment",
+        },
+        {
+          type: "mdxJsxAttribute",
+          name: "path",
+          value: "/payments",
+        },
+      ],
+      children: [],
+      data: {},
     };
 
     // handleApiLinkComponent 함수 실행
-    const result = handleApiLinkComponent(props);
+    const result = handleApiLinkComponent(node);
 
     // 결과 검증
     expect(result).toEqual({

--- a/scripts/mdx-to-markdown/jsx/apiLink.ts
+++ b/scripts/mdx-to-markdown/jsx/apiLink.ts
@@ -1,17 +1,23 @@
+import type { MdxJsxFlowElement, MdxJsxTextElement } from "mdast-util-mdx";
+
+import { extractMdxJsxAttributes } from "./common";
+
 /**
  * ApiLink 컴포넌트를 마크다운으로 변환하는 함수
  *
  * @param node ApiLink 컴포넌트 노드
  * @returns 마크다운 노드
  */
-export function handleApiLinkComponent(props: Record<string, unknown>) {
+export function handleApiLinkComponent(
+  node: MdxJsxFlowElement | MdxJsxTextElement,
+) {
   // 필수 속성 확인
   const {
     basepath: basepathStr,
     method: methodStr,
     path: pathStr,
     apiName: apiNameStr,
-  } = props;
+  } = extractMdxJsxAttributes(node);
 
   const basepath = typeof basepathStr === "string" ? basepathStr : undefined;
   const method = typeof methodStr === "string" ? methodStr : undefined;

--- a/scripts/mdx-to-markdown/jsx/common.ts
+++ b/scripts/mdx-to-markdown/jsx/common.ts
@@ -1,3 +1,4 @@
+import type { Node, Root } from "mdast";
 import type { MdxJsxFlowElement, MdxJsxTextElement } from "mdast-util-mdx";
 /**
  * MDX JSX 속성을 추출하는 함수
@@ -27,4 +28,34 @@ export function extractMdxJsxAttributes(
     }
   }
   return props;
+}
+
+export function unwrapJsxNode(
+  node: MdxJsxFlowElement | MdxJsxTextElement,
+  transformRecursively: (ast: Node) => {
+    ast: Node;
+    unhandledTags: Set<string>;
+  },
+): { ast: Root; unhandledTags: Set<string> } {
+  if (!node.children || node.children.length === 0) {
+    // Nothing to keep, remove this node from the AST
+    return {
+      ast: { type: "root", children: [] } as Root,
+      unhandledTags: new Set(),
+    };
+  }
+
+  const results = node.children.map(transformRecursively);
+
+  // 기본적으로 자식 노드만 유지
+  return {
+    ast: {
+      type: "root",
+      children: results.map((r) => r.ast),
+    } as Root,
+    unhandledTags: results.reduce(
+      (acc, r) => acc.union(r.unhandledTags),
+      new Set<string>(),
+    ),
+  };
 }

--- a/scripts/mdx-to-markdown/jsx/condition.test.ts
+++ b/scripts/mdx-to-markdown/jsx/condition.test.ts
@@ -1,7 +1,7 @@
 import type { MdxJsxFlowElement } from "mdast-util-mdx";
 import type { Node, Parent } from "unist";
 import { visit } from "unist-util-visit";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { handleConditionComponent } from "./condition";
 
@@ -11,6 +11,7 @@ describe("handleConditionComponent", () => {
     const node = {
       type: "mdxJsxFlowElement",
       name: "Condition",
+      attributes: [{ type: "mdxJsxAttribute", name: "if", value: "browser" }],
       children: [
         {
           type: "paragraph",
@@ -19,20 +20,19 @@ describe("handleConditionComponent", () => {
       ],
     } as unknown as MdxJsxFlowElement;
 
-    // 목 함수 생성 (transformJsxComponentsFn)
-    const mockTransformFn = (_ast: Node) => {
-      // 테스트에서는 아무 작업도 하지 않음
-    };
+    // 목 함수 생성 (transformRecursively)
+    const mockTransformRecursively = vi
+      .fn()
+      .mockImplementation((ast: Node) => ({
+        ast,
+        unhandledTags: new Set<string>(),
+      }));
 
     // handleConditionComponent 함수 실행
-    const result = handleConditionComponent(
-      node,
-      { if: "browser" },
-      mockTransformFn,
-    );
+    const result = handleConditionComponent(node, mockTransformRecursively);
 
     // 결과 검증
-    expect(result).toEqual({
+    expect(result.ast).toEqual({
       type: "root",
       children: [
         {
@@ -66,6 +66,7 @@ describe("handleConditionComponent", () => {
     const node = {
       type: "mdxJsxFlowElement",
       name: "Condition",
+      attributes: [{ type: "mdxJsxAttribute", name: "when", value: "future" }],
       children: [
         {
           type: "paragraph",
@@ -74,20 +75,19 @@ describe("handleConditionComponent", () => {
       ],
     } as unknown as MdxJsxFlowElement;
 
-    // 목 함수 생성 (transformJsxComponentsFn)
-    const mockTransformFn = (_ast: Node) => {
-      // 테스트에서는 아무 작업도 하지 않음
-    };
+    // 목 함수 생성 (transformRecursively)
+    const mockTransformRecursively = vi
+      .fn()
+      .mockImplementation((ast: Node) => ({
+        ast,
+        unhandledTags: new Set<string>(),
+      }));
 
     // handleConditionComponent 함수 실행
-    const result = handleConditionComponent(
-      node,
-      { when: "future" },
-      mockTransformFn,
-    );
+    const result = handleConditionComponent(node, mockTransformRecursively);
 
     // 결과 검증
-    expect(result).toEqual({
+    expect(result.ast).toEqual({
       type: "root",
       children: [
         {
@@ -121,6 +121,7 @@ describe("handleConditionComponent", () => {
     const node = {
       type: "mdxJsxFlowElement",
       name: "Condition",
+      attributes: [{ type: "mdxJsxAttribute", name: "language", value: "js" }],
       children: [
         {
           type: "paragraph",
@@ -129,20 +130,19 @@ describe("handleConditionComponent", () => {
       ],
     } as unknown as MdxJsxFlowElement;
 
-    // 목 함수 생성 (transformJsxComponentsFn)
-    const mockTransformFn = (_ast: Node) => {
-      // 테스트에서는 아무 작업도 하지 않음
-    };
+    // 목 함수 생성 (transformRecursively)
+    const mockTransformRecursively = vi
+      .fn()
+      .mockImplementation((ast: Node) => ({
+        ast,
+        unhandledTags: new Set<string>(),
+      }));
 
     // handleConditionComponent 함수 실행
-    const result = handleConditionComponent(
-      node,
-      { language: "js" },
-      mockTransformFn,
-    );
+    const result = handleConditionComponent(node, mockTransformRecursively);
 
     // 결과 검증
-    expect(result).toEqual({
+    expect(result.ast).toEqual({
       type: "root",
       children: [
         {
@@ -176,6 +176,7 @@ describe("handleConditionComponent", () => {
     const node = {
       type: "mdxJsxFlowElement",
       name: "Condition",
+      attributes: [{ type: "mdxJsxAttribute", name: "custom", value: "value" }],
       children: [
         {
           type: "paragraph",
@@ -184,20 +185,19 @@ describe("handleConditionComponent", () => {
       ],
     } as unknown as MdxJsxFlowElement;
 
-    // 목 함수 생성 (transformJsxComponentsFn)
-    const mockTransformFn = (_ast: Node) => {
-      // 테스트에서는 아무 작업도 하지 않음
-    };
+    // 목 함수 생성 (transformRecursively)
+    const mockTransformRecursively = vi
+      .fn()
+      .mockImplementation((ast: Node) => ({
+        ast,
+        unhandledTags: new Set<string>(),
+      }));
 
     // handleConditionComponent 함수 실행
-    const result = handleConditionComponent(
-      node,
-      { custom: "value" },
-      mockTransformFn,
-    );
+    const result = handleConditionComponent(node, mockTransformRecursively);
 
     // 결과 검증
-    expect(result).toEqual({
+    expect(result.ast).toEqual({
       type: "root",
       children: [
         {
@@ -226,11 +226,12 @@ describe("handleConditionComponent", () => {
     });
   });
 
-  it("속성이 없는 경우에도 transformJsxComponentsFn 함수를 호출하고 원본 내용을 반환한다", () => {
+  it("속성이 없는 경우에도 transformRecursively 함수를 호출하고 원본 내용을 반환한다", () => {
     // 테스트용 Condition 노드 생성
     const node = {
       type: "mdxJsxFlowElement",
       name: "Condition",
+      attributes: [],
       children: [
         {
           type: "paragraph",
@@ -239,17 +240,19 @@ describe("handleConditionComponent", () => {
       ],
     } as MdxJsxFlowElement;
 
-    // transformJsxComponentsFn 호출 여부를 확인하기 위한 목 함수
-    let transformCalled = false;
-    const mockTransformFn = (_ast: Node) => {
-      transformCalled = true;
-    };
+    // transformRecursively 호출 여부를 확인하기 위한 목 함수
+    const mockTransformRecursively = vi
+      .fn()
+      .mockImplementation((ast: Node) => ({
+        ast,
+        unhandledTags: new Set<string>(),
+      }));
 
     // handleConditionComponent 함수 실행 (속성 없음)
-    const result = handleConditionComponent(node, {}, mockTransformFn);
+    const result = handleConditionComponent(node, mockTransformRecursively);
 
     // 결과 검증
-    expect(result).toEqual({
+    expect(result.ast).toEqual({
       type: "root",
       children: [
         {
@@ -259,8 +262,10 @@ describe("handleConditionComponent", () => {
       ],
     });
 
-    // transformJsxComponentsFn가 호출되었는지 확인
-    expect(transformCalled).toBe(true);
+    // transformRecursively가 호출되었는지 확인
+    expect(mockTransformRecursively).toHaveBeenCalled();
+    // unhandledTags가 비어있는지 확인
+    expect(result.unhandledTags.size).toBe(0);
   });
 
   it("실제 AST 변환 과정에서 정상적으로 동작하는지 테스트", () => {
@@ -284,10 +289,13 @@ describe("handleConditionComponent", () => {
       ],
     };
 
-    // 목 함수 생성 (transformJsxComponentsFn)
-    const mockTransformFn = (_ast: Node) => {
-      // 테스트에서는 아무 작업도 하지 않음
-    };
+    // 목 함수 생성 (transformRecursively)
+    const mockTransformRecursively = vi
+      .fn()
+      .mockImplementation((ast: Node) => ({
+        ast,
+        unhandledTags: new Set<string>(),
+      }));
 
     // AST 변환 함수 (transformJsxComponents 함수의 일부 로직)
     visit(
@@ -295,26 +303,15 @@ describe("handleConditionComponent", () => {
       "mdxJsxFlowElement",
       (node: MdxJsxFlowElement, index, parent: Parent) => {
         if (node.name === "Condition" && index !== undefined) {
-          // 속성 추출
-          const props: Record<string, unknown> = {};
-          if (node.attributes && Array.isArray(node.attributes)) {
-            for (const attr of node.attributes) {
-              if ("name" in attr && attr.value !== undefined) {
-                props[attr.name] = attr.value;
-              }
-            }
-          }
-
           // Condition 컴포넌트 처리
-          const replacementNode = handleConditionComponent(
+          const result = handleConditionComponent(
             node,
-            props,
-            mockTransformFn,
+            mockTransformRecursively,
           );
 
           // 노드 교체
-          if (replacementNode && parent && Array.isArray(parent.children)) {
-            parent.children[index] = replacementNode;
+          if (result && parent && Array.isArray(parent.children)) {
+            parent.children[index] = result.ast;
           }
         }
       },
@@ -353,5 +350,8 @@ describe("handleConditionComponent", () => {
         },
       ],
     });
+
+    // transformRecursively가 호출되었는지 확인
+    expect(mockTransformRecursively).toHaveBeenCalled();
   });
 });

--- a/scripts/mdx-to-markdown/jsx/contentRef.test.ts
+++ b/scripts/mdx-to-markdown/jsx/contentRef.test.ts
@@ -1,4 +1,5 @@
 import type { Root } from "mdast";
+import type { MdxJsxFlowElement } from "mdast-util-mdx";
 import { describe, expect, it } from "vitest";
 
 import type { MdxParseResult } from "../mdx-parser";
@@ -26,10 +27,16 @@ describe("handleContentRefComponent", () => {
     };
 
     // handleContentRefComponent 함수 실행
-    const result = handleContentRefComponent(
-      { slug: "guide/payment" },
-      parseResultMap,
-    );
+    const node = {
+      type: "mdxJsxFlowElement",
+      name: "ContentRef",
+      attributes: [
+        { type: "mdxJsxAttribute", name: "slug", value: "guide/payment" },
+      ],
+      children: [],
+    } as MdxJsxFlowElement;
+
+    const result = handleContentRefComponent(node, parseResultMap);
 
     // 결과 검증
     expect(result).toEqual({
@@ -49,10 +56,16 @@ describe("handleContentRefComponent", () => {
     const parseResultMap = {};
 
     // handleContentRefComponent 함수 실행
-    const result = handleContentRefComponent(
-      { slug: "non-existent/page" },
-      parseResultMap,
-    );
+    const node = {
+      type: "mdxJsxFlowElement",
+      name: "ContentRef",
+      attributes: [
+        { type: "mdxJsxAttribute", name: "slug", value: "non-existent/page" },
+      ],
+      children: [],
+    } as MdxJsxFlowElement;
+
+    const result = handleContentRefComponent(node, parseResultMap);
 
     // 결과 검증
     expect(result).toEqual({
@@ -83,10 +96,16 @@ describe("handleContentRefComponent", () => {
     };
 
     // handleContentRefComponent 함수 실행 (slug가 '/'로 시작)
-    const result = handleContentRefComponent(
-      { slug: "/api/overview" },
-      parseResultMap,
-    );
+    const node = {
+      type: "mdxJsxFlowElement",
+      name: "ContentRef",
+      attributes: [
+        { type: "mdxJsxAttribute", name: "slug", value: "/api/overview" },
+      ],
+      children: [],
+    } as MdxJsxFlowElement;
+
+    const result = handleContentRefComponent(node, parseResultMap);
 
     // 결과 검증
     expect(result).toEqual({
@@ -116,10 +135,20 @@ describe("handleContentRefComponent", () => {
       },
     };
 
-    const result = handleContentRefComponent(
-      { slug: "/opi/ko/integration/ready/readme" },
-      parseResultMap,
-    );
+    const node = {
+      type: "mdxJsxFlowElement",
+      name: "ContentRef",
+      attributes: [
+        {
+          type: "mdxJsxAttribute",
+          name: "slug",
+          value: "/opi/ko/integration/ready/readme",
+        },
+      ],
+      children: [],
+    } as MdxJsxFlowElement;
+
+    const result = handleContentRefComponent(node, parseResultMap);
 
     expect(result).toEqual({
       type: "paragraph",
@@ -147,10 +176,20 @@ describe("handleContentRefComponent", () => {
       },
     };
 
-    const result = handleContentRefComponent(
-      { slug: "/opi/ko/integration/start/v1/auth" },
-      parseResultMap,
-    );
+    const node = {
+      type: "mdxJsxFlowElement",
+      name: "ContentRef",
+      attributes: [
+        {
+          type: "mdxJsxAttribute",
+          name: "slug",
+          value: "/opi/ko/integration/start/v1/auth",
+        },
+      ],
+      children: [],
+    } as MdxJsxFlowElement;
+
+    const result = handleContentRefComponent(node, parseResultMap);
 
     expect(result).toEqual({
       type: "paragraph",
@@ -178,10 +217,20 @@ describe("handleContentRefComponent", () => {
       },
     };
 
-    const result = handleContentRefComponent(
-      { slug: "/opi/ko/integration/start/v2/checkout" },
-      parseResultMap,
-    );
+    const node = {
+      type: "mdxJsxFlowElement",
+      name: "ContentRef",
+      attributes: [
+        {
+          type: "mdxJsxAttribute",
+          name: "slug",
+          value: "/opi/ko/integration/start/v2/checkout",
+        },
+      ],
+      children: [],
+    } as MdxJsxFlowElement;
+
+    const result = handleContentRefComponent(node, parseResultMap);
 
     expect(result).toEqual({
       type: "paragraph",
@@ -219,10 +268,20 @@ describe("handleContentRefComponent", () => {
       },
     };
 
-    const resultV1 = handleContentRefComponent(
-      { slug: "/opi/ko/integration/webhook/readme-v1" },
-      parseResultMap,
-    );
+    const nodeV1 = {
+      type: "mdxJsxFlowElement",
+      name: "ContentRef",
+      attributes: [
+        {
+          type: "mdxJsxAttribute",
+          name: "slug",
+          value: "/opi/ko/integration/webhook/readme-v1",
+        },
+      ],
+      children: [],
+    } as MdxJsxFlowElement;
+
+    const resultV1 = handleContentRefComponent(nodeV1, parseResultMap);
 
     expect(resultV1).toEqual({
       type: "paragraph",
@@ -235,10 +294,20 @@ describe("handleContentRefComponent", () => {
       ],
     });
 
-    const resultV2 = handleContentRefComponent(
-      { slug: "/opi/ko/integration/webhook/readme-v2" },
-      parseResultMap,
-    );
+    const nodeV2 = {
+      type: "mdxJsxFlowElement",
+      name: "ContentRef",
+      attributes: [
+        {
+          type: "mdxJsxAttribute",
+          name: "slug",
+          value: "/opi/ko/integration/webhook/readme-v2",
+        },
+      ],
+      children: [],
+    } as MdxJsxFlowElement;
+
+    const resultV2 = handleContentRefComponent(nodeV2, parseResultMap);
 
     expect(resultV2).toEqual({
       type: "paragraph",
@@ -276,10 +345,20 @@ describe("handleContentRefComponent", () => {
       },
     };
 
-    const resultV1 = handleContentRefComponent(
-      { slug: "/sdk/ko/v1-sdk/javascript-sdk/readme" },
-      parseResultMap,
-    );
+    const nodeV1 = {
+      type: "mdxJsxFlowElement",
+      name: "ContentRef",
+      attributes: [
+        {
+          type: "mdxJsxAttribute",
+          name: "slug",
+          value: "/sdk/ko/v1-sdk/javascript-sdk/readme",
+        },
+      ],
+      children: [],
+    } as MdxJsxFlowElement;
+
+    const resultV1 = handleContentRefComponent(nodeV1, parseResultMap);
 
     expect(resultV1).toEqual({
       type: "paragraph",
@@ -292,10 +371,20 @@ describe("handleContentRefComponent", () => {
       ],
     });
 
-    const resultV2 = handleContentRefComponent(
-      { slug: "/sdk/ko/v2-sdk/readme" },
-      parseResultMap,
-    );
+    const nodeV2 = {
+      type: "mdxJsxFlowElement",
+      name: "ContentRef",
+      attributes: [
+        {
+          type: "mdxJsxAttribute",
+          name: "slug",
+          value: "/sdk/ko/v2-sdk/readme",
+        },
+      ],
+      children: [],
+    } as MdxJsxFlowElement;
+
+    const resultV2 = handleContentRefComponent(nodeV2, parseResultMap);
 
     expect(resultV2).toEqual({
       type: "paragraph",
@@ -333,10 +422,20 @@ describe("handleContentRefComponent", () => {
       },
     };
 
-    const resultV1 = handleContentRefComponent(
-      { slug: "/opi/ko/integration/pg/v1/readme" },
-      parseResultMap,
-    );
+    const nodeV1 = {
+      type: "mdxJsxFlowElement",
+      name: "ContentRef",
+      attributes: [
+        {
+          type: "mdxJsxAttribute",
+          name: "slug",
+          value: "/opi/ko/integration/pg/v1/readme",
+        },
+      ],
+      children: [],
+    } as MdxJsxFlowElement;
+
+    const resultV1 = handleContentRefComponent(nodeV1, parseResultMap);
 
     expect(resultV1).toEqual({
       type: "paragraph",
@@ -349,10 +448,20 @@ describe("handleContentRefComponent", () => {
       ],
     });
 
-    const resultV2 = handleContentRefComponent(
-      { slug: "/opi/ko/integration/pg/v2/readme" },
-      parseResultMap,
-    );
+    const nodeV2 = {
+      type: "mdxJsxFlowElement",
+      name: "ContentRef",
+      attributes: [
+        {
+          type: "mdxJsxAttribute",
+          name: "slug",
+          value: "/opi/ko/integration/pg/v2/readme",
+        },
+      ],
+      children: [],
+    } as MdxJsxFlowElement;
+
+    const resultV2 = handleContentRefComponent(nodeV2, parseResultMap);
 
     expect(resultV2).toEqual({
       type: "paragraph",

--- a/scripts/mdx-to-markdown/jsx/contentRef.ts
+++ b/scripts/mdx-to-markdown/jsx/contentRef.ts
@@ -1,17 +1,21 @@
+import type { MdxJsxFlowElement, MdxJsxTextElement } from "mdast-util-mdx";
+
 import type { MdxParseResult } from "../mdx-parser";
+import { extractMdxJsxAttributes } from "./common";
 
 /**
- * ConentRef 컴포넌트 처리
- * @param props 컴포넌트 속성
+ * ContentRef 컴포넌트 처리
+ * @param node JSX 컴포넌트 노드
  * @param parseResultMap 모든 MDX 파일의 파싱 결과 맵
  * @param useMarkdownLinks 내부 링크를 마크다운 파일 링크로 변환할지 여부 (true: 마크다운 파일 링크, false: 웹페이지 링크)
  * @returns 변환된 마크다운 노드
  */
 export function handleContentRefComponent(
-  props: Record<string, unknown>,
+  node: MdxJsxFlowElement | MdxJsxTextElement,
   parseResultMap: Record<string, MdxParseResult>,
   useMarkdownLinks: boolean = true,
 ) {
+  const props = extractMdxJsxAttributes(node);
   const slugProp = props.slug;
   const slug = typeof slugProp === "string" ? slugProp.replace(/^\//, "") : "";
   let title;

--- a/scripts/mdx-to-markdown/jsx/details.test.ts
+++ b/scripts/mdx-to-markdown/jsx/details.test.ts
@@ -1,6 +1,6 @@
 import type { MdxJsxFlowElement } from "mdast-util-mdx";
 import type { Node } from "unist";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   handleDetailsComponent,
@@ -23,16 +23,17 @@ describe("handleDetailsComponent", () => {
       ],
     } as MdxJsxFlowElement;
 
-    // 목 transformJsxComponentsFn 함수 생성
-    const mockTransformJsxComponentsFn = (_ast: Node) => {
-      // 테스트에서는 아무 작업도 하지 않음
-    };
+    // 목 transformRecursively 함수 생성
+    const mockTransformRecursively = vi.fn((ast: Node) => ({
+      ast,
+      unhandledTags: new Set<string>(),
+    }));
 
     // handleDetailsComponent 함수 실행
-    const result = handleDetailsComponent(node, mockTransformJsxComponentsFn);
+    const result = handleDetailsComponent(node, mockTransformRecursively);
 
     // 결과 검증
-    expect(result).toEqual({
+    expect(result.ast).toEqual({
       type: "root",
       children: [
         { type: "html", value: "<details>" },
@@ -43,6 +44,8 @@ describe("handleDetailsComponent", () => {
         { type: "html", value: "</details>" },
       ],
     });
+    expect(result.unhandledTags).toBeDefined();
+    expect(result.unhandledTags.size).toBe(0);
   });
 
   it("자식 노드가 없는 경우 기본 텍스트를 사용한다", () => {
@@ -54,23 +57,25 @@ describe("handleDetailsComponent", () => {
       children: [],
     } as MdxJsxFlowElement;
 
-    // 목 transformJsxComponentsFn 함수 생성
-    const mockTransformJsxComponentsFn = (_ast: Node) => {
-      // 테스트에서는 아무 작업도 하지 않음
-    };
+    // 목 transformRecursively 함수 생성
+    const mockTransformRecursively = vi.fn((ast: Node) => ({
+      ast,
+      unhandledTags: new Set<string>(),
+    }));
 
     // handleDetailsComponent 함수 실행
-    const result = handleDetailsComponent(node, mockTransformJsxComponentsFn);
+    const result = handleDetailsComponent(node, mockTransformRecursively);
 
     // 결과 검증
-    expect(result).toEqual({
+    expect(result.ast).toEqual({
       type: "root",
       children: [
         { type: "html", value: "<details>" },
-        { type: "text", value: "상세 정보" },
         { type: "html", value: "</details>" },
       ],
     });
+    expect(result.unhandledTags).toBeDefined();
+    expect(result.unhandledTags.size).toBe(0);
   });
 });
 
@@ -89,19 +94,20 @@ describe("handleDetailsSummaryComponent", () => {
       ],
     } as MdxJsxFlowElement;
 
-    // 목 transformJsxComponentsFn 함수 생성
-    const mockTransformJsxComponentsFn = (_ast: Node) => {
-      // 테스트에서는 아무 작업도 하지 않음
-    };
+    // 목 transformRecursively 함수 생성
+    const mockTransformRecursively = vi.fn((ast: Node) => ({
+      ast,
+      unhandledTags: new Set<string>(),
+    }));
 
     // handleDetailsSummaryComponent 함수 실행
     const result = handleDetailsSummaryComponent(
       node,
-      mockTransformJsxComponentsFn,
+      mockTransformRecursively,
     );
 
     // 결과 검증
-    expect(result).toEqual({
+    expect(result.ast).toEqual({
       type: "root",
       children: [
         { type: "html", value: "<summary>" },
@@ -112,6 +118,8 @@ describe("handleDetailsSummaryComponent", () => {
         { type: "html", value: "</summary>" },
       ],
     });
+    expect(result.unhandledTags).toBeDefined();
+    expect(result.unhandledTags.size).toBe(0);
   });
 
   it("자식 노드가 없는 경우 기본 텍스트를 사용한다", () => {
@@ -123,26 +131,28 @@ describe("handleDetailsSummaryComponent", () => {
       children: [],
     } as MdxJsxFlowElement;
 
-    // 목 transformJsxComponentsFn 함수 생성
-    const mockTransformJsxComponentsFn = (_ast: Node) => {
-      // 테스트에서는 아무 작업도 하지 않음
-    };
+    // 목 transformRecursively 함수 생성
+    const mockTransformRecursively = vi.fn((ast: Node) => ({
+      ast,
+      unhandledTags: new Set<string>(),
+    }));
 
     // handleDetailsSummaryComponent 함수 실행
     const result = handleDetailsSummaryComponent(
       node,
-      mockTransformJsxComponentsFn,
+      mockTransformRecursively,
     );
 
     // 결과 검증
-    expect(result).toEqual({
+    expect(result.ast).toEqual({
       type: "root",
       children: [
         { type: "html", value: "<summary>" },
-        { type: "text", value: "상세 정보" },
         { type: "html", value: "</summary>" },
       ],
     });
+    expect(result.unhandledTags).toBeDefined();
+    expect(result.unhandledTags.size).toBe(0);
   });
 });
 
@@ -161,19 +171,20 @@ describe("handleDetailsContentComponent", () => {
       ],
     } as MdxJsxFlowElement;
 
-    // 목 transformJsxComponentsFn 함수 생성
-    const mockTransformJsxComponentsFn = (_ast: Node) => {
-      // 테스트에서는 아무 작업도 하지 않음
-    };
+    // 목 transformRecursively 함수 생성
+    const mockTransformRecursively = vi.fn((ast: Node) => ({
+      ast,
+      unhandledTags: new Set<string>(),
+    }));
 
     // handleDetailsContentComponent 함수 실행
     const result = handleDetailsContentComponent(
       node,
-      mockTransformJsxComponentsFn,
+      mockTransformRecursively,
     );
 
     // 결과 검증
-    expect(result).toEqual({
+    expect(result.ast).toEqual({
       type: "root",
       children: [
         {
@@ -182,6 +193,8 @@ describe("handleDetailsContentComponent", () => {
         },
       ],
     });
+    expect(result.unhandledTags).toBeDefined();
+    expect(result.unhandledTags.size).toBe(0);
   });
 
   it("자식 노드가 없는 경우 빈 노드를 반환한다", () => {
@@ -193,21 +206,24 @@ describe("handleDetailsContentComponent", () => {
       children: [],
     } as MdxJsxFlowElement;
 
-    // 목 transformJsxComponentsFn 함수 생성
-    const mockTransformJsxComponentsFn = (_ast: Node) => {
-      // 테스트에서는 아무 작업도 하지 않음
-    };
+    // 목 transformRecursively 함수 생성
+    const mockTransformRecursively = vi.fn((ast: Node) => ({
+      ast,
+      unhandledTags: new Set<string>(),
+    }));
 
     // handleDetailsContentComponent 함수 실행
     const result = handleDetailsContentComponent(
       node,
-      mockTransformJsxComponentsFn,
+      mockTransformRecursively,
     );
 
     // 결과 검증
-    expect(result).toEqual({
+    expect(result.ast).toEqual({
       type: "root",
       children: [],
     });
+    expect(result.unhandledTags).toBeDefined();
+    expect(result.unhandledTags.size).toBe(0);
   });
 });

--- a/scripts/mdx-to-markdown/jsx/details.ts
+++ b/scripts/mdx-to-markdown/jsx/details.ts
@@ -1,123 +1,104 @@
-import type { Html, Root, Text } from "mdast";
+import type { Html, Root } from "mdast";
 import type { MdxJsxFlowElement, MdxJsxTextElement } from "mdast-util-mdx";
 import type { Node } from "unist";
+
+import { unwrapJsxNode } from "./common";
 
 /**
  * Details 컴포넌트를 HTML details 태그로 변환하는 함수
  * @param node Details 컴포넌트 노드
- * @param transformJsxComponentsFn 내부 JSX 컴포넌트를 재귀적으로 변환하는 함수
+ * @param transformRecursively 내부 JSX 컴포넌트를 재귀적으로 변환하는 함수
  * @returns 변환된 노드
  */
 export function handleDetailsComponent(
   node: MdxJsxFlowElement | MdxJsxTextElement,
-  transformJsxComponentsFn: (ast: Node) => void,
-) {
-  const resultNodes: Node[] = [];
-
+  transformRecursively: (ast: Node) => {
+    ast: Node;
+    unhandledTags: Set<string>;
+  },
+): { ast: Root; unhandledTags: Set<string> } {
   // summary 시작 태그
-  resultNodes.push({
+  const detailsStartTag = {
     type: "html",
     value: "<details>",
-  } as Html);
-
-  if (node.children && node.children.length > 0) {
-    const detailsContent = {
-      type: "root",
-      children: node.children,
-    } as Root;
-    transformJsxComponentsFn(detailsContent);
-    resultNodes.push(...detailsContent.children);
-  } else {
-    // 기본 Summary 텍스트
-    resultNodes.push({
-      type: "text",
-      value: "상세 정보",
-    } as Text);
-  }
+  } as Html;
 
   // summary 종료 태그
-  resultNodes.push({
+  const detailsEndTag = {
     type: "html",
     value: "</details>",
-  } as Html);
+  } as Html;
+
+  const results = node.children.map(transformRecursively);
+
+  const newChildren = results.map((r) => r.ast);
+  const unhandledTags = results.reduce(
+    (acc, r) => acc.union(r.unhandledTags),
+    new Set<string>(),
+  );
 
   return {
-    type: "root",
-    children: resultNodes,
-  } as Root;
+    ast: {
+      type: "root",
+      children: [detailsStartTag, ...newChildren, detailsEndTag],
+    } as Root,
+    unhandledTags,
+  };
 }
 
 /**
  * Details.Summary 컴포넌트를 처리하는 함수
  * @param node Summary 컴포넌트 노드
- * @param transformJsxComponentsFn 내부 JSX 컴포넌트를 재귀적으로 변환하는 함수
+ * @param transformRecursively 내부 JSX 컴포넌트를 재귀적으로 변환하는 함수
  * @returns 변환된 노드
  */
 export function handleDetailsSummaryComponent(
   node: MdxJsxFlowElement | MdxJsxTextElement,
-  transformJsxComponentsFn: (ast: Node) => void,
-) {
-  const resultNodes: Node[] = [];
-
+  transformRecursively: (ast: Node) => {
+    ast: Node;
+    unhandledTags: Set<string>;
+  },
+): { ast: Root; unhandledTags: Set<string> } {
   // summary 시작 태그
-  resultNodes.push({
+  const summaryStartTag = {
     type: "html",
     value: "<summary>",
-  } as Html);
-
-  // Summary 내용 추가 (AST 구조 유지)
-  if (node.children && node.children.length > 0) {
-    // Summary 노드를 재귀적으로 처리
-    const summaryContent = {
-      type: "root",
-      children: node.children,
-    } as Root;
-    transformJsxComponentsFn(summaryContent);
-    resultNodes.push(...summaryContent.children);
-  } else {
-    // 기본 Summary 텍스트
-    resultNodes.push({
-      type: "text",
-      value: "상세 정보",
-    } as Text);
-  }
+  } as Html;
 
   // summary 종료 태그
-  resultNodes.push({
+  const summaryEndTag = {
     type: "html",
     value: "</summary>",
-  } as Html);
+  } as Html;
+
+  const results = node.children.map(transformRecursively);
+  const newChildren = results.map((r) => r.ast);
+  const unhandledTags = results.reduce(
+    (acc, r) => acc.union(r.unhandledTags),
+    new Set<string>(),
+  );
 
   return {
-    type: "root",
-    children: resultNodes,
-  } as Root;
+    ast: {
+      type: "root",
+      children: [summaryStartTag, ...newChildren, summaryEndTag],
+    } as Root,
+    unhandledTags,
+  };
 }
 
 /**
  * Details.Content 컴포넌트를 처리하는 함수
  * @param node Content 컴포넌트 노드
- * @param transformJsxComponentsFn 내부 JSX 컴포넌트를 재귀적으로 변환하는 함수
+ * @param transformRecursively 내부 JSX 컴포넌트를 재귀적으로 변환하는 함수
  * @returns 변환된 노드
  */
 export function handleDetailsContentComponent(
   node: MdxJsxFlowElement | MdxJsxTextElement,
-  transformJsxComponentsFn: (ast: Node) => void,
-) {
-  // Content 내용이 없으면 빈 노드 반환
-  if (!node.children || node.children.length === 0) {
-    return {
-      type: "root",
-      children: [],
-    } as Root;
-  }
-
-  // Content 노드를 재귀적으로 처리
-  const contentNodeContent = {
-    type: "root",
-    children: node.children,
-  } as Root;
-  transformJsxComponentsFn(contentNodeContent);
-
-  return contentNodeContent;
+  transformRecursively: (ast: Node) => {
+    ast: Node;
+    unhandledTags: Set<string>;
+  },
+): { ast: Root; unhandledTags: Set<string> } {
+  return unwrapJsxNode(node, transformRecursively);
 }

--- a/scripts/mdx-to-markdown/jsx/figure.test.ts
+++ b/scripts/mdx-to-markdown/jsx/figure.test.ts
@@ -3,13 +3,22 @@ import type { Parent } from "unist";
 import { visit } from "unist-util-visit";
 import { describe, expect, it } from "vitest";
 
-import { extractMdxJsxAttributes } from "./common";
 import { handleFigureComponent } from "./figure";
 
 describe("handleFigureComponent", () => {
   it("캡션이 있는 경우 '(이미지 첨부: {caption})' 형태로 변환한다", () => {
+    // 테스트용 노드 생성
+    const node = {
+      type: "mdxJsxFlowElement",
+      name: "Figure",
+      attributes: [
+        { type: "mdxJsxAttribute", name: "caption", value: "테스트 이미지" },
+      ],
+      children: [],
+    } as MdxJsxFlowElement;
+
     // handleFigureComponent 함수 실행
-    const result = handleFigureComponent({ caption: "테스트 이미지" });
+    const result = handleFigureComponent(node);
 
     // 결과 검증
     expect(result).toEqual({
@@ -24,8 +33,18 @@ describe("handleFigureComponent", () => {
   });
 
   it("캡션이 없는 경우 '(관련 이미지 첨부)' 형태로 변환한다", () => {
+    // 테스트용 노드 생성
+    const node = {
+      type: "mdxJsxFlowElement",
+      name: "Figure",
+      attributes: [
+        { type: "mdxJsxAttribute", name: "src", value: "image2.png" },
+      ],
+      children: [],
+    } as MdxJsxFlowElement;
+
     // handleFigureComponent 함수 실행
-    const result = handleFigureComponent({ src: "image2.png" });
+    const result = handleFigureComponent(node);
 
     // 결과 검증
     expect(result).toEqual({
@@ -40,8 +59,16 @@ describe("handleFigureComponent", () => {
   });
 
   it("속성이 없는 경우에도 정상적으로 처리한다", () => {
+    // 테스트용 노드 생성
+    const node = {
+      type: "mdxJsxFlowElement",
+      name: "Figure",
+      attributes: [],
+      children: [],
+    } as MdxJsxFlowElement;
+
     // handleFigureComponent 함수 실행
-    const result = handleFigureComponent({});
+    const result = handleFigureComponent(node);
 
     // 결과 검증
     expect(result).toEqual({
@@ -86,9 +113,7 @@ describe("handleFigureComponent", () => {
       (node: MdxJsxFlowElement, index, parent: Parent) => {
         if (node.name === "Figure" && index !== undefined) {
           // Figure 컴포넌트 처리
-          const replacementNode = handleFigureComponent(
-            extractMdxJsxAttributes(node),
-          );
+          const replacementNode = handleFigureComponent(node);
 
           // 노드 교체
           if (replacementNode && parent && Array.isArray(parent.children)) {

--- a/scripts/mdx-to-markdown/jsx/figure.ts
+++ b/scripts/mdx-to-markdown/jsx/figure.ts
@@ -1,8 +1,15 @@
+import type { MdxJsxFlowElement, MdxJsxTextElement } from "mdast-util-mdx";
+
+import { extractMdxJsxAttributes } from "./common";
+
 /**
  * Figure 컴포넌트 처리
  */
-export function handleFigureComponent(props: Record<string, unknown>) {
+export function handleFigureComponent(
+  node: MdxJsxFlowElement | MdxJsxTextElement,
+) {
   // 이미지 캡션 추출
+  const props = extractMdxJsxAttributes(node);
   const caption = typeof props.caption === "string" ? props.caption : "";
 
   // '(이미지 첨부: {caption})' 형태로 변환

--- a/scripts/mdx-to-markdown/jsx/hint.ts
+++ b/scripts/mdx-to-markdown/jsx/hint.ts
@@ -1,18 +1,25 @@
+import type { Root } from "mdast";
 import type { MdxJsxFlowElement, MdxJsxTextElement } from "mdast-util-mdx";
 import type { Node } from "unist";
+
+import { extractMdxJsxAttributes } from "./common";
 
 /**
  * Hint 컴포넌트를 HTML div로 변환하는 함수
  * @param node Hint 컴포넌트 노드
  * @param props 컴포넌트 속성
- * @param transformJsxComponentsFn 내부 JSX 컴포넌트를 재귀적으로 변환하는 함수
+ * @param transformRecursively 내부 JSX 컴포넌트를 재귀적으로 변환하는 함수
  * @returns 변환된 노드
  */
 export function handleHintComponent(
   node: MdxJsxFlowElement | MdxJsxTextElement,
-  props: Record<string, unknown>,
-  transformJsxComponentsFn: (ast: Node) => void,
-) {
+  transformRecursively: (ast: Node) => {
+    ast: Node;
+    unhandledTags: Set<string>;
+  },
+): { ast: Root; unhandledTags: Set<string> } {
+  const props = extractMdxJsxAttributes(node);
+
   // 속성 문자열 생성
   let classNames = "hint";
   let attributesStr = "";
@@ -46,19 +53,20 @@ export function handleHintComponent(
     value: "</div>",
   };
 
-  // 자식 노드들을 재귀적으로 처리
-  const childrenContent = {
-    type: "root",
-    children: node.children || [],
-  };
-  transformJsxComponentsFn(childrenContent);
+  // Handle case when node.children is undefined
+  const children = node.children || [];
+  const results = children.map(transformRecursively);
+  const newChildren = results.map((r) => r.ast);
+  const unhandledTags = results.reduce(
+    (acc, r) => new Set([...acc, ...r.unhandledTags]),
+    new Set<string>(),
+  );
 
-  // 시작 태그, 처리된 자식 노드들, 종료 태그를 포함하는 배열 생성
-  const newChildren = [hintStartDiv, ...childrenContent.children, hintEndDiv];
-
-  // 루트 노드 반환
   return {
-    type: "root",
-    children: newChildren,
+    ast: {
+      type: "root",
+      children: [hintStartDiv, ...newChildren, hintEndDiv],
+    } as Root,
+    unhandledTags,
   };
 }

--- a/scripts/mdx-to-markdown/jsx/imports.test.ts
+++ b/scripts/mdx-to-markdown/jsx/imports.test.ts
@@ -1,7 +1,7 @@
 import type { Root } from "mdast";
 import { describe, expect, it } from "vitest";
 
-import { collectAllImportedElementNames } from "./imports";
+import { collectAllImportedElements } from "./imports";
 
 describe("collectAllImportedElementNames", () => {
   it("should return an empty set for an AST with no imports", () => {
@@ -22,11 +22,10 @@ describe("collectAllImportedElementNames", () => {
     };
 
     // Call the function
-    const result = collectAllImportedElementNames(ast);
+    const result = collectAllImportedElements(ast);
 
     // Verify the result
-    expect(result).toBeInstanceOf(Set);
-    expect(result.size).toBe(0);
+    expect(result.length).toBe(0);
   });
 
   it("should collect default imports", () => {
@@ -67,12 +66,16 @@ describe("collectAllImportedElementNames", () => {
     };
 
     // Call the function
-    const result = collectAllImportedElementNames(ast);
+    const result = collectAllImportedElements(ast);
 
     // Verify the result
-    expect(result).toBeInstanceOf(Set);
-    expect(result.size).toBe(1);
-    expect(result.has("React")).toBe(true);
+    expect(result.length).toBe(1);
+
+    // Check if the array contains an object with the expected name and from properties
+    const hasReact = result.some(
+      (item) => item.name === "React" && item.from === "react",
+    );
+    expect(hasReact).toBe(true);
   });
 
   it("should collect named imports", () => {
@@ -128,13 +131,20 @@ describe("collectAllImportedElementNames", () => {
     };
 
     // Call the function
-    const result = collectAllImportedElementNames(ast);
+    const result = collectAllImportedElements(ast);
 
     // Verify the result
-    expect(result).toBeInstanceOf(Set);
-    expect(result.size).toBe(2);
-    expect(result.has("useState")).toBe(true);
-    expect(result.has("useEffect")).toBe(true);
+    expect(result.length).toBe(2);
+
+    // Check if the array contains objects with the expected name and from properties
+    const hasUseState = result.some(
+      (item) => item.name === "useState" && item.from === "react",
+    );
+    const hasUseEffect = result.some(
+      (item) => item.name === "useEffect" && item.from === "react",
+    );
+    expect(hasUseState).toBe(true);
+    expect(hasUseEffect).toBe(true);
   });
 
   it("should collect renamed imports", () => {
@@ -179,12 +189,16 @@ describe("collectAllImportedElementNames", () => {
     };
 
     // Call the function
-    const result = collectAllImportedElementNames(ast);
+    const result = collectAllImportedElements(ast);
 
     // Verify the result
-    expect(result).toBeInstanceOf(Set);
-    expect(result.size).toBe(1);
-    expect(result.has("useStateAlias")).toBe(true);
+    expect(result.length).toBe(1);
+
+    // Check if the set contains an object with the expected name and from properties
+    const hasUseStateAlias = result.some(
+      (item) => item.name === "useStateAlias" && item.from === "react",
+    );
+    expect(hasUseStateAlias).toBe(true);
   });
 
   it("should collect namespace imports", () => {
@@ -225,12 +239,16 @@ describe("collectAllImportedElementNames", () => {
     };
 
     // Call the function
-    const result = collectAllImportedElementNames(ast);
+    const result = collectAllImportedElements(ast);
 
     // Verify the result
-    expect(result).toBeInstanceOf(Set);
-    expect(result.size).toBe(1);
-    expect(result.has("ReactAll")).toBe(true);
+    expect(result.length).toBe(1);
+
+    // Check if the array contains an object with the expected name and from properties
+    const hasReactAll = result.some(
+      (item) => item.name === "ReactAll" && item.from === "react",
+    );
+    expect(hasReactAll).toBe(true);
   });
 
   it("should collect mixed import types", () => {
@@ -311,15 +329,29 @@ describe("collectAllImportedElementNames", () => {
     };
 
     // Call the function
-    const result = collectAllImportedElementNames(ast);
+    const result = collectAllImportedElements(ast);
 
     // Verify the result
-    expect(result).toBeInstanceOf(Set);
-    expect(result.size).toBe(4);
-    expect(result.has("React")).toBe(true);
-    expect(result.has("useState")).toBe(true);
-    expect(result.has("useEffectAlias")).toBe(true);
-    expect(result.has("ReactDOM")).toBe(true);
+    expect(result.length).toBe(4);
+
+    // Check if the array contains objects with the expected name and from properties
+    const hasReact = result.some(
+      (item) => item.name === "React" && item.from === "react",
+    );
+    const hasUseState = result.some(
+      (item) => item.name === "useState" && item.from === "react",
+    );
+    const hasUseEffectAlias = result.some(
+      (item) => item.name === "useEffectAlias" && item.from === "react",
+    );
+    const hasReactDOM = result.some(
+      (item) => item.name === "ReactDOM" && item.from === "react-dom",
+    );
+
+    expect(hasReact).toBe(true);
+    expect(hasUseState).toBe(true);
+    expect(hasUseEffectAlias).toBe(true);
+    expect(hasReactDOM).toBe(true);
   });
 
   it("should handle multiple import statements", () => {
@@ -399,13 +431,24 @@ describe("collectAllImportedElementNames", () => {
     };
 
     // Call the function
-    const result = collectAllImportedElementNames(ast);
+    const result = collectAllImportedElements(ast);
 
     // Verify the result
-    expect(result).toBeInstanceOf(Set);
-    expect(result.size).toBe(3);
-    expect(result.has("React")).toBe(true);
-    expect(result.has("useState")).toBe(true);
-    expect(result.has("ReactDOM")).toBe(true);
+    expect(result.length).toBe(3);
+
+    // Check if the array contains objects with the expected name and from properties
+    const hasReact = result.some(
+      (item) => item.name === "React" && item.from === "react",
+    );
+    const hasUseState = result.some(
+      (item) => item.name === "useState" && item.from === "react",
+    );
+    const hasReactDOM = result.some(
+      (item) => item.name === "ReactDOM" && item.from === "react-dom",
+    );
+
+    expect(hasReact).toBe(true);
+    expect(hasUseState).toBe(true);
+    expect(hasReactDOM).toBe(true);
   });
 });

--- a/scripts/mdx-to-markdown/jsx/imports.test.ts
+++ b/scripts/mdx-to-markdown/jsx/imports.test.ts
@@ -1,0 +1,411 @@
+import type { Root } from "mdast";
+import { describe, expect, it } from "vitest";
+
+import { collectAllImportedElementNames } from "./imports";
+
+describe("collectAllImportedElementNames", () => {
+  it("should return an empty set for an AST with no imports", () => {
+    // Create a test AST with no imports
+    const ast: Root = {
+      type: "root",
+      children: [
+        {
+          type: "paragraph",
+          children: [
+            {
+              type: "text",
+              value: "This is a paragraph with no imports",
+            },
+          ],
+        },
+      ],
+    };
+
+    // Call the function
+    const result = collectAllImportedElementNames(ast);
+
+    // Verify the result
+    expect(result).toBeInstanceOf(Set);
+    expect(result.size).toBe(0);
+  });
+
+  it("should collect default imports", () => {
+    // Create a test AST with default imports
+    const ast: Root = {
+      type: "root",
+      children: [
+        {
+          type: "mdxjsEsm",
+          value: 'import React from "react";',
+          data: {
+            estree: {
+              type: "Program",
+              body: [
+                {
+                  type: "ImportDeclaration",
+                  specifiers: [
+                    {
+                      type: "ImportDefaultSpecifier",
+                      local: {
+                        type: "Identifier",
+                        name: "React",
+                      },
+                    },
+                  ],
+                  source: {
+                    type: "Literal",
+                    value: "react",
+                    raw: '"react"',
+                  },
+                },
+              ],
+              sourceType: "module",
+            },
+          },
+        },
+      ],
+    };
+
+    // Call the function
+    const result = collectAllImportedElementNames(ast);
+
+    // Verify the result
+    expect(result).toBeInstanceOf(Set);
+    expect(result.size).toBe(1);
+    expect(result.has("React")).toBe(true);
+  });
+
+  it("should collect named imports", () => {
+    // Create a test AST with named imports
+    const ast: Root = {
+      type: "root",
+      children: [
+        {
+          type: "mdxjsEsm",
+          value: 'import { useState, useEffect } from "react";',
+          data: {
+            estree: {
+              type: "Program",
+              body: [
+                {
+                  type: "ImportDeclaration",
+                  specifiers: [
+                    {
+                      type: "ImportSpecifier",
+                      local: {
+                        type: "Identifier",
+                        name: "useState",
+                      },
+                      imported: {
+                        type: "Identifier",
+                        name: "useState",
+                      },
+                    },
+                    {
+                      type: "ImportSpecifier",
+                      local: {
+                        type: "Identifier",
+                        name: "useEffect",
+                      },
+                      imported: {
+                        type: "Identifier",
+                        name: "useEffect",
+                      },
+                    },
+                  ],
+                  source: {
+                    type: "Literal",
+                    value: "react",
+                    raw: '"react"',
+                  },
+                },
+              ],
+              sourceType: "module",
+            },
+          },
+        },
+      ],
+    };
+
+    // Call the function
+    const result = collectAllImportedElementNames(ast);
+
+    // Verify the result
+    expect(result).toBeInstanceOf(Set);
+    expect(result.size).toBe(2);
+    expect(result.has("useState")).toBe(true);
+    expect(result.has("useEffect")).toBe(true);
+  });
+
+  it("should collect renamed imports", () => {
+    // Create a test AST with renamed imports
+    const ast: Root = {
+      type: "root",
+      children: [
+        {
+          type: "mdxjsEsm",
+          value: 'import { useState as useStateAlias } from "react";',
+          data: {
+            estree: {
+              type: "Program",
+              body: [
+                {
+                  type: "ImportDeclaration",
+                  specifiers: [
+                    {
+                      type: "ImportSpecifier",
+                      local: {
+                        type: "Identifier",
+                        name: "useStateAlias",
+                      },
+                      imported: {
+                        type: "Identifier",
+                        name: "useState",
+                      },
+                    },
+                  ],
+                  source: {
+                    type: "Literal",
+                    value: "react",
+                    raw: '"react"',
+                  },
+                },
+              ],
+              sourceType: "module",
+            },
+          },
+        },
+      ],
+    };
+
+    // Call the function
+    const result = collectAllImportedElementNames(ast);
+
+    // Verify the result
+    expect(result).toBeInstanceOf(Set);
+    expect(result.size).toBe(1);
+    expect(result.has("useStateAlias")).toBe(true);
+  });
+
+  it("should collect namespace imports", () => {
+    // Create a test AST with namespace imports
+    const ast: Root = {
+      type: "root",
+      children: [
+        {
+          type: "mdxjsEsm",
+          value: 'import * as ReactAll from "react";',
+          data: {
+            estree: {
+              type: "Program",
+              body: [
+                {
+                  type: "ImportDeclaration",
+                  specifiers: [
+                    {
+                      type: "ImportNamespaceSpecifier",
+                      local: {
+                        type: "Identifier",
+                        name: "ReactAll",
+                      },
+                    },
+                  ],
+                  source: {
+                    type: "Literal",
+                    value: "react",
+                    raw: '"react"',
+                  },
+                },
+              ],
+              sourceType: "module",
+            },
+          },
+        },
+      ],
+    };
+
+    // Call the function
+    const result = collectAllImportedElementNames(ast);
+
+    // Verify the result
+    expect(result).toBeInstanceOf(Set);
+    expect(result.size).toBe(1);
+    expect(result.has("ReactAll")).toBe(true);
+  });
+
+  it("should collect mixed import types", () => {
+    // Create a test AST with mixed import types
+    const ast: Root = {
+      type: "root",
+      children: [
+        {
+          type: "mdxjsEsm",
+          value:
+            'import React, { useState, useEffect as useEffectAlias } from "react";\nimport * as ReactDOM from "react-dom";',
+          data: {
+            estree: {
+              type: "Program",
+              body: [
+                {
+                  type: "ImportDeclaration",
+                  specifiers: [
+                    {
+                      type: "ImportDefaultSpecifier",
+                      local: {
+                        type: "Identifier",
+                        name: "React",
+                      },
+                    },
+                    {
+                      type: "ImportSpecifier",
+                      local: {
+                        type: "Identifier",
+                        name: "useState",
+                      },
+                      imported: {
+                        type: "Identifier",
+                        name: "useState",
+                      },
+                    },
+                    {
+                      type: "ImportSpecifier",
+                      local: {
+                        type: "Identifier",
+                        name: "useEffectAlias",
+                      },
+                      imported: {
+                        type: "Identifier",
+                        name: "useEffect",
+                      },
+                    },
+                  ],
+                  source: {
+                    type: "Literal",
+                    value: "react",
+                    raw: '"react"',
+                  },
+                },
+                {
+                  type: "ImportDeclaration",
+                  specifiers: [
+                    {
+                      type: "ImportNamespaceSpecifier",
+                      local: {
+                        type: "Identifier",
+                        name: "ReactDOM",
+                      },
+                    },
+                  ],
+                  source: {
+                    type: "Literal",
+                    value: "react-dom",
+                    raw: '"react-dom"',
+                  },
+                },
+              ],
+              sourceType: "module",
+            },
+          },
+        },
+      ],
+    };
+
+    // Call the function
+    const result = collectAllImportedElementNames(ast);
+
+    // Verify the result
+    expect(result).toBeInstanceOf(Set);
+    expect(result.size).toBe(4);
+    expect(result.has("React")).toBe(true);
+    expect(result.has("useState")).toBe(true);
+    expect(result.has("useEffectAlias")).toBe(true);
+    expect(result.has("ReactDOM")).toBe(true);
+  });
+
+  it("should handle multiple import statements", () => {
+    // Create a test AST with multiple import statements
+    const ast: Root = {
+      type: "root",
+      children: [
+        {
+          type: "mdxjsEsm",
+          value:
+            'import React from "react";\nimport { useState } from "react";\nimport * as ReactDOM from "react-dom";',
+          data: {
+            estree: {
+              type: "Program",
+              body: [
+                {
+                  type: "ImportDeclaration",
+                  specifiers: [
+                    {
+                      type: "ImportDefaultSpecifier",
+                      local: {
+                        type: "Identifier",
+                        name: "React",
+                      },
+                    },
+                  ],
+                  source: {
+                    type: "Literal",
+                    value: "react",
+                    raw: '"react"',
+                  },
+                },
+                {
+                  type: "ImportDeclaration",
+                  specifiers: [
+                    {
+                      type: "ImportSpecifier",
+                      local: {
+                        type: "Identifier",
+                        name: "useState",
+                      },
+                      imported: {
+                        type: "Identifier",
+                        name: "useState",
+                      },
+                    },
+                  ],
+                  source: {
+                    type: "Literal",
+                    value: "react",
+                    raw: '"react"',
+                  },
+                },
+                {
+                  type: "ImportDeclaration",
+                  specifiers: [
+                    {
+                      type: "ImportNamespaceSpecifier",
+                      local: {
+                        type: "Identifier",
+                        name: "ReactDOM",
+                      },
+                    },
+                  ],
+                  source: {
+                    type: "Literal",
+                    value: "react-dom",
+                    raw: '"react-dom"',
+                  },
+                },
+              ],
+              sourceType: "module",
+            },
+          },
+        },
+      ],
+    };
+
+    // Call the function
+    const result = collectAllImportedElementNames(ast);
+
+    // Verify the result
+    expect(result).toBeInstanceOf(Set);
+    expect(result.size).toBe(3);
+    expect(result.has("React")).toBe(true);
+    expect(result.has("useState")).toBe(true);
+    expect(result.has("ReactDOM")).toBe(true);
+  });
+});

--- a/scripts/mdx-to-markdown/jsx/imports.ts
+++ b/scripts/mdx-to-markdown/jsx/imports.ts
@@ -1,0 +1,39 @@
+import type { MdxjsEsm } from "mdast-util-mdx";
+import type { Node } from "unist";
+import { visit } from "unist-util-visit";
+
+/**
+ * Collects all imported element names from the MDX AST
+ * @param ast MDX AST
+ * @returns Set of imported element names
+ */
+export function collectAllImportedElementNames(ast: Node): Set<string> {
+  const importedElementNames = new Set<string>();
+  visit(ast, "mdxjsEsm", (node: MdxjsEsm) => {
+    if (node.data?.estree) {
+      const estree = node.data.estree;
+
+      // Process each statement in the ESM module
+      for (const statement of estree.body) {
+        // Look for import declarations
+        if (statement.type === "ImportDeclaration") {
+          // Process each import specifier
+          for (const specifier of statement.specifiers) {
+            if (specifier.type === "ImportDefaultSpecifier") {
+              // Handle default imports like: import React from 'react'
+              importedElementNames.add(specifier.local.name);
+            } else if (specifier.type === "ImportSpecifier") {
+              // Handle named imports like: import { useState as useStateAlias } from 'react'
+              importedElementNames.add(specifier.local.name);
+            } else if (specifier.type === "ImportNamespaceSpecifier") {
+              // Handle namespace imports like: import * as React from 'react'
+              importedElementNames.add(specifier.local.name);
+            }
+          }
+        }
+      }
+    }
+  });
+
+  return importedElementNames;
+}

--- a/scripts/mdx-to-markdown/jsx/imports.ts
+++ b/scripts/mdx-to-markdown/jsx/imports.ts
@@ -2,6 +2,7 @@ import type { MdxjsEsm } from "mdast-util-mdx";
 import type { Node } from "unist";
 import { visit } from "unist-util-visit";
 
+// TODO: provide an option to exclude components
 /**
  * Collects all imported element names from the MDX AST
  * @param ast MDX AST

--- a/scripts/mdx-to-markdown/jsx/index.test.ts
+++ b/scripts/mdx-to-markdown/jsx/index.test.ts
@@ -108,10 +108,10 @@ describe("transformJsxComponents", () => {
     };
 
     // transformJsxComponents 함수 실행
-    transformJsxComponents(ast, parseResultMap);
+    const { ast: transformedAst } = transformJsxComponents(ast, parseResultMap);
 
     // 결과 검증 - VersionGate 내부의 ContentRef가 마크다운 링크로 변환되었는지 확인
-    expect(ast).toEqual({
+    expect(transformedAst).toEqual({
       type: "root",
       children: [
         {
@@ -289,10 +289,10 @@ describe("transformJsxComponents", () => {
     };
 
     // transformJsxComponents 함수 실행
-    transformJsxComponents(ast, parseResultMap);
+    const { ast: transformedAst } = transformJsxComponents(ast, parseResultMap);
 
     // 결과 검증 - 중첩된 VersionGate와 ContentRef가 모두 처리되었는지 확인
-    expect(ast).toEqual({
+    expect(transformedAst).toEqual({
       type: "root",
       children: [
         {
@@ -463,10 +463,10 @@ describe("transformJsxComponents", () => {
     };
 
     // transformJsxComponents 함수 실행
-    transformJsxComponents(ast, parseResultMap);
+    const { ast: transformedAst } = transformJsxComponents(ast, parseResultMap);
 
     // 결과 검증 - 다양한 컴포넌트가 모두 처리되었는지 확인
-    expect(ast).toEqual({
+    expect(transformedAst).toEqual({
       type: "root",
       children: [
         {
@@ -631,10 +631,10 @@ describe("transformJsxComponents", () => {
     };
 
     // transformJsxComponents 함수 실행
-    transformJsxComponents(ast, parseResultMap);
+    const { ast: transformedAst } = transformJsxComponents(ast, parseResultMap);
 
     // 결과 검증 - 각 Condition 컴포넌트가 HTML 주석으로 변환되었는지 확인
-    expect(ast).toEqual({
+    expect(transformedAst).toEqual({
       type: "root",
       children: [
         {

--- a/scripts/mdx-to-markdown/jsx/index.ts
+++ b/scripts/mdx-to-markdown/jsx/index.ts
@@ -1,3 +1,4 @@
+import type { Html } from "mdast";
 import type { MdxJsxFlowElement, MdxJsxTextElement } from "mdast-util-mdx";
 import type { Node, Parent } from "unist";
 import { visit } from "unist-util-visit";
@@ -77,14 +78,21 @@ export function transformJsxComponents(
               ),
           );
         }
-      } else if (componentName === "code") {
-        // 코드 내용 추출 및 백틱으로 감싼 텍스트 노드 생성
-        replacementNode = extractCodeContent(jsxNode);
       } else {
         // 속성 추출
         const props = extractMdxJsxAttributes(jsxNode);
 
         switch (componentName) {
+          case "code":
+            replacementNode = extractCodeContent(jsxNode);
+            break;
+          case "br":
+            replacementNode = {
+              type: "html",
+              value: "<br />",
+            } as Html;
+
+            break;
           case "Figure":
             replacementNode = handleFigureComponent(props);
             break;

--- a/scripts/mdx-to-markdown/jsx/index.ts
+++ b/scripts/mdx-to-markdown/jsx/index.ts
@@ -28,7 +28,11 @@ import { handleVersionGateComponent } from "./versionGate";
 import { handleYoutubeComponent } from "./youtube";
 
 // TODO: handle imported tags
-const tagsNotToHandle = new Set<string>(["Parameter", "center"]);
+const tagsNotToHandle = new Set<string>([
+  "Parameter",
+  "Parameter.Details",
+  "center",
+]);
 
 /**
  * JSX 컴포넌트를 마크다운으로 변환하는 함수
@@ -83,6 +87,9 @@ export function transformJsxComponents(
           case "table":
           case "thead":
           case "tbody":
+          case "th":
+          case "tr":
+          case "td":
             return replaceToHtml(jsxNode, transformRecursively);
           case "Figure":
             return {

--- a/scripts/mdx-to-markdown/jsx/index.ts
+++ b/scripts/mdx-to-markdown/jsx/index.ts
@@ -16,6 +16,7 @@ import {
 } from "./details";
 import { handleFigureComponent } from "./figure";
 import { handleHintComponent } from "./hint";
+import { collectAllImportedElementNames } from "./imports";
 import { handleProseComponent } from "./prose";
 import {
   handleSwaggerComponent,
@@ -26,17 +27,26 @@ import { handleTabComponent, handleTabsComponent } from "./tabs";
 import { handleVersionGateComponent } from "./versionGate";
 import { handleYoutubeComponent } from "./youtube";
 
+// TODO: handle imported tags
+const tagsNotToHandle = new Set<string>(["Parameter", "center"]);
+
 /**
  * JSX 컴포넌트를 마크다운으로 변환하는 함수
  * @param ast MDX AST
  * @param parseResultMap 모든 MDX 파일의 파싱 결과 맵 (slug -> MdxParseResult)
  * @param useMarkdownLinks 내부 링크를 마크다운 파일 링크로 변환할지 여부 (true: 마크다운 파일 링크, false: 웹페이지 링크)
+ * @returns 처리되지 않은 태그 목록
  */
 export function transformJsxComponents(
   ast: Node,
   parseResultMap: Record<string, MdxParseResult>,
   useMarkdownLinks: boolean = true,
-): void {
+): Set<string> {
+  const unhandledTags = new Set<string>();
+
+  // Collect all imported element names
+  const importedElementNames = collectAllImportedElementNames(ast);
+
   // JSX Flow 컴포넌트 변환
   visit(
     ast,
@@ -46,54 +56,19 @@ export function transformJsxComponents(
       const jsxNode = node as MdxJsxFlowElement | MdxJsxTextElement;
       if (!jsxNode.name || index === undefined || !parent) return;
 
-      // prose 태그 처리 (예: <prose.h1>, <prose.p> 등)
-      if (jsxNode.name.startsWith("prose.")) {
-        const proseElementType = jsxNode.name.split(".")[1];
-        if (proseElementType) {
-          // 노드 교체 - 배열에서 직접 교체
-          parent.children.splice(
-            index,
-            1,
-            handleProseComponent(jsxNode, proseElementType, (innerAst: Node) =>
-              transformJsxComponents(
-                innerAst,
-                parseResultMap,
-                useMarkdownLinks,
-              ),
-            ),
-          );
-          return;
-        }
-      }
-
-      // code 요소인지 확인
-      if (jsxNode.name === "code") {
-        // 코드 내용 추출 및 백틱으로 감싼 텍스트 노드 생성
-        const backtickNode = extractCodeContent(jsxNode);
-
-        // 원래 노드를 백틱 노드로 교체
-        parent.children.splice(index, 1, backtickNode);
-        return;
-      }
-
-      // 일반 컴포넌트 처리 (대문자로 시작하는 컴포넌트)
-      if (!/^[A-Z]/.test(jsxNode.name)) return;
-
       // 컴포넌트 이름과 속성
       const componentName = jsxNode.name;
 
-      // 속성 추출
-      const props = extractMdxJsxAttributes(jsxNode);
+      let replacementNode: Node | undefined;
 
-      let replacementNode: Node;
-      switch (componentName) {
-        case "Figure":
-          replacementNode = handleFigureComponent(props);
-          break;
-        case "Hint":
-          replacementNode = handleHintComponent(
+      // prose 태그 처리 (예: <prose.h1>, <prose.p> 등)
+      if (componentName.startsWith("prose.")) {
+        const proseElementType = componentName.split(".")[1];
+        if (proseElementType) {
+          // 노드 교체 - 배열에서 직접 교체
+          replacementNode = handleProseComponent(
             jsxNode,
-            props,
+            proseElementType,
             (innerAst: Node) =>
               transformJsxComponents(
                 innerAst,
@@ -101,155 +76,196 @@ export function transformJsxComponents(
                 useMarkdownLinks,
               ),
           );
-          break;
-        case "Tabs":
-          replacementNode = handleTabsComponent(jsxNode, (innerAst: Node) =>
-            transformJsxComponents(innerAst, parseResultMap, useMarkdownLinks),
-          );
-          break;
-        case "Tabs.Tab":
-          replacementNode = handleTabComponent(
-            jsxNode,
-            props,
-            (innerAst: Node) =>
-              transformJsxComponents(
-                innerAst,
-                parseResultMap,
-                useMarkdownLinks,
-              ),
-          );
-          break;
-        case "Details":
-          replacementNode = handleDetailsComponent(jsxNode, (innerAst: Node) =>
-            transformJsxComponents(innerAst, parseResultMap, useMarkdownLinks),
-          );
-          break;
-        case "Details.Summary":
-          replacementNode = handleDetailsSummaryComponent(
-            jsxNode,
-            (innerAst: Node) =>
-              transformJsxComponents(
-                innerAst,
-                parseResultMap,
-                useMarkdownLinks,
-              ),
-          );
-          break;
-        case "Details.Content":
-          replacementNode = handleDetailsContentComponent(
-            jsxNode,
-            (innerAst: Node) =>
-              transformJsxComponents(
-                innerAst,
-                parseResultMap,
-                useMarkdownLinks,
-              ),
-          );
-          break;
-        case "Condition":
-          replacementNode = handleConditionComponent(
-            jsxNode,
-            props,
-            (innerAst: Node) =>
-              transformJsxComponents(
-                innerAst,
-                parseResultMap,
-                useMarkdownLinks,
-              ),
-          );
-          break;
-        case "ContentRef":
-          replacementNode = handleContentRefComponent(
-            props,
-            parseResultMap,
-            useMarkdownLinks,
-          );
-          break;
-        case "VersionGate":
-          // VersionGate 컴포넌트 처리 - 내부에서 재귀적으로 transformJsxComponents 호출
-          // 클로저를 사용하여 parseResultMap을 캡처한 함수 전달
-          replacementNode = handleVersionGateComponent(
-            jsxNode,
-            props,
-            (innerAst: Node) =>
-              transformJsxComponents(
-                innerAst,
-                parseResultMap,
-                useMarkdownLinks,
-              ),
-          );
-          break;
-        case "Youtube":
-          replacementNode = handleYoutubeComponent(props);
-          break;
-        case "ApiLink":
-          replacementNode = handleApiLinkComponent(props);
-          break;
-        case "PaymentV1":
-        case "PaymentV2":
-        case "Recon":
-        case "Console":
-        case "Partner":
-          replacementNode = handleBadgeComponent(componentName);
-          break;
-        case "Swagger":
-          replacementNode = handleSwaggerComponent(
-            jsxNode,
-            props,
-            (innerAst: Node) =>
-              transformJsxComponents(
-                innerAst,
-                parseResultMap,
-                useMarkdownLinks,
-              ),
-          );
-          break;
-        case "SwaggerDescription":
-          replacementNode = handleSwaggerDescriptionComponent(
-            jsxNode,
-            props,
-            (innerAst: Node) =>
-              transformJsxComponents(
-                innerAst,
-                parseResultMap,
-                useMarkdownLinks,
-              ),
-          );
-          break;
-        case "SwaggerResponse":
-          replacementNode = handleSwaggerResponseComponent(
-            jsxNode,
-            props,
-            (innerAst: Node) =>
-              transformJsxComponents(
-                innerAst,
-                parseResultMap,
-                useMarkdownLinks,
-              ),
-          );
-          break;
-        default:
-          // 기본적으로 자식 노드만 유지
-          replacementNode = {
-            type: "root",
-            children: jsxNode.children || [],
-          } as Parent;
+        }
+      } else if (componentName === "code") {
+        // 코드 내용 추출 및 백틱으로 감싼 텍스트 노드 생성
+        replacementNode = extractCodeContent(jsxNode);
+      } else {
+        // 속성 추출
+        const props = extractMdxJsxAttributes(jsxNode);
 
-          // 자식 노드들에 대해 재귀적으로 transformJsxComponents 호출
-          if (
-            (replacementNode as Parent).children &&
-            (replacementNode as Parent).children.length > 0
-          ) {
-            transformJsxComponents(
-              replacementNode,
+        switch (componentName) {
+          case "Figure":
+            replacementNode = handleFigureComponent(props);
+            break;
+          case "Hint":
+            replacementNode = handleHintComponent(
+              jsxNode,
+              props,
+              (innerAst: Node) =>
+                transformJsxComponents(
+                  innerAst,
+                  parseResultMap,
+                  useMarkdownLinks,
+                ),
+            );
+            break;
+          case "Tabs":
+            replacementNode = handleTabsComponent(jsxNode, (innerAst: Node) =>
+              transformJsxComponents(
+                innerAst,
+                parseResultMap,
+                useMarkdownLinks,
+              ),
+            );
+            break;
+          case "Tabs.Tab":
+            replacementNode = handleTabComponent(
+              jsxNode,
+              props,
+              (innerAst: Node) =>
+                transformJsxComponents(
+                  innerAst,
+                  parseResultMap,
+                  useMarkdownLinks,
+                ),
+            );
+            break;
+          case "Details":
+            replacementNode = handleDetailsComponent(
+              jsxNode,
+              (innerAst: Node) =>
+                transformJsxComponents(
+                  innerAst,
+                  parseResultMap,
+                  useMarkdownLinks,
+                ),
+            );
+            break;
+          case "Details.Summary":
+            replacementNode = handleDetailsSummaryComponent(
+              jsxNode,
+              (innerAst: Node) =>
+                transformJsxComponents(
+                  innerAst,
+                  parseResultMap,
+                  useMarkdownLinks,
+                ),
+            );
+            break;
+          case "Details.Content":
+            replacementNode = handleDetailsContentComponent(
+              jsxNode,
+              (innerAst: Node) =>
+                transformJsxComponents(
+                  innerAst,
+                  parseResultMap,
+                  useMarkdownLinks,
+                ),
+            );
+            break;
+          case "Condition":
+            replacementNode = handleConditionComponent(
+              jsxNode,
+              props,
+              (innerAst: Node) =>
+                transformJsxComponents(
+                  innerAst,
+                  parseResultMap,
+                  useMarkdownLinks,
+                ),
+            );
+            break;
+          case "ContentRef":
+            replacementNode = handleContentRefComponent(
+              props,
               parseResultMap,
               useMarkdownLinks,
             );
-          }
+            break;
+          case "VersionGate":
+            replacementNode = handleVersionGateComponent(
+              jsxNode,
+              props,
+              (innerAst: Node) =>
+                transformJsxComponents(
+                  innerAst,
+                  parseResultMap,
+                  useMarkdownLinks,
+                ),
+            );
+            break;
+          case "Youtube":
+            replacementNode = handleYoutubeComponent(props);
+            break;
+          case "ApiLink":
+            replacementNode = handleApiLinkComponent(props);
+            break;
+          case "PaymentV1":
+          case "PaymentV2":
+          case "Recon":
+          case "Console":
+          case "Partner":
+            replacementNode = handleBadgeComponent(componentName);
+            break;
+          case "Swagger":
+            replacementNode = handleSwaggerComponent(
+              jsxNode,
+              props,
+              (innerAst: Node) =>
+                transformJsxComponents(
+                  innerAst,
+                  parseResultMap,
+                  useMarkdownLinks,
+                ),
+            );
+            break;
+          case "SwaggerDescription":
+            replacementNode = handleSwaggerDescriptionComponent(
+              jsxNode,
+              props,
+              (innerAst: Node) =>
+                transformJsxComponents(
+                  innerAst,
+                  parseResultMap,
+                  useMarkdownLinks,
+                ),
+            );
+            break;
+          case "SwaggerResponse":
+            replacementNode = handleSwaggerResponseComponent(
+              jsxNode,
+              props,
+              (innerAst: Node) =>
+                transformJsxComponents(
+                  innerAst,
+                  parseResultMap,
+                  useMarkdownLinks,
+                ),
+            );
+            break;
+        }
+      }
+
+      if (!replacementNode) {
+        unhandledTags.add(componentName);
+
+        if (!jsxNode.children || jsxNode.children.length === 0) {
+          // Nothing to keep, remove this node from the AST
+          parent.children.splice(index, 1);
+          return index;
+        }
+
+        // 기본적으로 자식 노드만 유지
+        replacementNode = {
+          type: "root",
+          children: jsxNode.children,
+        } as Parent;
+
+        // 자식 노드들에 대해 재귀적으로 transformJsxComponents 호출
+        transformJsxComponents(
+          replacementNode,
+          parseResultMap,
+          useMarkdownLinks,
+        );
       }
 
       // 노드 교체
       parent.children.splice(index, 1, replacementNode);
     },
   );
+
+  return unhandledTags
+    .difference(tagsNotToHandle)
+    .difference(importedElementNames);
 }

--- a/scripts/mdx-to-markdown/jsx/prose.test.ts
+++ b/scripts/mdx-to-markdown/jsx/prose.test.ts
@@ -1,6 +1,6 @@
 import type { MdxJsxFlowElement } from "mdast-util-mdx";
 import type { Node } from "unist";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { handleProseComponent } from "./prose";
 
@@ -13,20 +13,17 @@ describe("handleProseComponent", () => {
       children: [{ type: "text", value: "제목 텍스트" }],
     } as unknown as MdxJsxFlowElement;
 
-    // 목 transformJsxComponentsFn 함수 생성
-    const mockTransformJsxComponentsFn = (_ast: Node) => {
-      // 테스트에서는 아무 작업도 하지 않음
-    };
+    // Mock transformRecursively 함수 생성
+    const mockTransformRecursively = vi.fn((ast: Node) => ({
+      ast,
+      unhandledTags: new Set<string>(),
+    }));
 
     // handleProseComponent 함수 실행
-    const result = handleProseComponent(
-      node,
-      "h1",
-      mockTransformJsxComponentsFn,
-    );
+    const result = handleProseComponent(node, "h1", mockTransformRecursively);
 
     // 결과 검증
-    expect(result).toEqual({
+    expect(result.ast).toEqual({
       type: "heading",
       depth: 1,
       children: [{ type: "text", value: "제목 텍스트" }],
@@ -34,10 +31,11 @@ describe("handleProseComponent", () => {
   });
 
   it("h2부터 h6까지 요소를 적절한 depth의 heading으로 변환한다", () => {
-    // 목 transformJsxComponentsFn 함수 생성
-    const mockTransformJsxComponentsFn = (_ast: Node) => {
-      // 테스트에서는 아무 작업도 하지 않음
-    };
+    // Mock transformRecursively 함수 생성
+    const mockTransformRecursively = vi.fn((ast: Node) => ({
+      ast,
+      unhandledTags: new Set<string>(),
+    }));
 
     // h2부터 h6까지 테스트
     for (let i = 2; i <= 6; i++) {
@@ -52,11 +50,11 @@ describe("handleProseComponent", () => {
       const result = handleProseComponent(
         node,
         `h${i}`,
-        mockTransformJsxComponentsFn,
+        mockTransformRecursively,
       );
 
       // 결과 검증
-      expect(result).toEqual({
+      expect(result.ast).toEqual({
         type: "heading",
         depth: i,
         children: [{ type: "text", value: `제목 레벨 ${i}` }],
@@ -72,20 +70,17 @@ describe("handleProseComponent", () => {
       children: [{ type: "text", value: "단락 텍스트" }],
     } as unknown as MdxJsxFlowElement;
 
-    // 목 transformJsxComponentsFn 함수 생성
-    const mockTransformJsxComponentsFn = (_ast: Node) => {
-      // 테스트에서는 아무 작업도 하지 않음
-    };
+    // Mock transformRecursively 함수 생성
+    const mockTransformRecursively = vi.fn((ast: Node) => ({
+      ast,
+      unhandledTags: new Set<string>(),
+    }));
 
     // handleProseComponent 함수 실행
-    const result = handleProseComponent(
-      node,
-      "p",
-      mockTransformJsxComponentsFn,
-    );
+    const result = handleProseComponent(node, "p", mockTransformRecursively);
 
     // 결과 검증
-    expect(result).toEqual({
+    expect(result.ast).toEqual({
       type: "paragraph",
       children: [{ type: "text", value: "단락 텍스트" }],
     });
@@ -111,20 +106,17 @@ describe("handleProseComponent", () => {
       children: [{ type: "text", value: "링크 텍스트" }],
     } as unknown as MdxJsxFlowElement;
 
-    // 목 transformJsxComponentsFn 함수 생성
-    const mockTransformJsxComponentsFn = (_ast: Node) => {
-      // 테스트에서는 아무 작업도 하지 않음
-    };
+    // Mock transformRecursively 함수 생성
+    const mockTransformRecursively = vi.fn((ast: Node) => ({
+      ast,
+      unhandledTags: new Set<string>(),
+    }));
 
     // handleProseComponent 함수 실행
-    const result = handleProseComponent(
-      node,
-      "a",
-      mockTransformJsxComponentsFn,
-    );
+    const result = handleProseComponent(node, "a", mockTransformRecursively);
 
     // 결과 검증
-    expect(result).toEqual({
+    expect(result.ast).toEqual({
       type: "link",
       url: "https://example.com",
       title: "예제 링크",
@@ -147,20 +139,17 @@ describe("handleProseComponent", () => {
       children: [{ type: "text", value: "링크 텍스트" }],
     } as unknown as MdxJsxFlowElement;
 
-    // 목 transformJsxComponentsFn 함수 생성
-    const mockTransformJsxComponentsFn = (_ast: Node) => {
-      // 테스트에서는 아무 작업도 하지 않음
-    };
+    // Mock transformRecursively 함수 생성
+    const mockTransformRecursively = vi.fn((ast: Node) => ({
+      ast,
+      unhandledTags: new Set<string>(),
+    }));
 
     // handleProseComponent 함수 실행
-    const result = handleProseComponent(
-      node,
-      "a",
-      mockTransformJsxComponentsFn,
-    );
+    const result = handleProseComponent(node, "a", mockTransformRecursively);
 
     // 결과 검증
-    expect(result).toEqual({
+    expect(result.ast).toEqual({
       type: "link",
       url: "#",
       title: "예제 링크",
@@ -181,20 +170,21 @@ describe("handleProseComponent", () => {
       ],
     } as unknown as MdxJsxFlowElement;
 
-    // 목 transformJsxComponentsFn 함수 생성
-    const mockTransformJsxComponentsFn = (_ast: Node) => {
-      // 테스트에서는 아무 작업도 하지 않음
-    };
+    // Mock transformRecursively 함수 생성
+    const mockTransformRecursively = vi.fn((ast: Node) => ({
+      ast,
+      unhandledTags: new Set<string>(),
+    }));
 
     // handleProseComponent 함수 실행
     const result = handleProseComponent(
       node,
       "blockquote",
-      mockTransformJsxComponentsFn,
+      mockTransformRecursively,
     );
 
     // 결과 검증
-    expect(result).toEqual({
+    expect(result.ast).toEqual({
       type: "blockquote",
       children: [
         {
@@ -222,20 +212,17 @@ describe("handleProseComponent", () => {
       ],
     } as unknown as MdxJsxFlowElement;
 
-    // 목 transformJsxComponentsFn 함수 생성
-    const mockTransformJsxComponentsFn = (_ast: Node) => {
-      // 테스트에서는 아무 작업도 하지 않음
-    };
+    // Mock transformRecursively 함수 생성
+    const mockTransformRecursively = vi.fn((ast: Node) => ({
+      ast,
+      unhandledTags: new Set<string>(),
+    }));
 
     // handleProseComponent 함수 실행
-    const result = handleProseComponent(
-      node,
-      "ul",
-      mockTransformJsxComponentsFn,
-    );
+    const result = handleProseComponent(node, "ul", mockTransformRecursively);
 
     // 결과 검증
-    expect(result).toEqual({
+    expect(result.ast).toEqual({
       type: "list",
       ordered: false,
       spread: false,
@@ -260,20 +247,21 @@ describe("handleProseComponent", () => {
       children: [{ type: "text", value: "알 수 없는 요소" }],
     } as unknown as MdxJsxFlowElement;
 
-    // 목 transformJsxComponentsFn 함수 생성
-    const mockTransformJsxComponentsFn = (_ast: Node) => {
-      // 테스트에서는 아무 작업도 하지 않음
-    };
+    // Mock transformRecursively 함수 생성
+    const mockTransformRecursively = vi.fn((ast: Node) => ({
+      ast,
+      unhandledTags: new Set<string>(),
+    }));
 
     // handleProseComponent 함수 실행
     const result = handleProseComponent(
       node,
       "unknown",
-      mockTransformJsxComponentsFn,
+      mockTransformRecursively,
     );
 
     // 결과 검증
-    expect(result).toEqual({
+    expect(result.ast).toEqual({
       type: "paragraph",
       children: [{ type: "text", value: "알 수 없는 요소" }],
     });
@@ -286,22 +274,52 @@ describe("handleProseComponent", () => {
       name: "prose.p",
     } as unknown as MdxJsxFlowElement;
 
-    // 목 transformJsxComponentsFn 함수 생성
-    const mockTransformJsxComponentsFn = (_ast: Node) => {
-      // 테스트에서는 아무 작업도 하지 않음
-    };
+    // Mock transformRecursively 함수 생성
+    const mockTransformRecursively = vi.fn((ast: Node) => ({
+      ast,
+      unhandledTags: new Set<string>(),
+    }));
 
     // handleProseComponent 함수 실행
-    const result = handleProseComponent(
-      node,
-      "p",
-      mockTransformJsxComponentsFn,
-    );
+    const result = handleProseComponent(node, "p", mockTransformRecursively);
 
     // 결과 검증
-    expect(result).toEqual({
+    expect(result.ast).toEqual({
       type: "paragraph",
       children: [],
     });
+    expect(result.unhandledTags.size).toBe(0);
+  });
+
+  it("unhandledTags를 올바르게 수집한다", () => {
+    // 테스트용 Prose 노드 생성
+    const node = {
+      type: "mdxJsxFlowElement",
+      name: "prose.p",
+      children: [
+        { type: "text", value: "텍스트" },
+        { type: "mdxJsxFlowElement", name: "CustomComponent" },
+      ],
+    } as unknown as MdxJsxFlowElement;
+
+    // Mock transformRecursively 함수 생성
+    const mockTransformRecursively = vi
+      .fn()
+      .mockImplementationOnce((ast) => ({
+        ast,
+        unhandledTags: new Set<string>(),
+      }))
+      .mockImplementationOnce((ast) => ({
+        ast,
+        unhandledTags: new Set(["CustomComponent"]),
+      }));
+
+    // handleProseComponent 함수 실행
+    const result = handleProseComponent(node, "p", mockTransformRecursively);
+
+    // 결과 검증
+    expect(result.unhandledTags.size).toBe(1);
+    expect(result.unhandledTags.has("CustomComponent")).toBe(true);
+    expect(mockTransformRecursively).toHaveBeenCalledTimes(2);
   });
 });

--- a/scripts/mdx-to-markdown/jsx/prose.ts
+++ b/scripts/mdx-to-markdown/jsx/prose.ts
@@ -1,3 +1,4 @@
+import type { Blockquote, Heading, Link, List, Paragraph } from "mdast";
 import type { MdxJsxFlowElement, MdxJsxTextElement } from "mdast-util-mdx";
 import type { Node } from "unist";
 
@@ -7,93 +8,130 @@ import { extractMdxJsxAttributes } from "./common";
  * Prose 컴포넌트 처리 (prose.h1, prose.h2, prose.p 등)
  * @param node MDX JSX 노드
  * @param elementType prose 요소 타입 (h1, h2, p 등)
- * @param transformJsxComponentsFn 내부 JSX 컴포넌트를 재귀적으로 변환하는 함수
+ * @param transformRecursively 내부 JSX 컴포넌트를 재귀적으로 변환하는 함수
  * @returns 변환된 노드
  */
 export function handleProseComponent(
   node: MdxJsxFlowElement | MdxJsxTextElement,
   elementType: string,
-  transformJsxComponentsFn: (ast: Node) => void,
-) {
+  transformRecursively: (ast: Node) => {
+    ast: Node;
+    unhandledTags: Set<string>;
+  },
+): { ast: Node; unhandledTags: Set<string> } {
   // 자식 노드들을 재귀적으로 처리하기 위한 임시 노드
-  const childrenContent = {
-    type: "root",
-    children: node.children || [],
-  };
+  const results = (node.children || []).map(transformRecursively);
 
-  // 자식 노드들을 재귀적으로 처리
-  transformJsxComponentsFn(childrenContent);
+  const children = results.map((r) => r.ast);
+
+  const unhandledTags = results.reduce(
+    (acc, r) => acc.union(r.unhandledTags),
+    new Set<string>(),
+  );
 
   // prose 태그 내의 처리된 자식 노드들을 적절한 마크다운 요소로 변환
   switch (elementType) {
     case "h1":
       return {
-        type: "heading",
-        depth: 1,
-        children: childrenContent.children,
+        ast: {
+          type: "heading",
+          depth: 1,
+          children,
+        } as Heading,
+        unhandledTags,
       };
     case "h2":
       return {
-        type: "heading",
-        depth: 2,
-        children: childrenContent.children,
+        ast: {
+          type: "heading",
+          depth: 2,
+          children,
+        } as Heading,
+        unhandledTags,
       };
     case "h3":
       return {
-        type: "heading",
-        depth: 3,
-        children: childrenContent.children,
+        ast: {
+          type: "heading",
+          depth: 3,
+          children,
+        } as Heading,
+        unhandledTags,
       };
     case "h4":
       return {
-        type: "heading",
-        depth: 4,
-        children: childrenContent.children,
+        ast: {
+          type: "heading",
+          depth: 4,
+          children,
+        } as Heading,
+        unhandledTags,
       };
     case "h5":
       return {
-        type: "heading",
-        depth: 5,
-        children: childrenContent.children,
+        ast: {
+          type: "heading",
+          depth: 5,
+          children,
+        } as Heading,
+        unhandledTags,
       };
     case "h6":
       return {
-        type: "heading",
-        depth: 6,
-        children: childrenContent.children,
+        ast: {
+          type: "heading",
+          depth: 6,
+          children,
+        } as Heading,
+        unhandledTags,
       };
     case "p":
       return {
-        type: "paragraph",
-        children: childrenContent.children,
+        ast: {
+          type: "paragraph",
+          children,
+        } as Paragraph,
+        unhandledTags,
       };
     case "a": {
       // 링크 속성 추출
       const props = extractMdxJsxAttributes(node);
       return {
-        type: "link",
-        url: props.href || "#",
-        title: props.title,
-        children: childrenContent.children,
+        ast: {
+          type: "link",
+          url: props.href || "#",
+          title: props.title,
+          children,
+        } as Link,
+        unhandledTags,
       };
     }
     case "blockquote":
       return {
-        type: "blockquote",
-        children: childrenContent.children,
+        ast: {
+          type: "blockquote",
+          children,
+        } as Blockquote,
+        unhandledTags,
       };
     case "ul":
       return {
-        type: "list",
-        ordered: false,
-        spread: false,
-        children: childrenContent.children,
+        ast: {
+          type: "list",
+          ordered: false,
+          spread: false,
+          children,
+        } as List,
+        unhandledTags,
       };
     default:
       // 기본적으로 자식 노드만 유지하는 paragraph로 변환
       return {
-        type: "paragraph",
-        children: childrenContent.children,
+        ast: {
+          type: "paragraph",
+          children,
+        } as Paragraph,
+        unhandledTags,
       };
   }
 }

--- a/scripts/mdx-to-markdown/jsx/replaceToHtml.test.ts
+++ b/scripts/mdx-to-markdown/jsx/replaceToHtml.test.ts
@@ -1,0 +1,191 @@
+import type { Html, Root } from "mdast";
+import type { MdxJsxFlowElement, MdxJsxTextElement } from "mdast-util-mdx";
+import type { Node } from "unist";
+import { describe, expect, it, vi } from "vitest";
+
+import { replaceToHtml } from "./replaceToHtml";
+
+describe("replaceToHtml", () => {
+  it("should convert a self-closing JSX element to HTML", () => {
+    const jsxNode = {
+      type: "mdxJsxTextElement",
+      name: "hr",
+      attributes: [],
+      children: [],
+    } as MdxJsxTextElement;
+
+    const mockTransformRecursively = vi.fn((ast: Node) => ({
+      ast,
+      unhandledTags: new Set<string>(),
+    }));
+
+    const result = replaceToHtml(jsxNode, mockTransformRecursively);
+
+    expect(result.ast).toEqual({
+      type: "html",
+      value: "<hr />",
+    } as Html);
+    expect(result.unhandledTags.size).toBe(0);
+    expect(mockTransformRecursively).not.toHaveBeenCalled();
+  });
+
+  it("should convert a JSX element with attributes to HTML", () => {
+    const jsxNode = {
+      type: "mdxJsxFlowElement",
+      name: "div",
+      attributes: [
+        {
+          type: "mdxJsxAttribute",
+          name: "class",
+          value: "container",
+        },
+        {
+          type: "mdxJsxAttribute",
+          name: "id",
+          value: "main-content",
+        },
+        {
+          type: "mdxJsxAttribute",
+          name: "disabled",
+          value: null,
+        },
+      ],
+      children: [],
+    } as MdxJsxFlowElement;
+
+    const mockTransformRecursively = vi.fn((ast: Node) => ({
+      ast,
+      unhandledTags: new Set<string>(),
+    }));
+
+    const result = replaceToHtml(jsxNode, mockTransformRecursively);
+
+    expect(result.ast).toEqual({
+      type: "html",
+      value: '<div class="container" id="main-content" disabled />',
+    } as Html);
+    expect(result.unhandledTags.size).toBe(0);
+    expect(mockTransformRecursively).not.toHaveBeenCalled();
+  });
+
+  it("should handle JSX element with children", () => {
+    const jsxNode = {
+      type: "mdxJsxFlowElement",
+      name: "div",
+      attributes: [
+        {
+          type: "mdxJsxAttribute",
+          name: "class",
+          value: "container",
+        },
+      ],
+      children: [
+        {
+          type: "paragraph",
+          children: [
+            {
+              type: "text",
+              value: "Hello world",
+            },
+          ],
+        },
+      ],
+    } as MdxJsxFlowElement;
+
+    // Mock transformRecursively function
+    const mockTransformRecursively = vi.fn((ast: Node) => ({
+      ast,
+      unhandledTags: new Set<string>(),
+    }));
+
+    const result = replaceToHtml(jsxNode, mockTransformRecursively);
+
+    expect(result.ast).toEqual({
+      type: "root",
+      children: [
+        {
+          type: "html",
+          value: '<div class="container">',
+        },
+        {
+          type: "paragraph",
+          children: [
+            {
+              type: "text",
+              value: "Hello world",
+            },
+          ],
+        },
+        {
+          type: "html",
+          value: "</div>",
+        },
+      ],
+    } as Root);
+    expect(result.unhandledTags.size).toBe(0);
+    expect(mockTransformRecursively).toHaveBeenCalledTimes(1);
+  });
+
+  it("should handle quotes in attribute values", () => {
+    const jsxNode = {
+      type: "mdxJsxFlowElement",
+      name: "div",
+      attributes: [
+        {
+          type: "mdxJsxAttribute",
+          name: "title",
+          value: 'Example with "quotes"',
+        },
+      ],
+      children: [],
+    } as MdxJsxFlowElement;
+
+    const mockTransformRecursively = vi.fn((ast: Node) => ({
+      ast,
+      unhandledTags: new Set<string>(),
+    }));
+
+    const result = replaceToHtml(jsxNode, mockTransformRecursively);
+
+    expect(result.ast).toEqual({
+      type: "html",
+      value: '<div title="Example with &quot;quotes&quot;" />',
+    } as Html);
+    expect(result.unhandledTags.size).toBe(0);
+  });
+
+  it("should collect unhandled tags from children", () => {
+    const jsxNode = {
+      type: "mdxJsxFlowElement",
+      name: "div",
+      attributes: [],
+      children: [
+        { type: "text", value: "Some text" },
+        {
+          type: "mdxJsxFlowElement",
+          name: "CustomComponent",
+          attributes: [],
+          children: [],
+        },
+      ],
+    } as MdxJsxFlowElement;
+
+    // Mock transformRecursively function that returns unhandled tags
+    const mockTransformRecursively = vi
+      .fn()
+      .mockImplementationOnce((ast: Node) => ({
+        ast,
+        unhandledTags: new Set<string>(),
+      }))
+      .mockImplementationOnce((ast: Node) => ({
+        ast,
+        unhandledTags: new Set(["CustomComponent"]),
+      }));
+
+    const result = replaceToHtml(jsxNode, mockTransformRecursively);
+
+    expect(result.unhandledTags.size).toBe(1);
+    expect(result.unhandledTags.has("CustomComponent")).toBe(true);
+    expect(mockTransformRecursively).toHaveBeenCalledTimes(2);
+  });
+});

--- a/scripts/mdx-to-markdown/jsx/replaceToHtml.ts
+++ b/scripts/mdx-to-markdown/jsx/replaceToHtml.ts
@@ -1,0 +1,74 @@
+import type { Html, Root } from "mdast";
+import type { MdxJsxFlowElement, MdxJsxTextElement } from "mdast-util-mdx";
+import { extractMdxJsxAttributes } from "scripts/mdx-to-markdown/jsx/common";
+import type { Node } from "unist";
+
+/**
+ * JSX 엘리먼트를 HTML 노드로 변환하는 함수
+ *
+ * @param node 변환할 MDX JSX 노드
+ * @param transformRecursively 자식 노드들을 재귀적으로 변환하는 함수
+ * @returns HTML 노드
+ */
+export function replaceToHtml(
+  node: MdxJsxFlowElement | MdxJsxTextElement,
+  transformRecursively: (innerAst: Node) => {
+    ast: Node;
+    unhandledTags: Set<string>;
+  },
+): { ast: Node; unhandledTags: Set<string> } {
+  // 속성 추출
+  const attrs = extractMdxJsxAttributes(node);
+  const attrsString = Object.entries(attrs)
+    .map(([key, value]) => {
+      if (value === true) {
+        return key;
+      }
+      return `${key}="${String(value).replace(/"/g, "&quot;")}"`;
+    })
+    .join(" ");
+
+  // 속성이 있는 경우 공백 추가
+  const attrsPart = attrsString ? ` ${attrsString}` : "";
+
+  // 자식 노드가 있는지 확인
+  const hasChildren = node.children && node.children.length > 0;
+
+  // 자식 노드가 없는 경우 self-closing 태그 반환
+  if (!hasChildren) {
+    return {
+      ast: {
+        type: "html",
+        value: `<${node.name ?? "unknown"}${attrsPart} />`,
+      } satisfies Html as Html,
+      unhandledTags: new Set<string>(),
+    };
+  }
+
+  // 자식 노드 재귀적으로 변환
+  const results = node.children.map(transformRecursively);
+  const newChildren = results.map((r) => r.ast);
+  const unhandledTags = results.reduce(
+    (acc, r) => acc.union(r.unhandledTags),
+    new Set<string>(),
+  );
+
+  // 열고 닫는 태그와 그 사이에 자식 노드 배치
+  return {
+    ast: {
+      type: "root",
+      children: [
+        {
+          type: "html",
+          value: `<${node.name}${attrsPart}>`,
+        },
+        ...newChildren,
+        {
+          type: "html",
+          value: `</${node.name}>`,
+        },
+      ],
+    } as Root,
+    unhandledTags,
+  };
+}

--- a/scripts/mdx-to-markdown/jsx/tabs.test.ts
+++ b/scripts/mdx-to-markdown/jsx/tabs.test.ts
@@ -1,6 +1,6 @@
 import type { MdxJsxFlowElement } from "mdast-util-mdx";
 import type { Node } from "unist";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { handleTabComponent, handleTabsComponent } from "./tabs";
 
@@ -19,16 +19,17 @@ describe("handleTabsComponent", () => {
       ],
     } as MdxJsxFlowElement;
 
-    // 목 transformJsxComponentsFn 함수 생성
-    const mockTransformJsxComponentsFn = (_ast: Node) => {
-      // 테스트에서는 아무 작업도 하지 않음
-    };
+    // Mock transformRecursively 함수 생성
+    const mockTransformRecursively = vi.fn((ast: Node) => ({
+      ast,
+      unhandledTags: new Set<string>(),
+    }));
 
     // handleTabsComponent 함수 실행
-    const result = handleTabsComponent(node, mockTransformJsxComponentsFn);
+    const result = handleTabsComponent(node, mockTransformRecursively);
 
     // 결과 검증
-    expect(result).toEqual({
+    expect(result.ast).toEqual({
       type: "root",
       children: [
         { type: "html", value: '<div class="tabs-container">' },
@@ -39,6 +40,7 @@ describe("handleTabsComponent", () => {
         { type: "html", value: "</div>" },
       ],
     });
+    expect(result.unhandledTags.size).toBe(0);
   });
 
   it("자식 노드가 없는 Tabs 컴포넌트도 정상적으로 처리한다", () => {
@@ -50,22 +52,24 @@ describe("handleTabsComponent", () => {
       children: [],
     } as MdxJsxFlowElement;
 
-    // 목 transformJsxComponentsFn 함수 생성
-    const mockTransformJsxComponentsFn = (_ast: Node) => {
-      // 테스트에서는 아무 작업도 하지 않음
-    };
+    // Mock transformRecursively 함수 생성
+    const mockTransformRecursively = vi.fn((ast: Node) => ({
+      ast,
+      unhandledTags: new Set<string>(),
+    }));
 
     // handleTabsComponent 함수 실행
-    const result = handleTabsComponent(node, mockTransformJsxComponentsFn);
+    const result = handleTabsComponent(node, mockTransformRecursively);
 
     // 결과 검증
-    expect(result).toEqual({
+    expect(result.ast).toEqual({
       type: "root",
       children: [
         { type: "html", value: '<div class="tabs-container">' },
         { type: "html", value: "</div>" },
       ],
     });
+    expect(result.unhandledTags.size).toBe(0);
   });
 });
 
@@ -84,23 +88,26 @@ describe("handleTabComponent", () => {
       ],
     } as MdxJsxFlowElement;
 
-    // 목 transformJsxComponentsFn 함수 생성
-    const mockTransformJsxComponentsFn = (_ast: Node) => {
-      // 테스트에서는 아무 작업도 하지 않음
-    };
+    // 속성 추가
+    node.attributes = [
+      {
+        type: "mdxJsxAttribute",
+        name: "title",
+        value: "테스트 탭",
+      },
+    ];
 
-    // props 객체 생성
-    const props = { title: "테스트 탭" };
+    // Mock transformRecursively 함수 생성
+    const mockTransformRecursively = vi.fn((ast: Node) => ({
+      ast,
+      unhandledTags: new Set<string>(),
+    }));
 
     // handleTabComponent 함수 실행
-    const result = handleTabComponent(
-      node,
-      props,
-      mockTransformJsxComponentsFn,
-    );
+    const result = handleTabComponent(node, mockTransformRecursively);
 
     // 결과 검증
-    expect(result).toEqual({
+    expect(result.ast).toEqual({
       type: "root",
       children: [
         {
@@ -114,6 +121,7 @@ describe("handleTabComponent", () => {
         { type: "html", value: "</div>" },
       ],
     });
+    expect(result.unhandledTags.size).toBe(0);
   });
 
   it("탭 제목이 없는 경우 기본 제목을 사용한다", () => {
@@ -130,23 +138,20 @@ describe("handleTabComponent", () => {
       ],
     } as MdxJsxFlowElement;
 
-    // 목 transformJsxComponentsFn 함수 생성
-    const mockTransformJsxComponentsFn = (_ast: Node) => {
-      // 테스트에서는 아무 작업도 하지 않음
-    };
+    // 속성은 추가하지 않음 (빈 title을 테스트)
+    node.attributes = [];
 
-    // 빈 props 객체 생성
-    const props = {};
+    // Mock transformRecursively 함수 생성
+    const mockTransformRecursively = vi.fn((ast: Node) => ({
+      ast,
+      unhandledTags: new Set<string>(),
+    }));
 
     // handleTabComponent 함수 실행
-    const result = handleTabComponent(
-      node,
-      props,
-      mockTransformJsxComponentsFn,
-    );
+    const result = handleTabComponent(node, mockTransformRecursively);
 
     // 결과 검증
-    expect(result).toEqual({
+    expect(result.ast).toEqual({
       type: "root",
       children: [
         { type: "html", value: '<div class="tabs-content" data-title="탭">' },
@@ -157,6 +162,7 @@ describe("handleTabComponent", () => {
         { type: "html", value: "</div>" },
       ],
     });
+    expect(result.unhandledTags.size).toBe(0);
   });
 
   it("자식 노드가 없는 Tab도 정상적으로 처리한다", () => {
@@ -168,23 +174,26 @@ describe("handleTabComponent", () => {
       children: [],
     } as MdxJsxFlowElement;
 
-    // 목 transformJsxComponentsFn 함수 생성
-    const mockTransformJsxComponentsFn = (_ast: Node) => {
-      // 테스트에서는 아무 작업도 하지 않음
-    };
+    // 속성 추가
+    node.attributes = [
+      {
+        type: "mdxJsxAttribute",
+        name: "title",
+        value: "빈 탭",
+      },
+    ];
 
-    // props 객체 생성
-    const props = { title: "빈 탭" };
+    // Mock transformRecursively 함수 생성
+    const mockTransformRecursively = vi.fn((ast: Node) => ({
+      ast,
+      unhandledTags: new Set<string>(),
+    }));
 
     // handleTabComponent 함수 실행
-    const result = handleTabComponent(
-      node,
-      props,
-      mockTransformJsxComponentsFn,
-    );
+    const result = handleTabComponent(node, mockTransformRecursively);
 
     // 결과 검증
-    expect(result).toEqual({
+    expect(result.ast).toEqual({
       type: "root",
       children: [
         {
@@ -194,5 +203,6 @@ describe("handleTabComponent", () => {
         { type: "html", value: "</div>" },
       ],
     });
+    expect(result.unhandledTags.size).toBe(0);
   });
 });

--- a/scripts/mdx-to-markdown/jsx/versionGate.test.ts
+++ b/scripts/mdx-to-markdown/jsx/versionGate.test.ts
@@ -11,6 +11,7 @@ describe("handleVersionGateComponent", () => {
     const node = {
       type: "mdxJsxFlowElement",
       name: "VersionGate",
+      attributes: [{ type: "mdxJsxAttribute", name: "v", value: "v2" }],
       children: [
         {
           type: "paragraph",
@@ -19,20 +20,19 @@ describe("handleVersionGateComponent", () => {
       ],
     } as unknown as MdxJsxFlowElement;
 
-    // 목 함수 생성 (transformJsxComponentsFn)
+    // 목 함수 생성 (transformRecursively)
     const mockTransformFn = (_ast: Node) => {
-      // 테스트에서는 아무 작업도 하지 않음
+      return {
+        ast: _ast,
+        unhandledTags: new Set<string>(),
+      };
     };
 
     // handleVersionGateComponent 함수 실행
-    const result = handleVersionGateComponent(
-      node,
-      { v: "v2" },
-      mockTransformFn,
-    );
+    const result = handleVersionGateComponent(node, mockTransformFn);
 
     // 결과 검증
-    expect(result).toEqual({
+    expect(result.ast).toEqual({
       type: "root",
       children: [
         {
@@ -66,6 +66,7 @@ describe("handleVersionGateComponent", () => {
     const node = {
       type: "mdxJsxFlowElement",
       name: "VersionGate",
+      attributes: [],
       children: [
         {
           type: "paragraph",
@@ -74,16 +75,19 @@ describe("handleVersionGateComponent", () => {
       ],
     } as MdxJsxFlowElement;
 
-    // 목 함수 생성 (transformJsxComponentsFn)
+    // 목 함수 생성 (transformRecursively)
     const mockTransformFn = (_ast: Node) => {
-      // 테스트에서는 아무 작업도 하지 않음
+      return {
+        ast: _ast,
+        unhandledTags: new Set<string>(),
+      };
     };
 
     // handleVersionGateComponent 함수 실행 (v 속성 없음)
-    const result = handleVersionGateComponent(node, {}, mockTransformFn);
+    const result = handleVersionGateComponent(node, mockTransformFn);
 
     // 결과 검증
-    expect(result).toEqual({
+    expect(result.ast).toEqual({
       type: "root",
       children: [
         {
@@ -113,9 +117,12 @@ describe("handleVersionGateComponent", () => {
       ],
     };
 
-    // 목 함수 생성 (transformJsxComponentsFn)
+    // 목 함수 생성 (transformRecursively)
     const mockTransformFn = (_ast: Node) => {
-      // 테스트에서는 아무 작업도 하지 않음
+      return {
+        ast: _ast,
+        unhandledTags: new Set<string>(),
+      };
     };
 
     // AST 변환 함수 (transformJsxComponents 함수의 일부 로직)
@@ -124,30 +131,12 @@ describe("handleVersionGateComponent", () => {
       "mdxJsxFlowElement",
       (node: MdxJsxFlowElement, index, parent: Parent) => {
         if (node.name === "VersionGate" && index !== undefined) {
-          // 속성 추출
-          const props: Record<string, unknown> = {};
-          if (node.attributes && Array.isArray(node.attributes)) {
-            for (const attr of node.attributes) {
-              if (
-                "name" in attr &&
-                typeof attr.name === "string" &&
-                attr.value !== undefined
-              ) {
-                props[attr.name] = attr.value;
-              }
-            }
-          }
-
           // VersionGate 컴포넌트 처리
-          const replacementNode = handleVersionGateComponent(
-            node,
-            props,
-            mockTransformFn,
-          );
+          const result = handleVersionGateComponent(node, mockTransformFn);
 
           // 노드 교체
-          if (replacementNode && parent && Array.isArray(parent.children)) {
-            parent.children[index] = replacementNode;
+          if (result.ast && parent && Array.isArray(parent.children)) {
+            parent.children[index] = result.ast;
           }
         }
       },

--- a/scripts/mdx-to-markdown/jsx/youtube.test.ts
+++ b/scripts/mdx-to-markdown/jsx/youtube.test.ts
@@ -1,17 +1,23 @@
+import type { MdxJsxFlowElement } from "mdast-util-mdx";
 import { describe, expect, it } from "vitest";
 
 import { handleYoutubeComponent } from "./youtube";
 
 describe("handleYoutubeComponent", () => {
   it("videoId와 caption이 있는 경우 caption을 텍스트로 하는 YouTube 링크를 생성한다", () => {
-    // props 설정
-    const props = {
-      videoId: "test123",
-      caption: "테스트 영상",
-    };
+    // 테스트용 노드 생성
+    const node = {
+      type: "mdxJsxFlowElement",
+      name: "Youtube",
+      attributes: [
+        { type: "mdxJsxAttribute", name: "videoId", value: "test123" },
+        { type: "mdxJsxAttribute", name: "caption", value: "테스트 영상" },
+      ],
+      children: [],
+    } as MdxJsxFlowElement;
 
     // handleYoutubeComponent 함수 실행
-    const result = handleYoutubeComponent(props);
+    const result = handleYoutubeComponent(node);
 
     // 결과 검증
     expect(result).toEqual({
@@ -27,13 +33,18 @@ describe("handleYoutubeComponent", () => {
   });
 
   it("caption이 없는 경우 기본 텍스트로 YouTube 링크를 생성한다", () => {
-    // props 설정 (caption 없음)
-    const props = {
-      videoId: "test456",
-    };
+    // 테스트용 노드 생성 (caption 없음)
+    const node = {
+      type: "mdxJsxFlowElement",
+      name: "Youtube",
+      attributes: [
+        { type: "mdxJsxAttribute", name: "videoId", value: "test456" },
+      ],
+      children: [],
+    } as MdxJsxFlowElement;
 
     // handleYoutubeComponent 함수 실행
-    const result = handleYoutubeComponent(props);
+    const result = handleYoutubeComponent(node);
 
     // 결과 검증
     expect(result).toEqual({

--- a/scripts/mdx-to-markdown/jsx/youtube.ts
+++ b/scripts/mdx-to-markdown/jsx/youtube.ts
@@ -1,11 +1,17 @@
+import type { MdxJsxFlowElement, MdxJsxTextElement } from "mdast-util-mdx";
+
+import { extractMdxJsxAttributes } from "./common";
 /**
  * Youtube 컴포넌트 처리
  * @param node MDX JSX 노드
  * @param props 컴포넌트 속성
  * @returns 변환된 마크다운 노드
  */
-export function handleYoutubeComponent(props: Record<string, unknown>) {
+export function handleYoutubeComponent(
+  node: MdxJsxFlowElement | MdxJsxTextElement,
+) {
   // videoId와 caption 추출
+  const props = extractMdxJsxAttributes(node);
   const videoId = typeof props.videoId === "string" ? props.videoId : "";
   const caption =
     typeof props.caption === "string" ? props.caption : "YouTube 비디오";


### PR DESCRIPTION
- `scripts/mdx-to-markdown/jsx/` 내부 로직에서 더 이상 `unist-util-visit`을 사용하지 않고 자체적인 재귀 함수로 동작하도록 리팩토링했습니다.
- 이제 `pnpm docs-for-llms` `pnpm llms-txt` 실행 시 변환이 고려되지 않은 태그들의 목록이 출력됩니다.