### PR TITLE
`llms-txt`, `docs-for-llms` 스크립트 리팩토링

### DIFF
--- a/scripts/docs-for-llms/README.md
+++ b/scripts/docs-for-llms/README.md
@@ -1,11 +1,21 @@
-# docs-for-llms
+# docs-for-llms 생성 스크립트
 
-PortOne 개발자 문서를 LLM(Large Language Model)에 최적화된 형태로 변환하는 스크립트입니다.
-실행하면 `docs-for-llms/` 디렉토리가 생성됩니다.
+이 디렉토리에는 PortOne 개발자 문서를 LLM(Large Language Model)에 최적화된 형태로 변환하는 스크립트가 포함되어 있습니다. 실행하면 `docs-for-llms/` 디렉토리가 생성됩니다.
 
-## 기능
+- `index.ts`: 메인 스크립트 파일로, 실행 흐름을 관리
+- `parseUtils.ts`: MDX 파싱 관련 유틸리티 함수
 
-이 스크립트는 다음과 같은 기능을 수행합니다:
+## 사용법
+
+```bash
+pnpm docs-for-llms
+```
+
+이 명령어는 모든 MDX 파일을 마크다운으로 변환하고, 스키마 파일을 복사한 후 버전별 문서 파일을 생성합니다.
+
+## 동작
+
+이 스크립트는 다음과 같은 동작을 수행합니다:
 
 1. MDX 파일을 파싱하여 마크다운 형식으로 변환
 2. 변환된 마크다운 파일을 `docs-for-llms` 디렉토리에 저장
@@ -13,16 +23,37 @@ PortOne 개발자 문서를 LLM(Large Language Model)에 최적화된 형태로 
 4. 목차가 포함된 README.md 파일 생성
 5. 버전별 전체 문서 파일(v1-docs-full.md, v2-docs-full.md) 생성
 
-## 사용 방법
+## 파일 생성 로직
 
-```bash
-# 프로젝트 루트 디렉토리에서 실행
-pnpm docs-for-llms
-```
+- `README.md` 생성:
+  - 모든 문서를 카테고리별로 정리
+  - 각 문서의 링크와 설명을 포함
+- `v1-docs-full.md` 생성:
+  - V1 API 관련 모든 문서가 통합된 파일
+  - 마크다운 형식으로 저장
+- `v2-docs-full.md` 생성:
+  - V2 API 관련 모든 문서가 통합된 파일
+  - 마크다운 형식으로 저장
 
-## 출력 결과
+## 문서 분류 로직
 
-스크립트 실행 후 다음과 같은 파일과 디렉토리가 생성됩니다:
+문서는 다음 기준으로 분류됩니다:
+
+1. 버전별 분류:
+
+   - V1 전용 문서: frontmatter의 `targetVersions`에 "v1"만 포함
+   - V2 전용 문서: frontmatter의 `targetVersions`에 "v2"만 포함
+   - 공통 문서: `targetVersions`가 비어있거나, "v1"과 "v2" 모두 포함
+
+2. 카테고리별 분류:
+   - SDK 문서: `sdk/` 경로로 시작하는 문서
+   - API 문서: `api/` 경로로 시작하는 문서
+   - 릴리스 노트: `release-notes/` 경로로 시작하는 문서
+   - 블로그: `blog/posts/` 경로로 시작하는 문서
+   - 파트너정산: `platform/` 경로로 시작하는 문서
+   - 기타 문서: 위 카테고리에 속하지 않는 문서
+
+## 출력 파일
 
 - `docs-for-llms/`: 모든 변환된 문서가 저장되는 루트 디렉토리
   - `README.md`: 모든 문서의 목차와 링크가 포함된 파일
@@ -31,35 +62,7 @@ pnpm docs-for-llms
   - `schema/`: API 스키마 파일이 저장되는 디렉토리
     - `v1.openapi.yml`, `v1.openapi.json`: V1 API 스키마
     - `v2.graphql`, `v2.openapi.yml`, `v2.openapi.json`: V2 API 스키마
+    - `browser-sdk.yml`: V2 브라우저 SDK 스키마
   - 각 문서별 마크다운 파일 (원본 경로 구조 유지)
 
