### PR TITLE
`llms-small.txt`에 문서별 프론트매터 추가

### DIFF
--- a/scripts/llms-txt/generator.ts
+++ b/scripts/llms-txt/generator.ts
@@ -9,7 +9,7 @@ import { join } from "node:path";
 
 import type { Root } from "mdast";
 
-import { astToMarkdownString } from "../mdx-to-markdown";
+import { astToMarkdownString, frontmatterToString } from "../mdx-to-markdown";
 import { type MdxParseResult } from "../mdx-to-markdown/mdx-parser";
 import {
   categorizeSlugs,
@@ -260,10 +260,24 @@ export async function generateLlmsTxtFiles(
   await writeFile(llmsFullTxtPath, fullContent, "utf-8");
   console.log(`llms-full.txt 파일이 생성되었습니다: ${llmsFullTxtPath}`);
 
-  // llms-small.txt 파일 생성 (llms.txt와 동일한 내용으로)
-  // llms.txt의 내용을 그대로 사용합니다
+  // llms-small.txt 파일 생성 (llms.txt 내용 + 각 문서의 링크와 프론트매터)
+  let smallContent = llmsTxtContent;
+
+  // 각 문서의 링크와 프론트매터 추가
+  for (const slug of slugs) {
+    const frontmatter = fileParseMap[slug]?.frontmatter;
+    if (frontmatter) {
+      // h1 헤딩으로 문서 링크 추가
+      smallContent += `\n\n# https://developers.portone.io/${slug}.md`;
+
+      // 프론트매터 추가 (frontmatterToString 함수 사용)
+      const frontmatterStr = frontmatterToString(frontmatter);
+      smallContent += `\n\n${frontmatterStr}`;
+    }
+  }
+
   const llmsSmallTxtPath = join(outputDir, "llms-small.txt");
-  await writeFile(llmsSmallTxtPath, llmsTxtContent, "utf-8");
+  await writeFile(llmsSmallTxtPath, smallContent, "utf-8");
   console.log(`llms-small.txt 파일이 생성되었습니다: ${llmsSmallTxtPath}`);
 
   return llmsTxtPath;

--- a/scripts/mdx-to-markdown/index.ts
+++ b/scripts/mdx-to-markdown/index.ts
@@ -63,6 +63,18 @@ export function transformAstForMarkdown(
 }
 
 /**
+ * 프론트매터 객체를 문자열로 변환하는 함수
+ * thumbnail 필드를 제외하고 YAML 형식으로 변환
+ * @param frontmatter 프론트매터 객체
+ * @returns 프론트매터 문자열 (YAML 형식)
+ */
+export function frontmatterToString(frontmatter: Frontmatter): string {
+  // thumbnail 필드를 제외한 프론트매터 생성
+  const { thumbnail: _thumbnail, ...filteredFrontmatter } = frontmatter;
+  return `---\n${yaml.dump(filteredFrontmatter)}---`;
+}
+
+/**
  * 변환된 AST를 마크다운 문자열로 변환하는 함수
  * 프론트매터를 포함한 완전한 마크다운 문자열을 생성
  * remark 설정을 통해 GitHub Flavored Markdown 형식으로 출력
@@ -75,12 +87,9 @@ export function astToMarkdownString(
   frontmatter?: Frontmatter,
 ): string {
   // 프론트매터 문자열 생성
-  let frontmatterStr = "";
-  if (frontmatter && Object.keys(frontmatter).length > 0) {
-    // thumbnail 필드를 제외한 프론트매터 생성
-    const { thumbnail: _thumbnail, ...filteredFrontmatter } = frontmatter;
-    frontmatterStr = `---\n${yaml.dump(filteredFrontmatter)}---\n\n`;
-  }
+  const frontmatterStr = frontmatter
+    ? frontmatterToString(frontmatter) + "\n\n"
+    : "";
 
   // 마크다운으로 변환
   const processor = unified()


### PR DESCRIPTION
`llms-small.txt` 의 기존 내용 이후에 각 문서별 프론트매터가 아래와 같은 형식으로 추가됩니다.

<img width="569" alt="image" src="https://github.com/user-attachments/assets/4393cb5f-a225-41b0-b7c8-7c373376c6a0" />
