### PR TITLE
마크다운 변환 추가 지원

### DIFF
--- a/scripts/docs-for-llms/generator.ts
+++ b/scripts/docs-for-llms/generator.ts
@@ -95,7 +95,11 @@ export function transformAllMdxToAst(
     `${Object.keys(transformedAstMap).length}개의 MDX 파일 AST 변환이 완료되었습니다.`,
   );
 
-  console.log(`처리되지 않은 태그: ${Array.from(allUnhandledTags).join(", ")}`);
+  if (allUnhandledTags.size > 0) {
+    console.log(
+      `처리되지 않은 태그: ${Array.from(allUnhandledTags).join(", ")}`,
+    );
+  }
   return transformedAstMap;
 }
 

--- a/scripts/llms-txt/generator.ts
+++ b/scripts/llms-txt/generator.ts
@@ -90,7 +90,11 @@ export function transformAllMdxToAst(
     `${Object.keys(transformedAstMap).length}개의 MDX 파일 AST 변환이 완료되었습니다.`,
   );
 
-  console.log(`처리되지 않은 태그: ${Array.from(allUnhandledTags).join(", ")}`);
+  if (allUnhandledTags.size > 0) {
+    console.log(
+      `처리되지 않은 태그: ${Array.from(allUnhandledTags).join(", ")}`,
+    );
+  }
   return transformedAstMap;
 }
 

--- a/scripts/mdx-to-markdown/README.md
+++ b/scripts/mdx-to-markdown/README.md
@@ -11,33 +11,6 @@
   - `common.ts`: 공통 유틸리티 함수들
   - `figure.ts`, `hint.ts`, `tabs.ts` 등: 각 컴포넌트별 변환 로직
 
-## MDX-to-Markdown 변환 로직
-
-### transformAstForMarkdown
-
-- MDX AST를 마크다운용 AST로 변환하는 핵심 함수
-- 다음 처리를 순차적으로 수행:
-  1. JSX 컴포넌트를 마크다운으로 변환 (transformJsxComponents)
-  2. 임포트 구문 제거 (removeImports)
-  3. YAML 노드 제거 (removeYamlNodes)
-  4. 남은 JSX 노드 단순화 (simplifyJsxNodes)
-  5. MDX 표현식 노드 처리 (handleRemainingMdxFlowExpressions)
-
-### astToMarkdownString
-
-- 변환된 AST를 마크다운 문자열로 변환
-- 프론트매터를 YAML 형식으로 추가 (thumbnail 필드 제외)
-- GitHub Flavored Markdown 형식으로 출력 (remarkGfm 사용)
-- 마크다운 형식 설정 (bullet, 강조, 들여쓰기, 테이블 등)
-
-### transformJsxComponents
-
-- 모든 JSX 컴포넌트를 마크다운으로 변환하는 메인 함수
-- AST를 순회하며 `mdxJsxFlowElement` 및 `mdxJsxTextElement` 타입의 노드를 처리
-- 컴포넌트 이름에 따라 적절한 처리 함수로 라우팅
-- 각 컴포넌트별 변환 로직은 별도 모듈에 구현 (figure.ts, hint.ts 등)
-- 지원하지 않는 컴포넌트는 자식 노드만 유지하거나 제거
-
 ## JSX 컴포넌트별 변환 동작
 
 다음은 각 JSX 컴포넌트의 마크다운 변환 방식입니다:
@@ -123,6 +96,10 @@
     ```markdown
     **상태 코드** - 설명
     ```
+  - SwaggerDescription: API 설명을 마크다운 형식으로 변환
+    ```markdown
+    _API 설명 텍스트_
+    ```
 
 - **code 요소**: 인라인 코드로 변환
 