-## 문서 분류 방식
-
-스크립트는 다음과 같은 기준으로 문서를 분류합니다:
-
-1. **버전별 분류**:
-
-   - V1 전용 문서: frontmatter의 `targetVersions`에 "v1"만 포함
-   - V2 전용 문서: frontmatter의 `targetVersions`에 "v2"만 포함
-   - 공통 문서: `targetVersions`가 비어있거나, "v1"과 "v2" 모두 포함
-
-2. **카테고리별 분류**:
-   - SDK 문서: `sdk/` 경로로 시작하는 문서
-   - API 문서: `api/` 경로로 시작하는 문서
-   - 릴리스 노트: `release-notes/` 경로로 시작하는 문서
-   - 블로그: `blog/posts/` 경로로 시작하는 문서
-   - 파트너정산: `platform/` 경로로 시작하는 문서
-   - 기타 문서: 위 카테고리에 속하지 않는 문서
-
-## 주요 함수
-
-- `parseAllMdxFiles()`: MDX 파일을 파싱하여 결과를 맵으로 반환
-- `transformAllMdxToAst()`: MDX 파일의 AST를 마크다운용 AST로 변환
-- `saveMarkdownFiles()`: 변환된 AST를 마크다운 파일로 저장
-- `generateDocsForLlms()`: docs-for-llms 디렉토리를 생성하고 마크다운 파일들을 저장
-
-## 참고 사항
-
-- 이 스크립트는 프로젝트 루트 디렉토리에서 실행해야 합니다.
-- 스크립트 실행 전 필요한 의존성이 설치되어 있어야 합니다.
-- 생성된 문서는 LLM에 최적화된 형태로, 웹 링크와 마크다운 형식을 유지합니다.
+위 파일들은 LLM에 최적화된 형태로, 웹 링크와 마크다운 형식을 유지합니다.

