### PR TITLE
name 필드 설명란에 주문자명에서 주문상품명으로 변경

### DIFF
--- a/src/routes/(root)/sdk/ko/v1-sdk/javascript-sdk/payrt.mdx
+++ b/src/routes/(root)/sdk/ko/v1-sdk/javascript-sdk/payrt.mdx
@@ -115,7 +115,7 @@ import Parameter from "~/components/parameter/Parameter";
 
   - name: string
 
-    **주문자명**
+    **주문상품명**
 
   - pg\_provider: string
 

--- a/src/routes/(root)/sdk/ko/v1-sdk/javascript-sdk/payrt.mdx
+++ b/src/routes/(root)/sdk/ko/v1-sdk/javascript-sdk/payrt.mdx
@@ -115,7 +115,7 @@ import Parameter from "~/components/parameter/Parameter";
 
   - name: string
 
-    **주문상품명**
+    **주문명**
 
   - pg\_provider: string
 


### PR DESCRIPTION
name 필드 설명과 buyer_name 필드 설명이 중복됩니다.
name을 주문상품명으로 변경했습니다.

현재 결제응답 파라미터 페이지의 필드 설명입니다.
https://developers.portone.io/sdk/ko/v1-sdk/javascript-sdk/payrq?v=v1
<img width="312" alt="스크린샷 2025-03-25 오후 5 30 20" src="https://github.com/user-attachments/assets/903d4244-f781-48c6-ab55-2b3101e5c193" />