@@ -131,6 +108,7 @@
   ```
 
 - **prose 태그**: 해당하는 마크다운 구문으로 변환
+
   - prose.h1 → # 제목 (heading 깊이 1)
   - prose.h2 → ## 제목 (heading 깊이 2)
   - prose.h3 → ### 제목 (heading 깊이 3)
@@ -139,18 +117,71 @@
   - prose.ul → 순서 없는 목록 (unordered list)
   - prose.a → 링크 (link)
 
-## 지원하는 SolidJS 커스텀 컴포넌트
+- **File**: 파일 다운로드 링크를 텍스트로 변환
 
-다음 커스텀 컴포넌트들이 마크다운으로 적절히 변환됩니다:
+  ```markdown
+  (파일: 캡션 텍스트)
+  ```
 
-- `<Figure>`: 이미지와 캡션으로 변환
-- `<Hint>`: 이모지와 함께 블록 인용구로 변환 (타입에 따라 다른 이모지 사용)
-- `<Tabs>`: 각 탭의 제목과 내용을 순차적으로 나열
-- `<Details>`: 제목과 내용을 마크다운 형식으로 변환
-- `<VersionGate>`: 버전 정보와 함께 내용을 마크다운으로 표시
-- `<ContentRef>`: 외부 문서에 대한 링크로 변환
-- `<Youtube>`: 유튜브 링크로 변환
-- `<ApiLink>`: API 문서 링크로 변환
-- `<EasyGuideLink>`: 처리 생략
-- `<Parameter>`: API 파라미터 정보를 마크다운 형식으로 변환
-- Swagger 관련 컴포넌트: 인라인 코드 또는 코드 블록으로 변환
+  또는 캡션이 없는 경우:
+
+  ```markdown
+  (파일 다운로드 링크)
+  ```
+
+- **img 태그**: 이미지 태그를 마크다운 링크로 변환
+
+  ```markdown
+  [이미지 설명](https://developers.portone.io/이미지/경로)
+  ```
+
+- **A 컴포넌트**: 링크를 HTML a 태그로 변환, 상대 경로에 자동으로 기본 URL 추가
+
+  ```html
+  <a href="https://developers.portone.io/경로" ...속성>링크 내용</a>
+  ```
+
+- **SDKParameter**: SDK 파라미터 정의를 마크다운 형식으로 변환
+
+  ```markdown
+  - 파라미터명?: 타입명
+    [definition link](https://developers.portone.io/schema/browser-sdk.yml#/경로)
+  ```
+
+- **SDKChangelog**: SDK 변경 로그 링크로 변환
+
+  ```markdown
+  [SDK Changelog](https://developers.portone.io/sdk/ko/v2-sdk/changelog)
+  ```
+
+- **Parameter.TypeDef**: 파라미터 타입 정의를 마크다운 형식으로 변환
+
+  ```markdown
+  - 파라미터명?: 타입
+
+    파라미터 설명
+
+    - 부가 설명
+  ```
+
+- **Condition**: 조건부 콘텐츠를 HTML 주석으로 변환
+
+  ```html
+  <!-- CONDITIONAL CONTENT if 조건 START -->
+  조건부 콘텐츠
+  <!-- CONDITIONAL CONTENT if 조건 END -->
+  ```
+
+- **기본 HTML 태그**: 일반적인 HTML 태그들을 그대로 HTML로 변환
+
+  - br, table, thead, tbody, th, tr, td, ul, li, p, span, i, strong, a 등
+
+  ```html
+  <태그명 속성="값">내용</태그명>
+  ```
+
+- **래핑 요소**: 단순히 내용을 래핑하는 컴포넌트는 내용만 추출
+
+  - Parameter, Parameter.Details, EasyGuideLink, center, div, figure, figcaption 등
+
+- **임포트된 MDX 파일**: MDX 파일을 임포트해서 컴포넌트로 사용한 경우, 해당 MDX 파일의 내용으로 대체

--- a/scripts/mdx-to-markdown/jsx/a.test.ts
+++ b/scripts/mdx-to-markdown/jsx/a.test.ts
@@ -1,0 +1,134 @@
+import { strict as assert } from "assert";
+import type { Root } from "mdast";
+import type { MdxJsxFlowElement } from "mdast-util-mdx";
+import { describe, it } from "vitest";
+
+import { handleAComponent } from "./a";
+
+describe("handleAComponent", () => {
+  // Helper function to create a node AST with children for testing
+  function createNodeWithChildren(
+    href: string,
+    className?: string,
+  ): MdxJsxFlowElement {
+    const attributes = [
+      {
+        type: "mdxJsxAttribute" as const,
+        name: "href",
+        value: href,
+      },
+    ];
+
+    if (className) {
+      attributes.push({
+        type: "mdxJsxAttribute" as const,
+        name: "class",
+        value: className,
+      });
+    }
+
+    return {
+      type: "mdxJsxFlowElement",
+      name: "A",
+      attributes,
+      children: [
+        {
+          type: "paragraph",
+          children: [
+            {
+              type: "text",
+              value: "Link Text",
+            },
+          ],
+        },
+      ],
+    };
+  }
+
+  // Mock transform function that returns the node unchanged
+  const mockTransform = (node: any) => ({
+    ast: node,
+    unhandledTags: new Set<string>(),
+  });
+
+  it("should handle relative href without leading slash", () => {
+    const node = createNodeWithChildren("api/rest-v1");
+    const result = handleAComponent(node, mockTransform);
+    const htmlOpening = (result.ast as Root).children[0] as any;
+
+    assert.equal(htmlOpening.type, "html");
+    assert.ok(
+      htmlOpening.value.includes('href="/api/rest-v1"'),
+      `Expected href to be prefixed with /, but got: ${htmlOpening.value}`,
+    );
+  });
+
+  it("should add domain to absolute href", () => {
+    const node = createNodeWithChildren("/api/rest-v2");
+    const result = handleAComponent(node, mockTransform);
+    const htmlOpening = (result.ast as Root).children[0] as any;
+
+    assert.equal(htmlOpening.type, "html");
+    assert.ok(
+      htmlOpening.value.includes(
+        'href="https://developers.portone.io/api/rest-v2"',
+      ),
+      `Expected href to include domain, but got: ${htmlOpening.value}`,
+    );
+  });
+
+  it("should not add domain if it's already included", () => {
+    const alreadyCompleteUrl = "/developers.portone.io/api/rest-v1";
+    const node = createNodeWithChildren(alreadyCompleteUrl);
+    const result = handleAComponent(node, mockTransform);
+    const htmlOpening = (result.ast as Root).children[0] as any;
+
+    assert.equal(htmlOpening.type, "html");
+    assert.ok(
+      htmlOpening.value.includes(`href="${alreadyCompleteUrl}"`),
+      `Expected href to remain unchanged, but got: ${htmlOpening.value}`,
+    );
+  });
+
+  it("should preserve external URLs", () => {
+    const externalUrl = "https://example.com/path";
+    const node = createNodeWithChildren(externalUrl);
+    const result = handleAComponent(node, mockTransform);
+    const htmlOpening = (result.ast as Root).children[0] as any;
+
+    assert.equal(htmlOpening.type, "html");
+    assert.ok(
+      htmlOpening.value.includes(`href="${externalUrl}"`),
+      `Expected href to remain unchanged, but got: ${htmlOpening.value}`,
+    );
+  });
+
+  it("should preserve mailto: URLs", () => {
+    const mailtoUrl = "mailto:test@example.com";
+    const node = createNodeWithChildren(mailtoUrl);
+    const result = handleAComponent(node, mockTransform);
+    const htmlOpening = (result.ast as Root).children[0] as any;
+
+    assert.equal(htmlOpening.type, "html");
+    assert.ok(
+      htmlOpening.value.includes(`href="${mailtoUrl}"`),
+      `Expected href to remain unchanged, but got: ${htmlOpening.value}`,
+    );
+  });
+
+  it("should preserve additional attributes", () => {
+    const node = createNodeWithChildren("/path", "custom-class");
+    const result = handleAComponent(node, mockTransform);
+    const htmlOpening = (result.ast as Root).children[0] as any;
+
+    assert.equal(htmlOpening.type, "html");
+    assert.ok(
+      htmlOpening.value.includes('class="custom-class"'),
+      `Expected class attribute to be preserved, but got: ${htmlOpening.value}`,
+    );
+    assert.ok(
+      htmlOpening.value.includes('href="https://developers.portone.io/path"'),
+      `Expected href to include domain, but got: ${htmlOpening.value}`,
+    );
+  });
+});

--- a/scripts/mdx-to-markdown/jsx/a.ts
+++ b/scripts/mdx-to-markdown/jsx/a.ts
@@ -1,0 +1,102 @@
+import type { Html, Root } from "mdast";
+import type { MdxJsxFlowElement, MdxJsxTextElement } from "mdast-util-mdx";
+import type { Node } from "unist";
+
+import { extractMdxJsxAttributes } from "./common";
+
+/**
+ * A 컴포넌트를 HTML <a> 태그로 변환하는 함수
+ *
+ * @param node 변환할 MDX JSX 노드
+ * @param transformRecursively 자식 노드들을 재귀적으로 변환하는 함수
+ * @returns 변환된 HTML 노드
+ */
+export function handleAComponent(
+  node: MdxJsxFlowElement | MdxJsxTextElement,
+  transformRecursively: (innerAst: Node) => {
+    ast: Node;
+    unhandledTags: Set<string>;
+  },
+): { ast: Node; unhandledTags: Set<string> } {
+  // 속성 추출
+  const attrs = extractMdxJsxAttributes(node);
+  const { href: wrappedHref, ...otherAttrs } = attrs;
+  const href =
+    typeof wrappedHref === "string"
+      ? wrappedHref.replace(/^`|`$/g, "")
+      : wrappedHref;
+
+  // href 처리 - 호스트명 추가
+  let processedHref = href;
+  if (typeof href === "string") {
+    // 외부 링크 체크 (http://, https://, mailto:, tel: 등으로 시작하는지)
+    if (
+      !href.match(/^(https?:\/\/|mailto:|tel:|ftp:|\/\/)/i) &&
+      !href.startsWith("/")
+    ) {
+      // 상대 경로이고 호스트명이 없는 경우 추가
+      processedHref = `/${href}`;
+    }
+
+    // 절대 경로인데 호스트명이 없으면 추가
+    if (href.startsWith("/") && !href.includes("developers.portone.io")) {
+      processedHref = `https://developers.portone.io${href}`;
+    }
+  }
+
+  // 수정된 속성으로 속성 문자열 생성
+  const allAttrs = { ...otherAttrs, href: processedHref };
+  const attrsString = Object.entries(allAttrs)
+    .filter(([_, value]) => value !== undefined)
+    .map(([key, value]) => {
+      if (value === true) {
+        return key;
+      }
+      return `${key}="${String(value).replace(/"/g, "&quot;")}"`;
+    })
+    .join(" ");
+
+  // 속성이 있는 경우 공백 추가
+  const attrsPart = attrsString ? ` ${attrsString}` : "";
+
+  // 자식 노드가 있는지 확인
+  const hasChildren = node.children.length > 0;
+
+  // 자식 노드가 없는 경우 self-closing 태그 반환
+  if (!hasChildren) {
+    return {
+      ast: {
+        type: "html",
+        value: `<a${attrsPart} />`,
+      } satisfies Html as Html,
+      unhandledTags: new Set<string>(),
+    };
+  }
+
+  // 자식 노드 재귀적으로 변환
+  const results = node.children.map(transformRecursively);
+  const newChildren = results.map((r) => r.ast);
+  const unhandledTags = results.reduce(
+    (acc, r) => acc.union(r.unhandledTags),
+    new Set<string>(),
+  );
+
+  // 열고 닫는 태그와 그 사이에 자식 노드 배치
+  return {
+    ast: {
+      type: "root",
+      children: [
+        {
+          type: "html",
+          value: `<a${attrsPart}>`,
+        },
+        ...newChildren,
+        {
+          type: "html",
+          value: `</a>`,
+        },
+      ],
+    } as Root,
+    unhandledTags,
+  };
+}