--- a/scripts/docs-for-llms/index.ts
+++ b/scripts/docs-for-llms/index.ts
@@ -1,9 +1,9 @@
 import type { MdxParseResult } from "../mdx-to-markdown/mdx-parser";
 import {
-  generateDocsForLlms,
   parseAllMdxFiles,
-  transformAllMdxToAst,
-} from "./generator";
+  transformAllMdxsToAsts,
+} from "../mdx-to-markdown/utils";
+import { generateDocsForLlms } from "./generator";
 
 /**
  * 메인 함수
@@ -20,7 +20,7 @@ export async function main() {
       await parseAllMdxFiles();
 
     // MDX 파일을 마크다운 AST로 변환 (웹페이지 링크 사용)
-    const transformedAstMap = transformAllMdxToAst(fileParseMap, false);
+    const transformedAstMap = transformAllMdxsToAsts(fileParseMap, false);
 
     // 변환된 AST를 재사용하여 docs-for-llms 디렉토리 생성
     const docsForLlmsPath = await generateDocsForLlms(

--- a/scripts/llms-txt/README.md
+++ b/scripts/llms-txt/README.md
@@ -2,42 +2,31 @@
 
 이 디렉터리에는 MDX 파일을 마크다운으로 변환하고 [llms.txt 표준](https://llmstxt.org/)에 맞게 llms.txt, llms-full.txt, llms-small.txt 파일을 생성하는 스크립트가 포함되어 있습니다.
 
-## 파일 구조
-
 - `index.ts`: 메인 스크립트 파일로, 실행 흐름을 관리
-- `generator.ts`: 마크다운 생성 및 llms.txt 파일 생성 로직을 포함
-- `scripts/mdx-to-markdown/`: MDX를 마크다운으로 변환하는 모듈 (자세한 내용은 해당 디렉터리의 README.md 참조)
+- `generator.ts`: llms.txt 관련 파일 생성 로직
 
-## 기능
+## 사용법
 
-이 스크립트는 다음과 같은 기능을 제공합니다:
+```bash
+pnpm llms-txt
+```
+
+이 명령어는 모든 MDX 파일을 마크다운으로 변환하고, 스키마 파일을 복사한 후 llms.txt, llms-full.txt, llms-small.txt 파일을 생성합니다.
+
+## 동작
+
+이 스크립트는 다음과 같은 동작을 수행합니다:
 
 1. MDX 파일을 파싱하여 frontmatter, slug, 파일 경로, imports, AST를 추출
 2. SolidJS 커스텀 컴포넌트를 마크다운으로 변환
 3. 변환된 마크다운 파일을 `public/` 디렉터리에 저장
-4. 다음 세 가지 형식의 파일 생성:
+4. `public/schema` 디렉터리의 모든 파일을 `public/schema` 디렉터리로 복사
+5. 다음 세 가지 형식의 파일 생성:
    - `llms.txt`: 모든 문서의 링크와 설명을 카테고리별로 정리한 파일
    - `llms-full.txt`: `llms.txt`의 내용과 함께 모든 문서의 전체 내용을 포함
    - `llms-small.txt`: `llms.txt`와 동일한 내용 (문서 링크와 설명만 포함)
 
 ## 파일 생성 로직
-
-### parseAllMdxFiles
-
-- `src/routes/` 디렉터리에서 모든 MDX 파일을 찾아 파싱
-- 각 파일의 frontmatter, slug, 파일 경로, imports, AST를 추출하여 맵으로 반환
-
-### transformAllMdxToAst
-
-- 파싱된 MDX 파일들의 AST를 마크다운용 AST로 변환
-- SolidJS 커스텀 컴포넌트를 표준 마크다운 구문으로 변환
-
-### saveMarkdownFiles
-
-- 변환된 AST를 마크다운 문자열로 변환하여 `public/` 디렉터리에 저장
-- 각 MDX 파일에 대응하는 마크다운 파일을 생성
-
-### generateLlmsTxtFiles
 
 - `llms.txt` 생성:
   - 모든 문서를 카테고리별로 정리 (공통, V1, V2, 파트너정산, 릴리스 노트, 블로그)
@@ -67,18 +56,13 @@
    - `["v2"]`: V2 전용 문서
    - 기타: 공통 문서로 처리
 
-## 사용법
-
-```bash
-pnpm llms-txt
-```
-
-이 명령어는 모든 MDX 파일을 마크다운으로 변환하고, llms.txt, llms-full.txt, llms-small.txt 파일을 생성합니다.
-
 ## 출력 파일
 
 - 개별 마크다운 파일: `public/{slug}.md`
+- 스키마 파일: `public/schema/{file}`
 - llms.txt 파일들:
   - `public/llms.txt`: 문서 목록과 링크
   - `public/llms-full.txt`: 모든 문서의 전체 내용
   - `public/llms-small.txt`: `llms.txt`와 동일한 내용
+
+위 파일들은 배포 시 정적 리소스로 사용자가 접근할 수 있습니다.

--- a/scripts/mdx-to-markdown/utils.ts
+++ b/scripts/mdx-to-markdown/utils.ts
@@ -1,0 +1,250 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import fastGlob from "fast-glob";
+import type { Root } from "mdast";
+
+import { astToMarkdownString, transformAstForMarkdown } from "./index";
+import { type MdxParseResult, parseMdxFile } from "./mdx-parser";
+
+// 프로젝트 경로 설정
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = join(__dirname, "../..");
+
+// 문서 카테고리 경로 접두사 정의
+export const PATH_PREFIXES = {
+  RELEASE_NOTES: "release-notes/",
+  BLOG: "blog/posts/",
+  API: "api/",
+  SDK: "sdk/",
+  PLATFORM: "platform/",
+};
+
+/**
+ * 모든 MDX 파일을 파싱하고 결과를 맵으로 반환하는 함수
+ * @returns 파일 경로(slug)와 파싱 결과를 매핑한 객체
+ */
+export async function parseAllMdxFiles(): Promise<
+  Record<string, MdxParseResult>
+> {
+  // MDX 파일 찾기
+  const mdxFiles = await fastGlob(["src/routes/**/*.mdx"], {
+    cwd: rootDir,
+  });
+
+  console.log(`총 ${mdxFiles.length}개의 MDX 파일을 찾았습니다.`);
+
+  // 파일 경로와 파싱 결과를 매핑할 객체
+  const fileParseMap: Record<string, MdxParseResult> = {};
+
+  // 각 MDX 파일 처리
+  for (const mdxFile of mdxFiles) {
+    try {
+      // MDX 파싱
+      const parseResult = await parseMdxFile(mdxFile);
+
+      // 객체에 파싱 결과 저장 (slug를 키로 사용)
+      fileParseMap[parseResult.slug] = parseResult;
+    } catch (error) {
+      console.error(`${mdxFile} 파싱 중 오류 발생:`, error);
+    }
+  }
+
+  return fileParseMap;
+}
+
+/**
+ * 모든 MDX 파일의 AST를 마크다운용 AST로 변환하는 함수
+ * @param fileParseMap 파일 경로와 파싱 결과를 매핑한 객체
+ * @param useMarkdownLinks 내부 링크를 마크다운 파일 링크로 변환할지 여부 (true: 마크다운 파일 링크, false: 웹페이지 링크)
+ * @returns 변환된 AST 노드 매핑 (slug -> Node)
+ */
+export function transformAllMdxsToAsts(
+  fileParseMap: Record<string, MdxParseResult>,
+  useMarkdownLinks: boolean = true,
+): Record<string, Root> {
+  // 변환된 AST 노드를 저장할 객체
+  const transformedAstMap: Record<string, Root> = {};
+
+  // 각 파싱 결과의 AST 변환
+  const allUnhandledTags: Set<string> = new Set();
+  for (const slug of Object.keys(fileParseMap)) {
+    try {
+      // AST 변환 (useMarkdownLinks 파라미터 전달)
+      const { ast, unhandledTags } = transformAstForMarkdown(
+        slug,
+        fileParseMap,
+        useMarkdownLinks,
+      );
+      transformedAstMap[slug] = ast;
+      for (const tag of unhandledTags) {
+        allUnhandledTags.add(tag);
+      }
+    } catch (error) {
+      console.error(
+        `${fileParseMap[slug]?.filePath} AST 변환 중 오류 발생:`,
+        error,
+      );
+    }
+  }
+
+  console.log(
+    `${Object.keys(transformedAstMap).length}개의 MDX 파일 AST 변환이 완료되었습니다.`,
+  );
+
+  if (allUnhandledTags.size > 0) {
+    console.log(
+      `처리되지 않은 태그: ${Array.from(allUnhandledTags).join(", ")}`,
+    );
+  }
+  return transformedAstMap;
+}
+
+/**
+ * 변환된 AST를 마크다운 파일로 저장하는 함수
+ * @param fileParseMap 파일 경로와 파싱 결과를 매핑한 객체
+ * @param transformedAstMap 변환된 AST 노드 매핑 (slug -> Node)
+ * @param outputDir 출력 디렉토리 경로
+ */
+export async function saveMarkdownFiles(
+  fileParseMap: Record<string, MdxParseResult>,
+  transformedAstMap: Record<string, Root>,
+  outputDir: string,
+): Promise<void> {
+  // 각 변환된 AST를 마크다운 파일로 저장
+  for (const slug of Object.keys(transformedAstMap)) {
+    try {
+      const transformedAst = transformedAstMap[slug];
+      if (transformedAst == null)
+        throw new Error(`${slug}에 대한 AST를 찾을 수 없습니다.`);
+
+      // 마크다운 문자열로 변환
+      const markdown = astToMarkdownString(
+        transformedAst,
+        fileParseMap[slug]?.frontmatter,
+      );
+
+      // 출력 경로 생성
+      const outputPath = join(outputDir, `${slug}.md`);
+
+      // 디렉토리 생성
+      await mkdir(dirname(outputPath), { recursive: true });
+
+      // 파일 저장
+      await writeFile(outputPath, markdown, "utf-8");
+    } catch (error) {
+      console.error(
+        `${fileParseMap[slug]?.filePath} 마크다운 저장 중 오류 발생:`,
+        error,
+      );
+    }
+  }
+
+  console.log("마크다운 파일 저장이 완료되었습니다.");
+}
+
+/**
+ * 카테고리별 슬러그 필터링 함수
+ * @param slugs 필터링할 슬러그 목록
+ * @param categoryPrefix 카테고리 접두사
+ * @returns 필터링된 슬러그 목록
+ */
+export function filterSlugsByCategory(
+  slugs: string[],
+  categoryPrefix: string,
+): string[] {
+  return slugs.filter((slug) => slug.startsWith(categoryPrefix));
+}
+
+/**
+ * 버전별 슬러그 분류 함수
+ * @param slugs 분류할 슬러그 목록
+ * @param fileParseMap 파일 파싱 결과 맵
+ * @returns 버전별로 분류된 슬러그 목록 객체
+ */
+export function categorizeSlugsByVersion(
+  slugs: string[],
+  fileParseMap: Record<string, MdxParseResult>,
+): { v1Slugs: string[]; v2Slugs: string[]; commonSlugs: string[] } {
+  const v1Slugs: string[] = [];
+  const v2Slugs: string[] = [];
+  const commonSlugs: string[] = [];
+
+  // 각 슬러그를 버전별로 분류
+  for (const slug of slugs) {
+    const parseResult = fileParseMap[slug];
+    const targetVersions = parseResult?.frontmatter.targetVersions || [];
+
+    // targetVersions가 ["v1", "v2"] 이거나 빈 배열이면 공용 문서로 취급
+    if (
+      targetVersions.length === 0 ||
+      (targetVersions.includes("v1") && targetVersions.includes("v2"))
+    ) {
+      commonSlugs.push(slug);
+    }
+    // v1 문서
+    else if (targetVersions.includes("v1")) {
+      v1Slugs.push(slug);
+    }
+    // v2 문서
+    else if (targetVersions.includes("v2")) {
+      v2Slugs.push(slug);
+    }
+    // 버전 정보가 없으면 공용 문서로 취급
+    else {
+      commonSlugs.push(slug);
+    }
+  }
+
+  return { v1Slugs, v2Slugs, commonSlugs };
+}
+
+/**
+ * 슬러그 그룹을 버전별로 분류하는 함수
+ * @param slugs 모든 슬러그 목록
+ * @param fileParseMap 파일 파싱 결과 맵
+ * @returns 카테고리 및 버전별로 분류된 슬러그 목록 객체
+ */
+export function categorizeSlugs(
+  slugs: string[],
+  fileParseMap: Record<string, MdxParseResult>,
+): {
+  releaseNoteSlugs: string[];
+  blogSlugs: string[];
+  platformSlugs: string[];
+  v1Slugs: string[];
+  v2Slugs: string[];
+  commonSlugs: string[];
+} {
+  // 릴리즈 노트, 블로그, 파트너정산 슬러그 먼저 필터링
+  const releaseNoteSlugs = filterSlugsByCategory(
+    slugs,
+    PATH_PREFIXES.RELEASE_NOTES,
+  );
+  const blogSlugs = filterSlugsByCategory(slugs, PATH_PREFIXES.BLOG);
+  const platformSlugs = filterSlugsByCategory(slugs, PATH_PREFIXES.PLATFORM);
+
+  // 릴리즈 노트, 블로그, 파트너정산을 제외한 나머지 슬러그들만 버전별로 분류
+  const remainingSlugs = slugs.filter(
+    (slug) =>
+      !slug.startsWith(PATH_PREFIXES.RELEASE_NOTES) &&
+      !slug.startsWith(PATH_PREFIXES.BLOG) &&
+      !slug.startsWith(PATH_PREFIXES.PLATFORM),
+  );
+
+  // 버전별 분류
+  const { v1Slugs, v2Slugs, commonSlugs } = categorizeSlugsByVersion(
+    remainingSlugs,
+    fileParseMap,
+  );
+
+  return {
+    releaseNoteSlugs,
+    blogSlugs,
+    platformSlugs,
+    v1Slugs,
+    v2Slugs,
+    commonSlugs,
+  };
+}


### PR DESCRIPTION
`pnpm llms-txt`, `pnpm docs-for-llms`에 존재하는 공통 로직 중 `scripts/mdx-to-markdown`에 포함될 수 있는 것들을 `scripts/mdx-to-markdown/utils.ts`로 옮겨 리팩토링했습니다.