### PR TITLE
`AI 도구 활용하기` 문서 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ public/llms-small.txt
 
 # docs-for-llms 관련 자동 생성 디렉토리
 /docs-for-llms/
+public/docs-for-llms.zip

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"repository": "https://github.com/portone-io/developers.portone.io",
 	"scripts": {
 		"dev": "pnpm update-schema && concurrently -k \"vinxi dev\" \"pnpm gen-collections watch\"",
-		"build": "pnpm update-schema && pnpm gen-collections && pnpm llms-txt && vinxi build",
+		"build": "pnpm update-schema && pnpm gen-collections && pnpm llms-txt && pnpm docs-for-llms && vinxi build",
 		"start": "NODE_OPTIONS='--import ./.output/server/instrument.server.mjs ' vinxi start",
 		"version": "vinxi version",
 		"check": "pnpm update-schema && pnpm lint",

--- a/scripts/docs-for-llms/README.md
+++ b/scripts/docs-for-llms/README.md
@@ -1,6 +1,6 @@
 # docs-for-llms 생성 스크립트
 
-이 디렉토리에는 PortOne 개발자 문서를 LLM(Large Language Model)에 최적화된 형태로 변환하는 스크립트가 포함되어 있습니다. 실행하면 `docs-for-llms/` 디렉토리가 생성됩니다.
+이 디렉토리에는 PortOne 개발자 문서를 LLM(Large Language Model)에 최적화된 형태로 변환하는 스크립트가 포함되어 있습니다. 실행하면 `docs-for-llms/` 디렉토리와 `public/docs-for-llms.zip` 파일이 생성됩니다.
 
 - `index.ts`: 메인 스크립트 파일로, 실행 흐름을 관리
 - `parseUtils.ts`: MDX 파싱 관련 유틸리티 함수
@@ -22,6 +22,7 @@ pnpm docs-for-llms
 3. 스키마 파일(OpenAPI, GraphQL)을 `docs-for-llms/schema` 디렉토리에 복사
 4. 목차가 포함된 README.md 파일 생성
 5. 버전별 전체 문서 파일(v1-docs-full.md, v2-docs-full.md) 생성
+6. `docs-for-llms` 디렉토리와 `public/docs-for-llms.zip` 파일 생성
 
 ## 파일 생성 로직
 
@@ -64,5 +65,6 @@ pnpm docs-for-llms
     - `v2.graphql`, `v2.openapi.yml`, `v2.openapi.json`: V2 API 스키마
     - `browser-sdk.yml`: V2 브라우저 SDK 스키마
   - 각 문서별 마크다운 파일 (원본 경로 구조 유지)
+- `public/docs-for-llms.zip`: 압축된 디렉토리
 
 위 파일들은 LLM에 최적화된 형태로, 웹 링크와 마크다운 형식을 유지합니다.

--- a/scripts/docs-for-llms/generator.ts
+++ b/scripts/docs-for-llms/generator.ts
@@ -1,6 +1,8 @@
+import { exec } from "node:child_process";
 import { cp, mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
 
 import fastGlob from "fast-glob";
 import type { Root } from "mdast";
@@ -20,6 +22,7 @@ const guideForLlmsFilePath = join(rootDir, "scripts", "guide-for-llms.md");
 const schemaDir = join(rootDir, "src", "schema");
 const docsForLlmsDir = join(rootDir, "docs-for-llms");
 const docsForLlmsSchemaDir = join(docsForLlmsDir, "schema");
+const publicDir = join(rootDir, "public");
 
 /**
  * docs-for-llms 디렉토리를 생성하고 마크다운 파일들을 저장하는 함수
@@ -381,5 +384,31 @@ author: PortOne
 
   await generateFullDocFile(join(docsForLlmsDir, "v2-docs-full.md"), "V2");
 
+  // 디렉토리를 zip 파일로 압축하고 public 디렉토리로 복사
+  await compressAndCopyToPublic();
+
   return docsForLlmsDir;
+}
+
+/**
+ * docs-for-llms 디렉토리를 zip 파일로 압축하여 public 디렉토리에 직접 저장하는 함수
+ */
+async function compressAndCopyToPublic(): Promise<void> {
+  console.log("docs-for-llms 디렉토리를 압축하는 중...");
+
+  try {
+    // zip 파일 이름 설정
+    const zipFileName = "docs-for-llms.zip";
+    const publicZipFilePath = join(publicDir, zipFileName);
+
+    // zip 명령어 실행 (macOS에 기본 내장) - 직접 public 디렉토리에 압축 파일 생성
+    const cmd = `cd "${rootDir}" && zip -r "${publicZipFilePath}" docs-for-llms`;
+
+    await promisify(exec)(cmd);
+
+    console.log(`${zipFileName} 파일이 public 디렉토리에 생성되었습니다.`);
+  } catch (error) {
+    console.error("압축 중 오류 발생:", error);
+    throw error;
+  }
 }

--- a/scripts/guide-for-llms.md
+++ b/scripts/guide-for-llms.md
@@ -15,7 +15,7 @@
 5. 사용자에게 문서 레퍼런스를 URL로 제공할 때는 마크다운 파일 링크가 아닌, 개발자센터 웹사이트 URL을 사용하세요.
 
    - `.md`로 끝나는 URL은 마크다운 파일 링크입니다. 마크다운 파일 링크에서 마지막 `.md`를 제거하면 웹사이트 URL로 사용할 수 있습니다.
-   - 단, `_components` 가 URL에 포함된 경우 웹사이트 URL로 사용할 수 없음에 주의하세요.
+   - 단, `_components` 등 underscore로 시작하는 path segment가 URL에 포함된 경우 웹사이트 URL로 사용할 수 없음에 주의하세요.
    - 사용자가 원하는 버전(V1, V2)이 특정되었다면 `?v=v2`, `?v=v1` 쿼리 파라미터를 추가하여 URL로 제공하세요.
    - hostname이 누락된 URL의 경우 `https://developers.portone.io`를 추가하세요.
 

--- a/scripts/mdx-to-markdown/jsx/importedMdx.ts
+++ b/scripts/mdx-to-markdown/jsx/importedMdx.ts
@@ -47,7 +47,9 @@ export function validateImportedMdx(
   const subSlug = importPath
     .replace(/^\.\//, `${parentSlug}/`)
     .replace(/^~\//, "")
-    .replace(/^[./]+/, "") // Remove any leading ./ ../ ~/ or combinations
+    .replace(/^routes\//, "")
+    .replace(/^\(root\)\//, "")
+    .replace(/^[./]+/, "") // Remove any leading ./ ../ or combinations
     .replace(/\.mdx$/, ""); // Remove .mdx extension
 
   // Find the MDX parse result for this slug

--- a/src/routes/(root)/_components/ko/docs-for-llms.mdx
+++ b/src/routes/(root)/_components/ko/docs-for-llms.mdx
@@ -1,0 +1,22 @@
+---
+title: LLM을 위한 개발자센터 문서 디렉터리 지원
+description: LLM을 위한 개발자센터 문서 디렉터리와 사용 방법을 설명합니다.
+targetVersions: ["v1", "v2"]
+---
+
+import File from "~/components/gitbook/File";
+import { prose } from "~/components/prose";
+
+Cursor, Windsurf, Claude Code와 같이 코드베이스 맥락을 자동으로 분석하는 AI 도구를 사용하는 경우,
+LLM을 위한 포트원 문서 디렉터리를 다운받아 작업 중인 코드베이스 내에 위치시키는 방식으로도 활용할 수 있습니다.
+
+이 경우, 위 AI 도구들이 제공하는 임베딩 기반 색인과 RAG (Retrieval Augmented Generation) 검색이 자동적으로 적용되어
+보다 원활히 원하는 결과를 얻으실 수 있습니다.
+
+<File src="/docs-for-llms.zip" captionInside="LLM 전용 포트원 문서 디렉터리 다운로드" />
+
+<prose.h3>사용 방법</prose.h3>
+
+1. 위 링크를 눌러 LLM 전용 포트원 문서 압축 파일을 다운로드합니다.
+2. 압축을 해제하고, 해당 디렉터리를 작업 중인 코드베이스 내에 위치시킵니다.
+3. 포트원 관련 질의 시 AI에게 해당 디렉터리를 태그하여 질의합니다.

--- a/src/routes/(root)/_components/ko/llms-txt-support.mdx
+++ b/src/routes/(root)/_components/ko/llms-txt-support.mdx
@@ -1,0 +1,13 @@
+---
+title: llms.txt 표준 지원
+description: 포트원이 지원하는 llms.txt 표준에 대한 내용입니다.
+targetVersions: ["v1", "v2"]
+---
+
+포트원 개발자센터 웹사이트는 [llms.txt 표준](https://llmstxt.org)을 준수하며, LLM이 문서 정보를 쉽게 조회할 수 있도록 지원하고 있습니다.
+
+- [llms.txt](https://developers.portone.io/llms.txt): LLM을 위한 가이드 및 문서 목차를 포함합니다.
+- [llms-full.txt](https://developers.portone.io/llms-full.txt): llms.txt에 더해 모든 문서 내용을 추가로 포함합니다.
+- [llms-small.txt](https://developers.portone.io/llms-small.txt): llms.txt에 더해 모든 문서의 메타 정보만 추가로 포함합니다.
+
+llms.txt, llms-small.txt를 사용하는 AI 어시스턴트의 프롬프트에 포함하거나, llms-full.txt를 파일로 업로드해 질의하는 방식으로도 활용이 가능합니다.

--- a/src/routes/(root)/_components/ko/using-mcp-server.mdx
+++ b/src/routes/(root)/_components/ko/using-mcp-server.mdx
@@ -1,0 +1,59 @@
+---
+title: 포트원 MCP (Model Context Protocol) 서버 사용하기
+description: 포트원이 제공하는 MCP (Model Context Protocol) 서버 사용 방법을 안내합니다.
+targetVersions: ["v1", "v2"]
+---
+
+import Hint from "~/components/Hint";
+import { prose } from "~/components/prose";
+
+포트원은 쉬운 연동과 빠른 개발을 위해 MCP 서버를 제공합니다. [(GitHub 저장소 바로가기)](https://github.com/portone-io/mcp-server)
+
+포트원 MCP 서버는 개발자센터 문서 내용을 AI에게 제공하여,
+AI가 보다 정확하고 구체적인 정보를 바탕으로 사용자의 연동 및 질의를 돕도록 합니다.
+
+<prose.h3>1. MCP 서버 등록하기</prose.h3>
+
+포트원 MCP 서버를 사용하기 위해서는 먼저 사용하는 AI 도구에 서버를 등록해야 합니다.
+
+Cursor, Windsurf, Claude Code, Claude for Desktop 등 다양한 AI 도구의 설정 파일에서 아래 내용을 추가하여 MCP 서버를 등록할 수 있습니다.
+
+```json
+{
+  // ...
+
+  "mcpServers": {
+    // ...
+
+    "portone-mcp-server": {
+      "command": "uvx",
+      "args": ["portone-mcp-server"]
+    }
+  }
+}
+```
+
+<Hint style="info">
+  사용 환경에 [uv](https://docs.astral.sh/uv/getting-started/installation/)가 설치되어 있어야 합니다.
+</Hint>
+
+설정 파일 수정이 완료된 후 AI 도구를 재시작하면 MCP 서버가 적용됩니다.
+
+<prose.h3>2. MCP 서버 활용하기</prose.h3>
+
+사용 중인 AI 도구에 포트원 MCP 서버가 적용되었다면, 아래 예시들과 같이 질의하여 사용할 수 있습니다.
+
+<prose.h4>개발 관련 프롬프트 예시</prose.h4>
+
+- _"포트원 V2 Python 서버 SDK를 사용해서 서버 연동 코드를 작성해줘"_
+- _"포트원 V2 Kotlin 서버 SDK를 사용해 웹훅 검증을 구현해줘"_
+- _"포트원 V1 브라우저 SDK를 사용한 페이팔 결제창 호출을 구현해줘"_
+- _"파트너정산 자동화 서비스에 파트너 등록하는 코드를 타입스크립트로 구현해줘"_
+- _"포트원 V2 본인인증 기능 연동해줘"_
+
+<prose.h4>전반적인 질의 예시</prose.h4>
+
+- _"포트원 V2와 V1의 차이점을 설명해줘"_
+- _"포트원 V2가 지원하는 PG사 목록 보여줘"_
+- _"포트원 API의 하위호환성 정책 설명해줘"_
+- _"포트원 파트너정산 자동화 서비스가 제공하는 기능들을 요약해줘"_

--- a/src/routes/(root)/opi/ko/_nav.yaml
+++ b/src/routes/(root)/opi/ko/_nav.yaml
@@ -29,6 +29,7 @@
         - /ko/integration/pg/v2/hyphen
         - /ko/integration/pg/v2/paypal-v2
         - /ko/integration/pg/v2/eximbay-v2
+    - /ko/integration/using-ai-tools
 
 - label: 부가 기능
   systemVersion: v2
@@ -119,6 +120,7 @@
             - /ko/integration/pg/v1/toss-brandpay/warning
         - /ko/integration/pg/v1/hyphen
     - /ko/integration/checklist/readme-v1
+    - /ko/integration/using-ai-tools
 
 - label: 부가 기능
   systemVersion: v1

--- a/src/routes/(root)/opi/ko/integration/using-ai-tools.mdx
+++ b/src/routes/(root)/opi/ko/integration/using-ai-tools.mdx
@@ -1,0 +1,16 @@
+---
+title: AI 도구 활용하기
+description: AI 도구를 활용하여 쉽고 빠르게 포트원을 연동하세요. 연동 코드 작성은 물론, 24시간 언제나 관련 질의에 대한 답변을 받을 수 있습니다.
+targetVersions: ["v1", "v2"]
+---
+
+import LlmsTxtSupport from "~/routes/(root)/_components/ko/llms-txt-support.mdx"
+import UsingMcpServer from "~/routes/(root)/_components/ko/using-mcp-server.mdx"
+
+## llms.txt 표준 지원
+
+<LlmsTxtSupport />
+
+## 포트원 MCP (Model Context Protocol) 서버
+
+<UsingMcpServer />

--- a/src/routes/(root)/opi/ko/integration/using-ai-tools.mdx
+++ b/src/routes/(root)/opi/ko/integration/using-ai-tools.mdx
@@ -4,6 +4,7 @@ description: AI 도구를 활용하여 쉽고 빠르게 포트원을 연동하�
 targetVersions: ["v1", "v2"]
 ---
 
+import DocsForLlms from "~/routes/(root)/_components/ko/docs-for-llms.mdx"
 import LlmsTxtSupport from "~/routes/(root)/_components/ko/llms-txt-support.mdx"
 import UsingMcpServer from "~/routes/(root)/_components/ko/using-mcp-server.mdx"
 
@@ -14,3 +15,7 @@ import UsingMcpServer from "~/routes/(root)/_components/ko/using-mcp-server.mdx"
 ## 포트원 MCP (Model Context Protocol) 서버
 
 <UsingMcpServer />
+
+## LLM 전용 개발자센터 문서 디렉터리
+
+<DocsForLlms />

--- a/src/routes/(root)/platform/ko/_nav.yaml
+++ b/src/routes/(root)/platform/ko/_nav.yaml
@@ -12,3 +12,7 @@
     - /ko/usages/partner
     - /ko/usages/discount
     - /ko/usages/fee
+
+- label: 기타
+  items:
+    - /ko/using-ai-tools

--- a/src/routes/(root)/platform/ko/using-ai-tools.mdx
+++ b/src/routes/(root)/platform/ko/using-ai-tools.mdx
@@ -1,0 +1,16 @@
+---
+title: AI 도구 활용하기
+description: AI 도구를 활용하여 쉽고 빠르게 포트원을 연동하세요. 연동 코드 작성은 물론, 24시간 언제나 관련 질의에 대한 답변을 받을 수 있습니다.
+targetVersions: ["v1", "v2"]
+---
+
+import LlmsTxtSupport from "~/routes/(root)/_components/ko/llms-txt-support.mdx"
+import UsingMcpServer from "~/routes/(root)/_components/ko/using-mcp-server.mdx"
+
+## llms.txt 표준 지원
+
+<LlmsTxtSupport />
+
+## 포트원 MCP (Model Context Protocol) 서버
+
+<UsingMcpServer />

--- a/src/routes/(root)/platform/ko/using-ai-tools.mdx
+++ b/src/routes/(root)/platform/ko/using-ai-tools.mdx
@@ -4,6 +4,7 @@ description: AI 도구를 활용하여 쉽고 빠르게 포트원을 연동하�
 targetVersions: ["v1", "v2"]
 ---
 
+import DocsForLlms from "~/routes/(root)/_components/ko/docs-for-llms.mdx"
 import LlmsTxtSupport from "~/routes/(root)/_components/ko/llms-txt-support.mdx"
 import UsingMcpServer from "~/routes/(root)/_components/ko/using-mcp-server.mdx"
 
@@ -14,3 +15,7 @@ import UsingMcpServer from "~/routes/(root)/_components/ko/using-mcp-server.mdx"
 ## 포트원 MCP (Model Context Protocol) 서버
 
 <UsingMcpServer />
+
+## LLM 전용 개발자센터 문서 디렉터리
+
+<DocsForLlms />


### PR DESCRIPTION
- 원 페이먼트 인프라, 파트너정산 탭에 각각 `AI 도구 활용하기` 항목을 추가했습니다.
- 해당 문서는 llms.txt, portone-mcp-server, docs-for-llms 관련 내용을 담고 있습니다.
- `pnpm docs-for-llms` 실행 시 `public/docs-for-llms.zip`을 생성하도록 변경하고, `pnpm build` 시 자동으로 실행되도록 변경했습니다.