--- a/scripts/mdx-to-markdown/jsx/common.ts
+++ b/scripts/mdx-to-markdown/jsx/common.ts
@@ -12,7 +12,7 @@ export function extractMdxJsxAttributes(
   if (node.attributes && Array.isArray(node.attributes)) {
     for (const attr of node.attributes) {
       if (attr.type === "mdxJsxAttribute" && attr.name) {
-        if (attr.value && typeof attr.value === "string") {
+        if (attr.value != null && typeof attr.value === "string") {
           props[attr.name] = attr.value;
         } else if (
           attr.value &&

--- a/scripts/mdx-to-markdown/jsx/file.test.ts
+++ b/scripts/mdx-to-markdown/jsx/file.test.ts
@@ -1,0 +1,63 @@
+import type { MdxJsxFlowElement } from "mdast-util-mdx";
+import { describe, expect, it } from "vitest";
+
+import { handleFileComponent } from "./file";
+
+describe("handleFileComponent", () => {
+  it("captionInside가 있는 경우 '(파일: {captionInside})' 형태로 변환한다", () => {
+    // 테스트용 노드 생성
+    const node = {
+      type: "mdxJsxFlowElement",
+      name: "File",
+      attributes: [
+        { type: "mdxJsxAttribute", name: "src", value: "/path/to/file.pdf" },
+        {
+          type: "mdxJsxAttribute",
+          name: "captionInside",
+          value: "파일 다운로드",
+        },
+      ],
+      children: [],
+    } as MdxJsxFlowElement;
+
+    // handleFileComponent 함수 실행
+    const result = handleFileComponent(node);
+
+    // 결과 검증
+    expect(result).toEqual({
+      type: "paragraph",
+      children: [
+        {
+          type: "text",
+          value: "(파일: 파일 다운로드)",
+        },
+      ],
+    });
+  });
+
+  it("captionInside가 없는 경우 '(파일 다운로드 링크)' 형태로 변환한다", () => {
+    // 테스트용 노드 생성
+    const node = {
+      type: "mdxJsxFlowElement",
+      name: "File",
+      attributes: [
+        { type: "mdxJsxAttribute", name: "src", value: "/path/to/file.pdf" },
+      ],
+      children: [],
+    } as MdxJsxFlowElement;
+
+    // handleFileComponent 함수 실행
+    const result = handleFileComponent(node);
+
+    // 결과 검증
+    expect(result).toEqual({
+      type: "paragraph",
+      children: [
+        {
+          type: "text",
+          value: "(파일 다운로드 링크)",
+        },
+      ],
+    });
+  });
+});

--- a/scripts/mdx-to-markdown/jsx/file.ts
+++ b/scripts/mdx-to-markdown/jsx/file.ts
@@ -1,0 +1,30 @@
+import type { MdxJsxFlowElement, MdxJsxTextElement } from "mdast-util-mdx";
+
+import { extractMdxJsxAttributes } from "./common";
+
+/**
+ * File 컴포넌트 처리
+ * @param node MDX JSX 노드
+ * @returns 변환된 마크다운 노드
+ */
+export function handleFileComponent(
+  node: MdxJsxFlowElement | MdxJsxTextElement,
+) {
+  // 속성 추출
+  const props = extractMdxJsxAttributes(node);
+  const captionInside =
+    typeof props.captionInside === "string" ? props.captionInside : "";
+
+  // 요구사항에 따라 변환: `(파일: ${captionInside})` 또는 "(파일 다운로드 링크)"
+  return {
+    type: "paragraph",
+    children: [
+      {
+        type: "text",
+        value: captionInside
+          ? `(파일: ${captionInside})`
+          : "(파일 다운로드 링크)",
+      },
+    ],
+  };
+}

--- a/scripts/mdx-to-markdown/jsx/img.test.ts
+++ b/scripts/mdx-to-markdown/jsx/img.test.ts
@@ -1,0 +1,169 @@
+import type { MdxJsxFlowElement } from "mdast-util-mdx";
+import { describe, expect, it } from "vitest";
+
+import { handleImgTag } from "./img";
+
+describe("handleImgTag", () => {
+  it("transforms img tag with src and alt to markdown link", () => {
+    // 테스트용 img 태그 노드 생성
+    const imgNode: MdxJsxFlowElement = {
+      type: "mdxJsxFlowElement",
+      name: "img",
+      attributes: [
+        {
+          type: "mdxJsxAttribute",
+          name: "src",
+          value: "/some/image/link.png",
+        },
+        {
+          type: "mdxJsxAttribute",
+          name: "alt",
+          value: "some description",
+        },
+      ],
+      children: [],
+    };
+
+    // 함수 실행
+    const result = handleImgTag(imgNode);
+
+    // 결과 검증
+    expect(result).toEqual({
+      type: "paragraph",
+      children: [
+        {
+          type: "link",
+          url: "https://developers.portone.io/some/image/link.png",
+          title: null,
+          children: [
+            {
+              type: "text",
+              value: "some description",
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("uses default alt text when alt attribute is missing", () => {
+    // alt 속성이 없는 img 태그 노드 생성
+    const imgNode: MdxJsxFlowElement = {
+      type: "mdxJsxFlowElement",
+      name: "img",
+      attributes: [
+        {
+          type: "mdxJsxAttribute",
+          name: "src",
+          value: "/some/image/link.png",
+        },
+      ],
+      children: [],
+    };
+
+    // 함수 실행
+    const result = handleImgTag(imgNode);
+
+    // 결과 검증
+    expect(result).toEqual({
+      type: "paragraph",
+      children: [
+        {
+          type: "link",
+          url: "https://developers.portone.io/some/image/link.png",
+          title: null,
+          children: [
+            {
+              type: "text",
+              value: "이미지 링크",
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("adds domain to relative paths", () => {
+    // 상대 경로가 있는 img 태그 노드 생성
+    const imgNode: MdxJsxFlowElement = {
+      type: "mdxJsxFlowElement",
+      name: "img",
+      attributes: [
+        {
+          type: "mdxJsxAttribute",
+          name: "src",
+          value: "some/image/link.png", // 슬래시로 시작하지 않는 경로
+        },
+        {
+          type: "mdxJsxAttribute",
+          name: "alt",
+          value: "relative path image",
+        },
+      ],
+      children: [],
+    };
+
+    // 함수 실행
+    const result = handleImgTag(imgNode);
+
+    // 결과 검증
+    expect(result).toEqual({
+      type: "paragraph",
+      children: [
+        {
+          type: "link",
+          url: "https://developers.portone.io/some/image/link.png",
+          title: null,
+          children: [
+            {
+              type: "text",
+              value: "relative path image",
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("preserves absolute URLs", () => {
+    // 절대 URL이 있는 img 태그 노드 생성
+    const imgNode: MdxJsxFlowElement = {
+      type: "mdxJsxFlowElement",
+      name: "img",
+      attributes: [
+        {
+          type: "mdxJsxAttribute",
+          name: "src",
+          value: "https://example.com/image.png",
+        },
+        {
+          type: "mdxJsxAttribute",
+          name: "alt",
+          value: "external image",
+        },
+      ],
+      children: [],
+    };
+
+    // 함수 실행
+    const result = handleImgTag(imgNode);
+
+    // 결과 검증
+    expect(result).toEqual({
+      type: "paragraph",
+      children: [
+        {
+          type: "link",
+          url: "https://example.com/image.png",
+          title: null,
+          children: [
+            {
+              type: "text",
+              value: "external image",
+            },
+          ],
+        },
+      ],
+    });
+  });
+});

--- a/scripts/mdx-to-markdown/jsx/img.ts
+++ b/scripts/mdx-to-markdown/jsx/img.ts
@@ -1,0 +1,47 @@
+import type { Link, Paragraph, Text } from "mdast";
+import type { MdxJsxFlowElement, MdxJsxTextElement } from "mdast-util-mdx";
+
+import { extractMdxJsxAttributes } from "./common";
+
+/**
+ * <img> 태그를 마크다운 링크로 변환하는 함수
+ *
+ * @param jsxNode img 태그 노드
+ * @returns 변환된 마크다운 형식의 링크를 담은 paragraph 노드
+ */
+export function handleImgTag(
+  jsxNode: MdxJsxFlowElement | MdxJsxTextElement,
+): Paragraph {
+  // 속성 추출
+  const attributes = extractMdxJsxAttributes(jsxNode);
+
+  // src 및 alt 속성 가져오기
+  const src = (attributes.src || "") as string;
+  const alt = (attributes.alt || "이미지 링크") as string;
+
+  // src가 http로 시작하지 않으면 기본 도메인 추가
+  const formattedSrc =
+    !src.startsWith("http://") && !src.startsWith("https://")
+      ? `https://developers.portone.io${src.startsWith("/") ? "" : "/"}${src}`
+      : src;
+
+  // alt 텍스트 노드 생성
+  const textNode: Text = {
+    type: "text",
+    value: alt,
+  };
+
+  // MDAST 링크 노드 생성
+  const linkNode: Link = {
+    type: "link",
+    url: formattedSrc,
+    title: null,
+    children: [textNode],
+  };
+
+  // paragraph 노드로 감싸서 반환
+  return {
+    type: "paragraph",
+    children: [linkNode],
+  };
+}

--- a/scripts/mdx-to-markdown/jsx/importedMdx.test.ts
+++ b/scripts/mdx-to-markdown/jsx/importedMdx.test.ts
@@ -1,0 +1,266 @@
+import type { MdxJsxFlowElement } from "mdast-util-mdx";
+import { describe, expect, it } from "vitest";
+
+import type { MdxParseResult } from "../mdx-parser";
+import { validateImportedMdx } from "./importedMdx";
+
+describe("validateImportedMdx", () => {
+  it("should validate and return MDX parse result for a valid imported MDX component", () => {
+    // Mock JSX node for an imported MDX component
+    const jsxNode = {
+      type: "mdxJsxFlowElement",
+      name: "ImportedComponent",
+      attributes: [],
+      children: [],
+    } as MdxJsxFlowElement;
+
+    // Mock imported elements
+    const importedElements = [
+      { name: "ImportedComponent", from: "./_components/imported.mdx" },
+    ];
+
+    // Mock MDX parse result
+    const mockParseResult: MdxParseResult = {
+      filePath: "src/routes/(root)/parent/_components/imported.mdx",
+      slug: "parent/_components/imported",
+      frontmatter: { title: "Imported Test" },
+      imports: [],
+      ast: {
+        type: "root",
+        children: [
+          {
+            type: "heading",
+            depth: 2,
+            children: [{ type: "text", value: "Imported Content Title" }],
+          },
+        ],
+      },
+      content: "---\ntitle: Imported Test\n---\n\n## Imported Content Title",
+    };
+
+    const parseResultMap: Record<string, MdxParseResult> = {
+      "parent/_components/imported": mockParseResult,
+    };
+
+    // Call the function with parent slug
+    const result = validateImportedMdx(
+      jsxNode,
+      "src/routes/(root)/parent/importer.mdx",
+      importedElements,
+      parseResultMap,
+    );
+
+    // Verify the result is the expected MDX parse result
+    expect(result).toBe(mockParseResult);
+  });
+
+  it("should return undefined when component name is not found", () => {
+    // Mock JSX node with no name
+    const jsxNode = {
+      type: "mdxJsxFlowElement",
+      name: null, // Use null instead of undefined to match the type
+      attributes: [],
+      children: [],
+    } as MdxJsxFlowElement;
+
+    // Mock imported elements
+    const importedElements = [
+      { name: "ImportedComponent", from: "./_components/imported.mdx" },
+    ];
+
+    // Mock parse result map
+    const parseResultMap: Record<string, MdxParseResult> = {};
+
+    // Call the function with parent slug
+    const result = validateImportedMdx(
+      jsxNode,
+      "src/routes/(root)/parent/importer.mdx",
+      importedElements,
+      parseResultMap,
+    );
+
+    // Verify the result is undefined
+    expect(result).toBeUndefined();
+  });
+
+  it("should return undefined when component is not in imported elements", () => {
+    // Mock JSX node for a component not in imported elements
+    const jsxNode = {
+      type: "mdxJsxFlowElement",
+      name: "UnknownComponent",
+      attributes: [],
+      children: [],
+    } as MdxJsxFlowElement;
+
+    // Mock imported elements (doesn't include UnknownComponent)
+    const importedElements = [
+      { name: "KnownComponent", from: "./_components/known.mdx" },
+    ];
+
+    // Mock parse result map
+    const parseResultMap: Record<string, MdxParseResult> = {};
+
+    // Call the function with parent slug
+    const result = validateImportedMdx(
+      jsxNode,
+      "src/routes/(root)/parent/importer.mdx",
+      importedElements,
+      parseResultMap,
+    );
+
+    // Verify the result is undefined
+    expect(result).toBeUndefined();
+  });
+
+  it("should return undefined when import path doesn't end with .mdx", () => {
+    // Mock JSX node
+    const jsxNode = {
+      type: "mdxJsxFlowElement",
+      name: "NonMdxComponent",
+      attributes: [],
+      children: [],
+    } as MdxJsxFlowElement;
+
+    // Mock imported elements with non-MDX import
+    const importedElements = [{ name: "NonMdxComponent", from: "react" }];
+
+    // Mock parse result map
+    const parseResultMap: Record<string, MdxParseResult> = {};
+
+    // Call the function with parent slug
+    const result = validateImportedMdx(
+      jsxNode,
+      "src/routes/(root)/parent/importer.mdx",
+      importedElements,
+      parseResultMap,
+    );
+
+    // Verify the result is undefined
+    expect(result).toBeUndefined();
+  });
+
+  it("should throw an error when MDX file is not found in parse results", () => {
+    // Mock JSX node
+    const jsxNode = {
+      type: "mdxJsxFlowElement",
+      name: "MissingComponent",
+      attributes: [],
+      children: [],
+    } as MdxJsxFlowElement;
+
+    // Mock imported elements
+    const importedElements = [
+      { name: "MissingComponent", from: "./_components/missing.mdx" },
+    ];
+
+    // Empty parse result map (missing.mdx not included)
+    const parseResultMap: Record<string, MdxParseResult> = {};
+
+    // Expect the function to throw an error with updated error message
+    expect(() =>
+      validateImportedMdx(
+        jsxNode,
+        "src/routes/(root)/parent/importer.mdx",
+        importedElements,
+        parseResultMap,
+      ),
+    ).toThrow(
+      "MDX sub-slug parent/_components/missing not found in parseResultMap",
+    );
+  });
+
+  it("should handle paths with various prefixes", () => {
+    // Create three mock JSX nodes with different import path styles
+    const relativeNode = {
+      type: "mdxJsxFlowElement",
+      name: "RelativeComponent",
+      attributes: [],
+      children: [],
+    } as MdxJsxFlowElement;
+
+    const tildaNode = {
+      type: "mdxJsxFlowElement",
+      name: "TildaComponent",
+      attributes: [],
+      children: [],
+    } as MdxJsxFlowElement;
+
+    const nestedNode = {
+      type: "mdxJsxFlowElement",
+      name: "NestedComponent",
+      attributes: [],
+      children: [],
+    } as MdxJsxFlowElement;
+
+    // Mock imported elements with different path styles
+    const importedElements = [
+      { name: "RelativeComponent", from: "./component.mdx" },
+      { name: "TildaComponent", from: "~/components/tilda.mdx" },
+      { name: "NestedComponent", from: "../nested/path/component.mdx" },
+    ];
+
+    // Mock MDX parse results with slugs that match the processed paths
+    const componentResult: MdxParseResult = {
+      filePath: "component.mdx",
+      slug: "parent/component",
+      frontmatter: {},
+      imports: [],
+      ast: { type: "root", children: [] },
+      content: "",
+    };
+
+    const tildaResult: MdxParseResult = {
+      filePath: "components/tilda.mdx",
+      slug: "components/tilda",
+      frontmatter: {},
+      imports: [],
+      ast: { type: "root", children: [] },
+      content: "",
+    };
+
+    const nestedResult: MdxParseResult = {
+      filePath: "nested/path/component.mdx",
+      slug: "nested/path/component",
+      frontmatter: {},
+      imports: [],
+      ast: { type: "root", children: [] },
+      content: "",
+    };
+
+    const parseResultMap: Record<string, MdxParseResult> = {
+      "parent/component": componentResult,
+      "components/tilda": tildaResult,
+      "nested/path/component": nestedResult,
+    };
+
+    // Test the relative path
+    expect(
+      validateImportedMdx(
+        relativeNode,
+        "src/routes/(root)/parent/importer.mdx",
+        importedElements,
+        parseResultMap,
+      ),
+    ).toBe(componentResult);
+
+    // Test the tilda path
+    expect(
+      validateImportedMdx(
+        tildaNode,
+        "src/routes/(root)/parent/importer.mdx",
+        importedElements,
+        parseResultMap,
+      ),
+    ).toBe(tildaResult);
+
+    // Test the nested path
+    expect(
+      validateImportedMdx(
+        nestedNode,
+        "src/routes/(root)/parent/importer.mdx",
+        importedElements,
+        parseResultMap,
+      ),
+    ).toBe(nestedResult);
+  });
+});

--- a/scripts/mdx-to-markdown/jsx/importedMdx.ts
+++ b/scripts/mdx-to-markdown/jsx/importedMdx.ts
@@ -1,0 +1,64 @@
+import type { MdxJsxFlowElement, MdxJsxTextElement } from "mdast-util-mdx";
+
+import type { MdxParseResult } from "../mdx-parser";
+import type { Import } from "./imports";
+
+/**
+ * Validates an imported MDX component and returns the corresponding MDX parse result if valid
+ * @param node JSX component node
+ * @param parentFilePath Filepath of the parent MDX file
+ * @param importedElements List of all imported elements
+ * @param parseResultMap Map of all MDX parse results by slug
+ * @returns The MDX parse result if successful, undefined otherwise
+ */
+export function validateImportedMdx(
+  node: MdxJsxFlowElement | MdxJsxTextElement,
+  parentFilePath: string,
+  importedElements: Import[],
+  parseResultMap: Record<string, MdxParseResult>,
+): MdxParseResult | undefined {
+  const componentName = node.name;
+  if (!componentName) {
+    return undefined;
+  }
+
+  // Find the corresponding import element
+  const importElement = importedElements.find(
+    (item) => item.name === componentName,
+  );
+
+  if (!importElement) {
+    return undefined;
+  }
+
+  // Extract the import path and determine if it's an MDX file
+  const importPath = importElement.from;
+  const isMdxComponent = importPath.endsWith(".mdx");
+
+  if (!isMdxComponent) {
+    return undefined;
+  }
+
+  const parentSlug = parentFilePath
+    .replace(/\/[^/]+\.mdx$/, "")
+    .replace(/^src\/routes\/\(root\)\//, "");
+
+  // Extract slug from the import path by removing any leading path prefixes and extension
+  const subSlug = importPath
+    .replace(/^\.\//, `${parentSlug}/`)
+    .replace(/^~\//, "")
+    .replace(/^[./]+/, "") // Remove any leading ./ ../ ~/ or combinations
+    .replace(/\.mdx$/, ""); // Remove .mdx extension
+
+  // Find the MDX parse result for this slug
+  const mdxResult = Object.values(parseResultMap).find((result) =>
+    result.slug.includes(subSlug),
+  );
+
+  if (!mdxResult) {
+    // If MDX file not found in parseResultMap, throw an error
+    throw new Error(`MDX sub-slug ${subSlug} not found in parseResultMap`);
+  }
+
+  return mdxResult;
+}

--- a/scripts/mdx-to-markdown/jsx/imports.ts
+++ b/scripts/mdx-to-markdown/jsx/imports.ts
@@ -2,15 +2,18 @@ import type { MdxjsEsm } from "mdast-util-mdx";
 import type { Node } from "unist";
 import { visit } from "unist-util-visit";
 
+export type Import = {
+  name: string;
+  from: string;
+};
+
 /**
  * Collects all imported elements from the MDX AST
  * @param ast MDX AST
  * @returns Array of imported elements
  */
-export function collectAllImportedElements(
-  ast: Node,
-): { name: string; from: string }[] {
-  const importedElements: { name: string; from: string }[] = [];
+export function collectAllImportedElements(ast: Node): Import[] {
+  const importedElements: Import[] = [];
   visit(ast, "mdxjsEsm", (node: MdxjsEsm) => {
     if (node.data?.estree) {
       const estree = node.data.estree;

--- a/scripts/mdx-to-markdown/jsx/index.test.ts
+++ b/scripts/mdx-to-markdown/jsx/index.test.ts
@@ -14,7 +14,7 @@ describe("transformJsxComponents", () => {
     // 테스트용 parseResultMap 생성
     const parseResultMap: Record<string, MdxParseResult> = {
       "opi/ko/integration/webhook/readme-v1": {
-        filePath: "/path/to/opi/ko/integration/webhook/readme-v1.mdx",
+        filePath: "src/routes/(root)/opi/ko/integration/webhook/readme-v1.mdx",
         slug: "opi/ko/integration/webhook/readme-v1",
         frontmatter: {
           title: "웹훅 연동하기 (V1)",
@@ -24,10 +24,20 @@ describe("transformJsxComponents", () => {
         content: "",
       },
       "opi/ko/integration/webhook/readme-v2": {
-        filePath: "/path/to/opi/ko/integration/webhook/readme-v2.mdx",
+        filePath: "src/routes/(root)/opi/ko/integration/webhook/readme-v2.mdx",
         slug: "opi/ko/integration/webhook/readme-v2",
         frontmatter: {
           title: "웹훅 연동하기 (V2)",
+        },
+        imports: [],
+        ast: emptyRoot,
+        content: "",
+      },
+      "opi/ko/integration/webhook/readme": {
+        filePath: "src/routes/(root)/opi/ko/integration/webhook/readme.mdx",
+        slug: "opi/ko/integration/webhook/readme",
+        frontmatter: {
+          title: "웹훅 연동하기",
         },
         imports: [],
         ast: emptyRoot,
@@ -108,7 +118,11 @@ describe("transformJsxComponents", () => {
     };
 
     // transformJsxComponents 함수 실행
-    const { ast: transformedAst } = transformJsxComponents(ast, parseResultMap);
+    const { ast: transformedAst } = transformJsxComponents(
+      "opi/ko/integration/webhook/readme",
+      ast,
+      parseResultMap,
+    );
 
     // 결과 검증 - VersionGate 내부의 ContentRef가 마크다운 링크로 변환되었는지 확인
     expect(transformedAst).toEqual({
@@ -215,7 +229,7 @@ describe("transformJsxComponents", () => {
     // 테스트용 parseResultMap 생성
     const parseResultMap: Record<string, MdxParseResult> = {
       "opi/ko/integration/start/v1/auth": {
-        filePath: "/path/to/opi/ko/integration/start/v1/auth.mdx",
+        filePath: "src/routes/(root)/opi/ko/integration/start/v1/auth.mdx",
         slug: "opi/ko/integration/start/v1/auth",
         frontmatter: {
           title: "인증결제 연동하기",
@@ -289,7 +303,11 @@ describe("transformJsxComponents", () => {
     };
 
     // transformJsxComponents 함수 실행
-    const { ast: transformedAst } = transformJsxComponents(ast, parseResultMap);
+    const { ast: transformedAst } = transformJsxComponents(
+      "opi/ko/integration/start/v1/auth",
+      ast,
+      parseResultMap,
+    );
 
     // 결과 검증 - 중첩된 VersionGate와 ContentRef가 모두 처리되었는지 확인
     expect(transformedAst).toEqual({
@@ -388,7 +406,7 @@ describe("transformJsxComponents", () => {
     // 테스트용 parseResultMap 생성
     const parseResultMap: Record<string, MdxParseResult> = {
       "opi/ko/integration/ready/readme": {
-        filePath: "/path/to/opi/ko/integration/ready/readme.mdx",
+        filePath: "src/routes/(root)/opi/ko/integration/ready/readme.mdx",
         slug: "opi/ko/integration/ready/readme",
         frontmatter: {
           title: "연동 준비하기",
@@ -463,7 +481,11 @@ describe("transformJsxComponents", () => {
     };
 
     // transformJsxComponents 함수 실행
-    const { ast: transformedAst } = transformJsxComponents(ast, parseResultMap);
+    const { ast: transformedAst } = transformJsxComponents(
+      "opi/ko/integration/ready/readme",
+      ast,
+      parseResultMap,
+    );
 
     // 결과 검증 - 다양한 컴포넌트가 모두 처리되었는지 확인
     expect(transformedAst).toEqual({
@@ -549,7 +571,19 @@ describe("transformJsxComponents", () => {
 
   it("Condition 컴포넌트를 HTML 주석으로 처리한다", () => {
     // 테스트용 parseResultMap 생성
-    const parseResultMap: Record<string, MdxParseResult> = {};
+    const parseResultMap: Record<string, MdxParseResult> = {
+      "opi/ko/integration/ready/condition-test": {
+        filePath:
+          "src/routes/(root)/opi/ko/integration/ready/condition-test.mdx",
+        slug: "opi/ko/integration/ready/condition-test",
+        frontmatter: {
+          title: "조건부 컨텐츠",
+        },
+        imports: [],
+        ast: emptyRoot,
+        content: "",
+      },
+    };
 
     // 테스트용 AST 생성 - 다양한 속성을 가진 Condition 컴포넌트
     const ast: Root = {
@@ -631,7 +665,11 @@ describe("transformJsxComponents", () => {
     };
 
     // transformJsxComponents 함수 실행
-    const { ast: transformedAst } = transformJsxComponents(ast, parseResultMap);
+    const { ast: transformedAst } = transformJsxComponents(
+      "opi/ko/integration/ready/condition-test",
+      ast,
+      parseResultMap,
+    );
 
     // 결과 검증 - 각 Condition 컴포넌트가 HTML 주석으로 변환되었는지 확인
     expect(transformedAst).toEqual({

--- a/scripts/mdx-to-markdown/jsx/index.ts
+++ b/scripts/mdx-to-markdown/jsx/index.ts
@@ -16,6 +16,7 @@ import {
 } from "./details";
 import { handleFigureComponent } from "./figure";
 import { handleHintComponent } from "./hint";
+import { handleImgTag } from "./img";
 import { validateImportedMdx } from "./importedMdx";
 import { handleParameterTypeDefComponent } from "./parameter";
 import { handleProseComponent } from "./prose";
@@ -158,6 +159,11 @@ export function transformJsxComponents(
               ast: sdkChangelog(),
               unhandledTags: emptySet,
             };
+          case "img":
+            return {
+              ast: handleImgTag(jsxNode),
+              unhandledTags: emptySet,
+            };
           case "br":
           case "table":
           case "thead":
@@ -165,11 +171,20 @@ export function transformJsxComponents(
           case "th":
           case "tr":
           case "td":
+          case "ul":
+          case "li":
+          case "p":
+          case "span":
+          case "i":
+          case "strong":
             return replaceToHtml(jsxNode, transformRecursively);
           case "Parameter":
           case "Parameter.Details":
-          case "center":
           case "EasyGuideLink":
+          case "center":
+          case "div":
+          case "figure":
+          case "figcaption":
             return unwrapJsxNode(jsxNode, transformRecursively);
           default: {
             const importedMdx = validateImportedMdx(

--- a/scripts/mdx-to-markdown/jsx/index.ts
+++ b/scripts/mdx-to-markdown/jsx/index.ts
@@ -19,6 +19,7 @@ import { handleHintComponent } from "./hint";
 import { validateImportedMdx } from "./importedMdx";
 import { handleParameterTypeDefComponent } from "./parameter";
 import { handleProseComponent } from "./prose";
+import { handleSDKParameterComponent, sdkChangelog } from "./sdk";
 import {
   handleSwaggerComponent,
   handleSwaggerDescriptionComponent,
@@ -84,14 +85,6 @@ export function transformJsxComponents(
               ast: extractCodeContent(jsxNode),
               unhandledTags: emptySet,
             };
-          case "br":
-          case "table":
-          case "thead":
-          case "tbody":
-          case "th":
-          case "tr":
-          case "td":
-            return replaceToHtml(jsxNode, transformRecursively);
           case "Figure":
             return {
               ast: handleFigureComponent(jsxNode),
@@ -153,15 +146,30 @@ export function transformJsxComponents(
               jsxNode,
               transformRecursively,
             );
-          case "Parameter":
-          case "Parameter.Details":
-            return unwrapJsxNode(jsxNode, transformRecursively);
           case "Parameter.TypeDef":
             return handleParameterTypeDefComponent(
               jsxNode,
               transformRecursively,
             );
+          case "SDKParameter":
+            return handleSDKParameterComponent(jsxNode);
+          case "SDKChangelog":
+            return {
+              ast: sdkChangelog(),
+              unhandledTags: emptySet,
+            };
+          case "br":
+          case "table":
+          case "thead":
+          case "tbody":
+          case "th":
+          case "tr":
+          case "td":
+            return replaceToHtml(jsxNode, transformRecursively);
+          case "Parameter":
+          case "Parameter.Details":
           case "center":
+          case "EasyGuideLink":
             return unwrapJsxNode(jsxNode, transformRecursively);
           default: {
             const importedMdx = validateImportedMdx(

--- a/scripts/mdx-to-markdown/jsx/index.ts
+++ b/scripts/mdx-to-markdown/jsx/index.ts
@@ -16,6 +16,7 @@ import {
   handleDetailsSummaryComponent,
 } from "./details";
 import { handleFigureComponent } from "./figure";
+import { handleFileComponent } from "./file";
 import { handleHintComponent } from "./hint";
 import { handleImgTag } from "./img";
 import { validateImportedMdx } from "./importedMdx";
@@ -90,6 +91,11 @@ export function transformJsxComponents(
           case "Figure":
             return {
               ast: handleFigureComponent(jsxNode),
+              unhandledTags: emptySet,
+            };
+          case "File":
+            return {
+              ast: handleFileComponent(jsxNode),
               unhandledTags: emptySet,
             };
           case "Hint":

--- a/scripts/mdx-to-markdown/jsx/index.ts
+++ b/scripts/mdx-to-markdown/jsx/index.ts
@@ -17,6 +17,7 @@ import {
 import { handleFigureComponent } from "./figure";
 import { handleHintComponent } from "./hint";
 import { collectAllImportedElements } from "./imports";
+import { handleParameterTypeDefComponent } from "./parameter";
 import { handleProseComponent } from "./prose";
 import {
   handleSwaggerComponent,
@@ -152,6 +153,12 @@ export function transformJsxComponents(
             );
           case "Parameter":
           case "Parameter.Details":
+            return unwrapJsxNode(jsxNode, transformRecursively);
+          case "Parameter.TypeDef":
+            return handleParameterTypeDefComponent(
+              jsxNode,
+              transformRecursively,
+            );
           case "center":
             return unwrapJsxNode(jsxNode, transformRecursively);
           default: {

--- a/scripts/mdx-to-markdown/jsx/index.ts
+++ b/scripts/mdx-to-markdown/jsx/index.ts
@@ -3,6 +3,7 @@ import { replaceToHtml } from "scripts/mdx-to-markdown/jsx/replaceToHtml";
 import type { Node, Parent } from "unist";
 
 import { type MdxParseResult } from "../mdx-parser";
+import { handleAComponent } from "./a";
 import { handleApiLinkComponent } from "./apiLink";
 import { handleBadgeComponent } from "./badge";
 import { extractCodeContent } from "./code";
@@ -126,6 +127,8 @@ export function transformJsxComponents(
               ast: handleApiLinkComponent(jsxNode),
               unhandledTags: emptySet,
             };
+          case "A":
+            return handleAComponent(jsxNode, transformRecursively);
           case "PaymentV1":
           case "PaymentV2":
           case "Recon":
@@ -177,6 +180,7 @@ export function transformJsxComponents(
           case "span":
           case "i":
           case "strong":
+          case "a":
             return replaceToHtml(jsxNode, transformRecursively);
           case "Parameter":
           case "Parameter.Details":

--- a/scripts/mdx-to-markdown/jsx/parameter.test.ts
+++ b/scripts/mdx-to-markdown/jsx/parameter.test.ts
@@ -1,0 +1,304 @@
+import type { MdxJsxFlowElement } from "mdast-util-mdx";
+import type { Node, Parent } from "unist";
+import { describe, expect, it, vi } from "vitest";
+
+import { handleParameterTypeDefComponent } from "./parameter";
+
+describe("handleParameterTypeDefComponent", () => {
+  it("transforms Parameter.TypeDef with all attributes into markdown", () => {
+    // Create test Parameter.TypeDef node
+    const node = {
+      type: "mdxJsxFlowElement",
+      name: "Parameter.TypeDef",
+      attributes: [
+        { type: "mdxJsxAttribute", name: "ident", value: "batch_soc_choice" },
+        {
+          type: "mdxJsxAttribute",
+          name: "type",
+          value: "'percard' | 'cocard'",
+        },
+        { type: "mdxJsxAttribute", name: "optional", value: true },
+      ],
+      children: [
+        {
+          type: "paragraph",
+          children: [
+            {
+              type: "strong",
+              children: [
+                {
+                  type: "text",
+                  value: "결제창에서 주민번호/사업자 번호 고정여부 설정",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: "list",
+          ordered: false,
+          children: [
+            {
+              type: "listItem",
+              children: [
+                {
+                  type: "paragraph",
+                  children: [{ type: "text", value: "S: 주민번호만 표시" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              children: [
+                {
+                  type: "paragraph",
+                  children: [{ type: "text", value: "C: 사업자번호만 표시" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    } as MdxJsxFlowElement;
+
+    // Mock transformRecursively function
+    const mockTransformRecursively = vi.fn((ast: Node) => ({
+      ast,
+      unhandledTags: new Set<string>(),
+    }));
+
+    // Execute handleParameterTypeDefComponent function
+    const result = handleParameterTypeDefComponent(
+      node,
+      mockTransformRecursively,
+    );
+
+    // Verify results
+    expect(result.ast.type).toBe("root");
+    expect(result.ast.children.length).toBe(1);
+
+    // First child should be a listItem containing parameter definition
+    const listItem = result.ast.children[0] as Parent;
+    expect(listItem).toBeDefined();
+    expect(listItem.type).toBe("listItem");
+    expect((listItem as any).spread).toBe(true); // Should be spread: true for loose list items with multiple blocks
+    expect(listItem.children.length).toBe(3); // paragraph with parameter + original paragraph + original list
+
+    // First child of list item should be the parameter definition paragraph
+    const paramDefParagraph = listItem.children[0] as Parent;
+    expect(paramDefParagraph).toBeDefined();
+    expect(paramDefParagraph.type).toBe("paragraph");
+    expect(paramDefParagraph.children.length).toBe(1);
+
+    const parameterDefText = paramDefParagraph.children[0];
+    expect(parameterDefText).toBeDefined();
+    expect(parameterDefText?.type).toBe("text");
+    expect((parameterDefText as any).value).toBe(
+      "batch_soc_choice?: 'percard' | 'cocard'",
+    );
+
+    // Check that original content is preserved
+    const originalParagraph = listItem.children[1] as Parent;
+    expect(originalParagraph).toBeDefined();
+    expect(originalParagraph.type).toBe("paragraph");
+    expect(originalParagraph.children.length).toBe(1);
+    expect(originalParagraph?.children[0]?.type).toBe("strong");
+
+    const originalList = listItem.children[2] as Parent;
+    expect(originalList).toBeDefined();
+    expect(originalList.type).toBe("list");
+    expect(originalList.children.length).toBe(2); // Two list items from the original content
+
+    expect(result.unhandledTags.size).toBe(0);
+  });
+
+  it("transforms Parameter.TypeDef with only ident into markdown", () => {
+    // Create test Parameter.TypeDef node with only ident
+    const node = {
+      type: "mdxJsxFlowElement",
+      name: "Parameter.TypeDef",
+      attributes: [
+        { type: "mdxJsxAttribute", name: "ident", value: "simple_param" },
+      ],
+      children: [
+        {
+          type: "paragraph",
+          children: [{ type: "text", value: "Simple parameter description" }],
+        },
+      ],
+    } as MdxJsxFlowElement;
+
+    // Mock transformRecursively function
+    const mockTransformRecursively = vi.fn((ast: Node) => ({
+      ast,
+      unhandledTags: new Set<string>(),
+    }));
+
+    // Execute handleParameterTypeDefComponent function
+    const result = handleParameterTypeDefComponent(
+      node,
+      mockTransformRecursively,
+    );
+
+    // Verify results
+    expect(result.ast.type).toBe("root");
+    expect(result.ast.children.length).toBe(1);
+
+    // First child should be a listItem containing parameter definition
+    const listItem = result.ast.children[0] as Parent;
+    expect(listItem).toBeDefined();
+    expect(listItem.type).toBe("listItem");
+    expect((listItem as any).spread).toBe(true);
+    expect(listItem.children.length).toBe(2); // parameter def paragraph + original content paragraph
+
+    // First child is parameter definition paragraph
+    const paramDefParagraph = listItem.children[0] as Parent;
+    expect(paramDefParagraph).toBeDefined();
+    expect(paramDefParagraph.type).toBe("paragraph");
+    expect(paramDefParagraph.children.length).toBe(1);
+
+    const parameterDefText = paramDefParagraph.children[0];
+    expect(parameterDefText).toBeDefined();
+    expect(parameterDefText?.type).toBe("text");
+    expect((parameterDefText as any).value).toBe("simple_param: ");
+
+    // Should have the original description content as second child of list item
+    const originalParagraph = listItem.children[1] as Parent;
+    expect(originalParagraph).toBeDefined();
+    expect(originalParagraph.type).toBe("paragraph");
+    expect(originalParagraph.children.length).toBe(1);
+    expect((originalParagraph.children[0] as any).value).toBe(
+      "Simple parameter description",
+    );
+
+    expect(result.unhandledTags.size).toBe(0);
+  });
+
+  it("properly unwraps when no ident is provided", () => {
+    // Create test Parameter.TypeDef node with no ident
+    const node = {
+      type: "mdxJsxFlowElement",
+      name: "Parameter.TypeDef",
+      attributes: [],
+      children: [
+        {
+          type: "paragraph",
+          children: [{ type: "text", value: "This should just be unwrapped" }],
+        },
+      ],
+    } as MdxJsxFlowElement;
+
+    // Mock transformRecursively function - simulate unwrapping behavior
+    const mockTransformRecursively = vi.fn((_ast: Node) => ({
+      ast: {
+        type: "root",
+        children: [
+          {
+            type: "paragraph",
+            children: [
+              { type: "text", value: "This should just be unwrapped" },
+            ],
+          },
+        ],
+      },
+      unhandledTags: new Set<string>(),
+    }));
+
+    // Execute handleParameterTypeDefComponent function
+    const result = handleParameterTypeDefComponent(
+      node,
+      mockTransformRecursively,
+    );
+
+    // Verify results - should just have unwrapped the content
+    expect(result.ast.type).toBe("root");
+    expect(result.ast.children.length).toBe(1);
+
+    // For unwrapped content, the children from the transformRecursively result are preserved
+    const unwrappedRoot = result.ast.children[0] as Parent;
+    expect(unwrappedRoot).toBeDefined();
+    expect(unwrappedRoot.type).toBe("root");
+    expect(unwrappedRoot.children.length).toBe(1);
+
+    const unwrappedParagraph = unwrappedRoot.children[0] as Parent;
+    expect(unwrappedParagraph).toBeDefined();
+    expect(unwrappedParagraph.type).toBe("paragraph");
+    expect(unwrappedParagraph.children.length).toBe(1);
+
+    const unwrappedText = unwrappedParagraph.children[0];
+    expect(unwrappedText).toBeDefined();
+    expect(unwrappedText?.type).toBe("text");
+    expect((unwrappedText as any).value).toBe("This should just be unwrapped");
+
+    expect(result.unhandledTags.size).toBe(0);
+
+    // Should have called transformRecursively once
+    expect(mockTransformRecursively).toHaveBeenCalledTimes(1);
+  });
+
+  it("transforms Parameter.TypeDef with type but no ident into markdown", () => {
+    // Create test Parameter.TypeDef node with type but no ident
+    const node = {
+      type: "mdxJsxFlowElement",
+      name: "Parameter.TypeDef",
+      attributes: [
+        { type: "mdxJsxAttribute", name: "type", value: "InicisV2BypassOnPc" },
+        { type: "mdxJsxAttribute", name: "optional", value: true },
+      ],
+      children: [
+        {
+          type: "paragraph",
+          children: [
+            {
+              type: "strong",
+              children: [{ type: "text", value: "PC용 파라미터" }],
+            },
+          ],
+        },
+      ],
+    } as MdxJsxFlowElement;
+
+    // Mock transformRecursively function
+    const mockTransformRecursively = vi.fn((ast: Node) => ({
+      ast,
+      unhandledTags: new Set<string>(),
+    }));
+
+    // Execute handleParameterTypeDefComponent function
+    const result = handleParameterTypeDefComponent(
+      node,
+      mockTransformRecursively,
+    );
+
+    // Verify results
+    expect(result.ast.type).toBe("root");
+    expect(result.ast.children.length).toBe(1);
+
+    // First child should be a listItem containing parameter definition
+    const listItem = result.ast.children[0] as Parent;
+    expect(listItem).toBeDefined();
+    expect(listItem.type).toBe("listItem");
+    expect((listItem as any).spread).toBe(true);
+    expect(listItem.children.length).toBe(2); // parameter def paragraph + original content paragraph
+
+    // First child is parameter definition paragraph
+    const paramDefParagraph = listItem.children[0] as Parent;
+    expect(paramDefParagraph).toBeDefined();
+    expect(paramDefParagraph.type).toBe("paragraph");
+    expect(paramDefParagraph.children.length).toBe(1);
+
+    const parameterDefText = paramDefParagraph.children[0];
+    expect(parameterDefText).toBeDefined();
+    expect(parameterDefText?.type).toBe("text");
+    expect((parameterDefText as any).value).toBe("InicisV2BypassOnPc?");
+
+    // Should have the original description content as second child of list item
+    const originalParagraph = listItem.children[1] as Parent;
+    expect(originalParagraph).toBeDefined();
+    expect(originalParagraph.type).toBe("paragraph");
+    expect(originalParagraph.children.length).toBe(1);
+    expect(originalParagraph.children[0]?.type).toBe("strong");
+
+    expect(result.unhandledTags.size).toBe(0);
+  });
+});

--- a/scripts/mdx-to-markdown/jsx/parameter.ts
+++ b/scripts/mdx-to-markdown/jsx/parameter.ts
@@ -1,0 +1,111 @@
+import type { BlockContent, ListItem, Paragraph, Root, Text } from "mdast";
+import type { MdxJsxFlowElement, MdxJsxTextElement } from "mdast-util-mdx";
+import type { Node } from "unist";
+
+import { extractMdxJsxAttributes, unwrapJsxNode } from "./common";
+
+/**
+ * Parameter.TypeDef 컴포넌트를 마크다운으로 변환하는 함수
+ * <Parameter.TypeDef ident="batch_soc_choice" type="'percard' | 'cocard'" optional>
+ *   **결제창에서 주민번호/사업자 번호 고정여부 설정**
+ *
+ *   - S: 주민번호만 표시
+ *   - C: 사업자번호만 표시
+ * </Parameter.TypeDef>
+ *
+ * 변환 결과:
+ * - batch_soc_choice?: 'percard' | 'cocard'
+ *
+ *    결제창에서 주민번호/사업자 번호 고정여부 설정
+ *
+ *    - S: 주민번호만 표시
+ *    - C: 사업자번호만 표시
+ *
+ * @param node Parameter.TypeDef 컴포넌트 노드
+ * @param transformRecursively 내부 JSX 컴포넌트를 재귀적으로 변환하는 함수
+ * @returns 변환된 노드
+ */
+export function handleParameterTypeDefComponent(
+  node: MdxJsxFlowElement | MdxJsxTextElement,
+  transformRecursively: (ast: Node) => {
+    ast: Node;
+    unhandledTags: Set<string>;
+  },
+): { ast: Root; unhandledTags: Set<string> } {
+  const props = extractMdxJsxAttributes(node);
+  const ident = props.ident as string | undefined;
+  const type = props.type as string | undefined;
+  const isOptional = "optional" in props;
+
+  // If there's no ident but there is a type, use the type as the identifier
+  // If neither ident nor type is provided, just unwrap the node
+  if (!ident && !type) {
+    return unwrapJsxNode(node, transformRecursively);
+  }
+
+  // Process the content (description and any other nested content)
+  const { ast: unwrappedContent, unhandledTags } = unwrapJsxNode(
+    node,
+    transformRecursively,
+  );
+
+  // Create the parameter definition text node
+  const parameterDefText: Text = {
+    type: "text",
+    value: ident
+      ? `${ident}${isOptional ? "?" : ""}: ${type || ""}`
+      : `${type}${isOptional ? "?" : ""}`,
+  };
+
+  // Create the paragraph containing the parameter definition
+  const parameterDefParagraph: Paragraph = {
+    type: "paragraph",
+    children: [parameterDefText],
+  };
+
+  // Check if there's unwrapped content to include
+  if (
+    unwrappedContent.type === "root" &&
+    unwrappedContent.children &&
+    unwrappedContent.children.length > 0
+  ) {
+    // Create a list item that includes both the parameter definition and its description
+    // This will make the description part of the list item, properly indented
+    const listItemChildren: BlockContent[] = [parameterDefParagraph];
+
+    // Add all child content from the unwrapped content
+    unwrappedContent.children.forEach((child) => {
+      listItemChildren.push(child as BlockContent);
+    });
+
+    // Create the list item with the parameter definition and description
+    const parameterLine: ListItem = {
+      type: "listItem",
+      spread: true, // Set spread to true for loose list formatting with paragraphs
+      children: listItemChildren,
+    };
+
+    return {
+      ast: {
+        type: "root",
+        children: [parameterLine],
+      } as Root,
+      unhandledTags,
+    };
+  } else {
+    // If there's no content, just return a simple parameter definition
+    const parameterLine: ListItem = {
+      type: "listItem",
+      spread: false,
+      children: [parameterDefParagraph],
+    };
+
+    return {
+      ast: {
+        type: "root",
+        children: [parameterLine],
+      } as Root,
+      unhandledTags,
+    };
+  }
+}

--- a/scripts/mdx-to-markdown/jsx/sdk.test.ts
+++ b/scripts/mdx-to-markdown/jsx/sdk.test.ts
@@ -1,4 +1,4 @@
-import type { Link, ListItem, Paragraph, Root, Text } from "mdast";
+import type { Link, ListItem, Paragraph, Text } from "mdast";
 import type { MdxJsxFlowElement } from "mdast-util-mdx";
 import { describe, expect, it } from "vitest";
 

--- a/scripts/mdx-to-markdown/jsx/sdk.test.ts
+++ b/scripts/mdx-to-markdown/jsx/sdk.test.ts
@@ -1,0 +1,172 @@
+import type { Link, ListItem, Paragraph, Root, Text } from "mdast";
+import type { MdxJsxFlowElement } from "mdast-util-mdx";
+import { describe, expect, it } from "vitest";
+
+import { handleSDKParameterComponent, sdkChangelog } from "./sdk";
+
+describe("sdkChangelog", () => {
+  it("returns a link to the SDK changelog", () => {
+    const result = sdkChangelog();
+
+    expect(result.type).toBe("link");
+    expect(result.url).toBe(
+      "https://developers.portone.io/sdk/ko/v2-sdk/changelog",
+    );
+    expect(result.children).toHaveLength(1);
+    expect(result.children[0]!.type).toBe("text");
+    expect((result.children[0] as Text).value).toBe("SDK Changelog");
+  });
+});
+
+describe("handleSDKParameterComponent", () => {
+  it("transforms SDKParameter with all attributes into markdown", () => {
+    // Create test SDKParameter node
+    const node = {
+      type: "mdxJsxFlowElement",
+      name: "SDKParameter",
+      attributes: [
+        {
+          type: "mdxJsxAttribute",
+          name: "path",
+          value: "#/resources/request/IssueBillingKeyAndPayRequest",
+        },
+        { type: "mdxJsxAttribute", name: "ident", value: "request" },
+        { type: "mdxJsxAttribute", name: "optional", value: true },
+      ],
+      children: [],
+    } as MdxJsxFlowElement;
+
+    // Execute handleSDKParameterComponent function
+    const result = handleSDKParameterComponent(node);
+
+    // Verify results
+    expect(result.ast.type).toBe("root");
+    expect(result.ast.children).toHaveLength(1);
+
+    // First child should be a listItem containing parameter definition
+    const listItem = result.ast.children[0] as ListItem;
+    expect(listItem).toBeDefined();
+    expect(listItem.type).toBe("listItem");
+    expect(listItem.spread).toBe(true);
+    expect(listItem.children).toHaveLength(2); // Parameter def paragraph + link paragraph
+
+    // First child of list item should be the parameter definition paragraph
+    const paramDefParagraph = listItem.children[0] as Paragraph;
+    expect(paramDefParagraph).toBeDefined();
+    expect(paramDefParagraph.type).toBe("paragraph");
+    expect(paramDefParagraph.children).toHaveLength(1);
+
+    const parameterDefText = paramDefParagraph.children[0] as Text;
+    expect(parameterDefText).toBeDefined();
+    expect(parameterDefText.type).toBe("text");
+    expect(parameterDefText.value).toBe(
+      "request?: IssueBillingKeyAndPayRequest",
+    );
+
+    // Second child should be the link paragraph
+    const linkParagraph = listItem.children[1] as Paragraph;
+    expect(linkParagraph).toBeDefined();
+    expect(linkParagraph.type).toBe("paragraph");
+    expect(linkParagraph.children).toHaveLength(1);
+
+    const link = linkParagraph.children[0] as Link;
+    expect(link).toBeDefined();
+    expect(link.type).toBe("link");
+    expect(link.url).toBe(
+      "https://developers.portone.io/schema/browser-sdk.yml#/resources/request/IssueBillingKeyAndPayRequest",
+    );
+    expect(link.children).toHaveLength(1);
+    expect(link.children[0]!.type).toBe("text");
+    expect((link.children[0] as Text).value).toBe("definition link");
+
+    expect(result.unhandledTags.size).toBe(0);
+  });
+
+  it("transforms SDKParameter with no ident attribute", () => {
+    // Create test SDKParameter node with no ident
+    const node = {
+      type: "mdxJsxFlowElement",
+      name: "SDKParameter",
+      attributes: [
+        {
+          type: "mdxJsxAttribute",
+          name: "path",
+          value: "#/resources/request/PaymentRequest",
+        },
+      ],
+      children: [],
+    } as MdxJsxFlowElement;
+
+    // Execute handleSDKParameterComponent function
+    const result = handleSDKParameterComponent(node);
+
+    // Verify results
+    expect(result.ast.type).toBe("root");
+    expect(result.ast.children).toHaveLength(1);
+
+    const listItem = result.ast.children[0] as ListItem;
+    expect(listItem.type).toBe("listItem");
+    expect(listItem.children).toHaveLength(2);
+
+    const paramDefParagraph = listItem.children[0] as Paragraph;
+    const parameterDefText = paramDefParagraph.children[0] as Text;
+    expect(parameterDefText.value).toBe("PaymentRequest");
+
+    const linkParagraph = listItem.children[1] as Paragraph;
+    const link = linkParagraph.children[0] as Link;
+    expect(link.url).toBe(
+      "https://developers.portone.io/schema/browser-sdk.yml#/resources/request/PaymentRequest",
+    );
+
+    expect(result.unhandledTags.size).toBe(0);
+  });
+
+  it("throws an error when no path is provided", () => {
+    // Create test SDKParameter node with no path
+    const node = {
+      type: "mdxJsxFlowElement",
+      name: "SDKParameter",
+      attributes: [
+        { type: "mdxJsxAttribute", name: "ident", value: "request" },
+      ],
+      children: [],
+    } as MdxJsxFlowElement;
+
+    // Expect the function to throw an error
+    expect(() => handleSDKParameterComponent(node)).toThrow(
+      "No path found in SDKParameter.",
+    );
+  });
+
+  it("correctly creates markdown with complex path segments", () => {
+    // Create test SDKParameter node with complex path
+    const node = {
+      type: "mdxJsxFlowElement",
+      name: "SDKParameter",
+      attributes: [
+        {
+          type: "mdxJsxAttribute",
+          name: "path",
+          value: "#/resources/response/ComplexResponse",
+        },
+        { type: "mdxJsxAttribute", name: "ident", value: "responseData" },
+      ],
+      children: [],
+    } as MdxJsxFlowElement;
+
+    // Execute handleSDKParameterComponent function
+    const result = handleSDKParameterComponent(node);
+
+    // Verify results
+    const listItem = result.ast.children[0] as ListItem;
+    const paramDefParagraph = listItem.children[0] as Paragraph;
+    const parameterDefText = paramDefParagraph.children[0] as Text;
+    expect(parameterDefText.value).toBe("responseData: ComplexResponse");
+
+    const linkParagraph = listItem.children[1] as Paragraph;
+    const link = linkParagraph.children[0] as Link;
+    expect(link.url).toBe(
+      "https://developers.portone.io/schema/browser-sdk.yml#/resources/response/ComplexResponse",
+    );
+  });
+});

--- a/scripts/mdx-to-markdown/jsx/sdk.ts
+++ b/scripts/mdx-to-markdown/jsx/sdk.ts
@@ -1,0 +1,106 @@
+import type {
+  BlockContent,
+  Link,
+  ListItem,
+  Paragraph,
+  Root,
+  Text,
+} from "mdast";
+import type { MdxJsxFlowElement, MdxJsxTextElement } from "mdast-util-mdx";
+
+import { extractMdxJsxAttributes } from "./common";
+
+export function sdkChangelog() {
+  // markdown link to https://developers.portone.io/sdk/ko/v2-sdk/changelog
+  return {
+    type: "link",
+    url: "https://developers.portone.io/sdk/ko/v2-sdk/changelog",
+    children: [
+      {
+        type: "text",
+        value: "SDK Changelog",
+      },
+    ],
+  };
+}
+
+/**
+ * SDKParameter 컴포넌트를 마크다운으로 변환하는 함수
+ * <SDKParameter path="#/resources/request/IssueBillingKeyAndPayRequest" ident="request" optional />
+ *
+ * 변환 결과:
+ * - request?: IssueBillingKeyAndPayRequest
+ *   [definition link](https://developers.portone.io/schema/browser-sdk.yml#/resources/request/IssueBillingKeyAndPayRequest)
+ *
+ * @param node SDKParameter 컴포넌트 노드
+ * @returns 변환된 노드
+ */
+export function handleSDKParameterComponent(
+  node: MdxJsxFlowElement | MdxJsxTextElement,
+): { ast: Root; unhandledTags: Set<string> } {
+  const props = extractMdxJsxAttributes(node);
+  const path = props.path as string;
+  const ident = props.ident as string | undefined;
+  const isOptional = "optional" in props;
+
+  // If there's no path, throw an error.
+  if (!path) {
+    throw new Error("No path found in SDKParameter.");
+  }
+
+  // Extract type name from the path
+  const typeName = path.split("/").pop() || "";
+
+  // Create the parameter definition text node
+  const identText = ident ? `${ident}${isOptional ? "?" : ""}: ` : "";
+  const parameterDefText: Text = {
+    type: "text",
+    value: `${identText}${typeName}`,
+  };
+
+  // Create the paragraph containing the parameter definition
+  const parameterDefParagraph: Paragraph = {
+    type: "paragraph",
+    children: [parameterDefText],
+  };
+
+  // Create the definition link
+  const linkUrl = `https://developers.portone.io/schema/browser-sdk.yml${path}`;
+  const linkText: Text = {
+    type: "text",
+    value: "definition link",
+  };
+
+  const definitionLink: Link = {
+    type: "link",
+    url: linkUrl,
+    title: null,
+    children: [linkText],
+  };
+
+  const linkParagraph: Paragraph = {
+    type: "paragraph",
+    children: [definitionLink],
+  };
+
+  // Create the list item with the parameter definition and link
+  const listItemChildren: BlockContent[] = [
+    parameterDefParagraph,
+    linkParagraph,
+  ];
+
+  // Create the list item node
+  const parameterLine: ListItem = {
+    type: "listItem",
+    spread: true,
+    children: listItemChildren,
+  };
+
+  return {
+    ast: {
+      type: "root",
+      children: [parameterLine],
+    } as Root,
+    unhandledTags: new Set<string>(),
+  };
+}


### PR DESCRIPTION
- `Parameter.TypeDef`, `SDKChangelog`, `SDKParameter`, `img`, `A`, `File` 등 미지원 JSX 태그들에 대한 마크다운 변환을 추가했습니다.
- 기타 html tag들에 대해서는 마크다운 내에서도 그대로 유지되도록 개선했습니다.
- import statement를 통해 임베딩되는 mdx 문서들이 마크다운 변환 시에도 문서 내에 첨부되도록 개선했습니다.

위 변경사항은 `llms-txt` `docs-for-llms` 스크립트에 반영됩니다.