### PR TITLE
퀵 가이드 샘플 코드를 반환하는 GET API 추가

### DIFF
--- a/src/routes/(root)/opi/ko/quick-guide/payment/_preview/type.test.ts
+++ b/src/routes/(root)/opi/ko/quick-guide/payment/_preview/type.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "vitest";
+
+import { pgOptions, validateParams } from "./type";
+
+describe("validateParams", () => {
+  // Valid parameter combinations
+  it("should return valid params when pg and payMethod are valid", () => {
+    const result = validateParams({
+      pg: "toss",
+      payMethod: "card",
+      smartRouting: "false",
+    });
+    expect(result).toEqual({
+      smartRouting: false,
+      pg: {
+        name: "toss",
+        payMethods: "card",
+      },
+    });
+  });
+
+  // Test all PG options with valid payment methods
+  Object.entries(pgOptions).forEach(([pg, options]) => {
+    options.payMethods.forEach((payMethod) => {
+      it(`should validate ${pg} with ${payMethod}`, () => {
+        const result = validateParams({
+          pg,
+          payMethod,
+          smartRouting: "false",
+        });
+        expect(result).toEqual({
+          smartRouting: false,
+          pg: {
+            name: pg,
+            payMethods: payMethod,
+          },
+        });
+      });
+    });
+  });
+
+  it("should return valid params with smartRouting=true", () => {
+    const result = validateParams({
+      pg: "nice",
+      payMethod: "virtualAccount",
+      smartRouting: "true",
+    });
+    expect(result).toEqual({
+      smartRouting: true,
+      pg: {
+        name: "nice",
+        payMethods: "virtualAccount",
+      },
+    });
+  });
+
+  it("should treat null smartRouting as false", () => {
+    const result = validateParams({
+      pg: "inicis",
+      payMethod: "easyPay",
+      smartRouting: null,
+    });
+    expect(result).toEqual({
+      smartRouting: false,
+      pg: {
+        name: "inicis",
+        payMethods: "easyPay",
+      },
+    });
+  });
+
+  // Default values for null parameters
+  it("should use the first pg supporting the given payMethod when pg is null", () => {
+    const availablePayMethods = [
+      "card",
+      "virtualAccount",
+      "easyPay",
+      "transfer",
+      "mobile",
+      "giftCertificate",
+    ];
+
+    for (const payMethod of availablePayMethods) {
+      // Find the first PG that supports this payment method
+      const expectedPg = Object.entries(pgOptions).find(([_, options]) =>
+        options.payMethods.some((method) => method === payMethod),
+      )?.[0];
+      expect(expectedPg).toBeDefined();
+
+      const result = validateParams({
+        pg: null,
+        payMethod,
+        smartRouting: "false",
+      });
+
+      expect(result).toEqual({
+        smartRouting: false,
+        pg: {
+          name: expectedPg,
+          payMethods: payMethod,
+        },
+      });
+    }
+  });
+
+  it("should use first payMethod when payMethod is null", () => {
+    const pg = "kakao";
+    const firstPayMethod = pgOptions[pg].payMethods[0];
+    const result = validateParams({
+      pg,
+      payMethod: null,
+      smartRouting: "false",
+    });
+    expect(result).toEqual({
+      smartRouting: false,
+      pg: {
+        name: pg,
+        payMethods: firstPayMethod,
+      },
+    });
+  });
+
+  it("should handle both pg and payMethod being null", () => {
+    const firstPg = Object.keys(pgOptions)[0] as keyof typeof pgOptions;
+    const firstPayMethod = pgOptions[firstPg].payMethods[0];
+    const result = validateParams({
+      pg: null,
+      payMethod: null,
+      smartRouting: "false",
+    });
+    expect(result).toEqual({
+      smartRouting: false,
+      pg: {
+        name: firstPg,
+        payMethods: firstPayMethod,
+      },
+    });
+  });
+
+  // Invalid parameter combinations
+  it("should throw error when pg is not in pgOptions", () => {
+    const availablePgs = Object.keys(pgOptions).join(", ");
+    expect(() =>
+      validateParams({
+        pg: "invalid-pg",
+        payMethod: "card",
+        smartRouting: "false",
+      }),
+    ).toThrow(`지원하지 않는 pg: invalid-pg. 사용 가능한 pg: ${availablePgs}`);
+  });
+
+  it("should throw error when payMethod is not supported by pg", () => {
+    const pg = "kakao";
+    const availablePayMethods = pgOptions[pg].payMethods.join(", ");
+    expect(() =>
+      validateParams({
+        pg,
+        payMethod: "card",
+        smartRouting: "false",
+      }),
+    ).toThrow(
+      `해당 pg에서 지원하지 않는 payMethod: card. ${pg}에서 사용 가능한 payMethod: ${availablePayMethods}`,
+    );
+  });
+
+  it("should throw error when smartRouting is invalid string", () => {
+    expect(() =>
+      validateParams({
+        pg: "toss",
+        payMethod: "card",
+        smartRouting: "invalid",
+      }),
+    ).toThrow("smartRouting은 true 또는 false여야 합니다");
+  });
+
+  it("should handle case-insensitive pg names", () => {
+    const result = validateParams({
+      pg: "TOSS",
+      payMethod: "card",
+      smartRouting: "false",
+    });
+    expect(result).toEqual({
+      smartRouting: false,
+      pg: {
+        name: "toss",
+        payMethods: "card",
+      },
+    });
+  });
+
+  it("should handle case-insensitive payment methods", () => {
+    const result = validateParams({
+      pg: "kcp",
+      payMethod: "CARD",
+      smartRouting: "false",
+    });
+    expect(result).toEqual({
+      smartRouting: false,
+      pg: {
+        name: "kcp",
+        payMethods: "card",
+      },
+    });
+  });
+});

--- a/src/routes/(root)/opi/ko/quick-guide/payment/_preview/type.test.ts
+++ b/src/routes/(root)/opi/ko/quick-guide/payment/_preview/type.test.ts
@@ -202,4 +202,34 @@ describe("validateParams", () => {
       },
     });
   });
+
+  it("should handle case-insensitive smartRouting parameter", () => {
+    // Test with uppercase TRUE
+    const resultTrue = validateParams({
+      pg: "toss",
+      payMethod: "card",
+      smartRouting: "TRUE",
+    });
+    expect(resultTrue).toEqual({
+      smartRouting: true,
+      pg: {
+        name: "toss",
+        payMethods: "card",
+      },
+    });
+
+    // Test with mixed case FaLsE
+    const resultFalse = validateParams({
+      pg: "nice",
+      payMethod: "virtualAccount",
+      smartRouting: "FaLsE",
+    });
+    expect(resultFalse).toEqual({
+      smartRouting: false,
+      pg: {
+        name: "nice",
+        payMethods: "virtualAccount",
+      },
+    });
+  });
 });

--- a/src/routes/(root)/opi/ko/quick-guide/payment/_preview/type.ts
+++ b/src/routes/(root)/opi/ko/quick-guide/payment/_preview/type.ts
@@ -89,9 +89,9 @@ export function validateParams(params: {
 
   // Nested function to parse smartRouting parameter
   const parseSmartRouting = (value: string | null): boolean => {
-    if (value === null || value === "false") {
+    if (value === null || value.toLowerCase() === "false") {
       return false;
-    } else if (value === "true") {
+    } else if (value.toLowerCase() === "true") {
       return true;
     } else {
       throw new Error("smartRouting은 true 또는 false여야 합니다");

--- a/src/routes/(root)/opi/ko/quick-guide/payment/_preview/type.ts
+++ b/src/routes/(root)/opi/ko/quick-guide/payment/_preview/type.ts
@@ -72,6 +72,133 @@ export type Params = {
   pg: ConvertToPgParam<typeof pgOptions>;
 };
 
+/*
+ * pg, payMethod, smartRouting 파라미터 조합이 pgOptions에 정의된 값인지 확인
+ * @param pg - PG 이름. null이면 pgOptions의 첫 번째 키 반환
+ * @param payMethod - 결제 방식. null이면 pgOptions[pg]의 첫 번째 payMethod 반환
+ * @param smartRouting - 스마트 라우팅 여부. "true" 또는 "false". null이면 false로 처리
+ * @returns {Params} - 성공 시 Params 타입
+ * @throws {Error} - 실패 시 메세지가 포함된 에러
+ */
+export function validateParams(params: {
+  pg: string | null;
+  payMethod: string | null;
+  smartRouting: string | null;
+}): Params {
+  const { pg, payMethod, smartRouting } = params;
+
+  // Nested function to parse smartRouting parameter
+  const parseSmartRouting = (value: string | null): boolean => {
+    if (value === null || value === "false") {
+      return false;
+    } else if (value === "true") {
+      return true;
+    } else {
+      throw new Error("smartRouting은 true 또는 false여야 합니다");
+    }
+  };
+
+  // Nested function to validate PG name
+  const validatePg = (pgValue: string): Params["pg"]["name"] => {
+    const normalizedPg = pgValue.toLowerCase();
+    const supportedPgs = Object.keys(pgOptions);
+    const pgName = supportedPgs.find((pg) => pg.toLowerCase() === normalizedPg);
+    if (!pgName) {
+      const availablePgs = supportedPgs.join(", ");
+      throw new Error(
+        `지원하지 않는 pg: ${pgValue}. 사용 가능한 pg: ${availablePgs}`,
+      );
+    }
+    return pgName as Params["pg"]["name"];
+  };
+
+  // Nested function to validate if payMethod is supported by pg
+  const validatePayMethodForPg = (
+    pgValue: Params["pg"]["name"],
+    payMethodValue: string,
+  ): string => {
+    const normalizedPayMethod = payMethodValue.toLowerCase();
+    const supportedPayMethods = pgOptions[pgValue].payMethods;
+
+    const payMethod = supportedPayMethods.find(
+      (method) => method.toLowerCase() === normalizedPayMethod,
+    );
+    if (!payMethod) {
+      const availablePayMethods = supportedPayMethods.join(", ");
+      throw new Error(
+        `해당 pg에서 지원하지 않는 payMethod: ${payMethodValue}. ${pgValue}에서 사용 가능한 payMethod: ${availablePayMethods}`,
+      );
+    } else {
+      return payMethod;
+    }
+  };
+
+  // Nested function to find first pg supporting a payMethod
+  const findPgForPayMethod = (
+    payMethodValue: string,
+  ): [Params["pg"]["name"], string] => {
+    const normalizedPayMethod = payMethodValue.toLowerCase();
+
+    const pgEntry = Object.entries(pgOptions).find(([_, options]) =>
+      options.payMethods.some(
+        (method) => method.toLowerCase() === normalizedPayMethod,
+      ),
+    );
+
+    if (!pgEntry) {
+      throw new Error(`지원하지 않는 payMethod: ${payMethodValue}`);
+    }
+
+    const pgName = pgEntry[0] as Params["pg"]["name"];
+    const exactPayMethod = pgOptions[pgName].payMethods.find(
+      (method) => method.toLowerCase() === normalizedPayMethod,
+    )!;
+
+    return [pgName, exactPayMethod];
+  };
+
+  // Nested function to get default pg and payMethod
+  const getDefaultPgAndPayMethod = (): [Params["pg"]["name"], string] => {
+    const defaultPg = Object.keys(pgOptions)[0] as Params["pg"]["name"];
+    const defaultPayMethod = pgOptions[defaultPg].payMethods[0];
+    return [defaultPg, defaultPayMethod];
+  };
+
+  // Parse smartRouting parameter
+  const parsedSmartRouting = parseSmartRouting(smartRouting);
+
+  // Handle pg and payMethod parameters
+  let pgName: Params["pg"]["name"];
+  let selectedPayMethod: string;
+
+  // Case 1: Both pg and payMethod are provided
+  if (pg !== null && payMethod !== null) {
+    pgName = validatePg(pg);
+    selectedPayMethod = validatePayMethodForPg(pgName, payMethod);
+  }
+  // Case 2: pg is null, payMethod is provided
+  else if (pg === null && payMethod !== null) {
+    [pgName, selectedPayMethod] = findPgForPayMethod(payMethod);
+  }
+  // Case 3: pg is provided, payMethod is null
+  else if (pg !== null && payMethod === null) {
+    pgName = validatePg(pg);
+    selectedPayMethod = pgOptions[pgName].payMethods[0];
+  }
+  // Case 4: Both pg and payMethod are null
+  else {
+    [pgName, selectedPayMethod] = getDefaultPgAndPayMethod();
+  }
+
+  return {
+    smartRouting: parsedSmartRouting,
+    pg: {
+      name: pgName,
+      payMethods: selectedPayMethod,
+    } as Params["pg"],
+  };
+}
+
 // 문서에 노출되는 순서대로
 export type Sections =
   | "client:import-portone-sdk"

--- a/src/routes/(root)/opi/ko/quick-guide/payment/_preview/utils.ts
+++ b/src/routes/(root)/opi/ko/quick-guide/payment/_preview/utils.ts
@@ -1,0 +1,27 @@
+import type { CodeExample } from "~/state/interactive-docs/index.jsx";
+
+import { type Params, type Sections } from "./type";
+
+export function markdownResponse(content: string, status: number) {
+  return new Response(content, {
+    status,
+    headers: {
+      "Content-Type": "text/markdown; charset=UTF-8",
+    },
+  });
+}
+
+export function formatCodeExample(
+  codeExample: CodeExample<Params, Sections>,
+  codeParams: Params,
+) {
+  return (
+    "```" +
+    codeExample.language +
+    " " +
+    codeExample.fileName +
+    "\n" +
+    codeExample.code(codeParams).code +
+    "\n```\n"
+  );
+}

--- a/src/routes/(root)/opi/ko/quick-guide/payment/backend-code.ts
+++ b/src/routes/(root)/opi/ko/quick-guide/payment/backend-code.ts
@@ -1,0 +1,74 @@
+import type { APIHandler } from "@solidjs/start/server";
+
+import type { CodeExample } from "~/state/interactive-docs/index.jsx";
+
+import * as files from "./_preview/backend";
+import { type Params, type Sections, validateParams } from "./_preview/type";
+import { formatCodeExample, markdownResponse } from "./_preview/utils";
+
+/**
+ * 백엔드 코드 예제를 위한 GET 핸들러
+ *
+ * 제공된 파라미터를 기반으로 결제 연동을 위한 백엔드 코드 예제를 생성합니다.
+ * 여러 백엔드 프레임워크(express, fastapi, flask, spring-kotlin)를 지원하며
+ * 입력 파라미터가 지원되는 결제 게이트웨이와 호환되는지 검증합니다.
+ *
+ * @param event - 서버로부터의 요청 이벤트
+ * @returns Promise<Response> - 코드 예제 또는 오류 메시지를 포함하는 마크다운 응답
+ */
+export const GET: APIHandler = (event): Promise<Response> => {
+  // 요청 URL에서 쿼리 파라미터 추출
+  const url = new URL(event.request.url);
+  const pg = url.searchParams.get("pg");
+  const payMethod = url.searchParams.get("payMethod");
+  const smartRouting = url.searchParams.get("smartRouting");
+  const framework = url.searchParams.get("framework");
+
+  const response = (() => {
+    try {
+      // 결제 파라미터 검증 및 정규화
+      // 파라미터가 지원되는 PG와 호환되는지 확인
+      const codeParams = validateParams({
+        pg,
+        payMethod,
+        smartRouting,
+      });
+
+      // 여러 코드 예제를 하나의 마크다운 문자열로 포맷팅하는 헬퍼 함수
+      const makeContent = (examples: CodeExample<Params, Sections>[]) => {
+        return examples
+          .map((example) => formatCodeExample(example, codeParams))
+          .join("\n");
+      };
+
+      // 요청된 프레임워크에 기반한 코드 예제 생성
+      // 대소문자 구분 없는 프레임워크 이름 매칭
+      switch (framework?.toLowerCase()) {
+        case "express":
+          return markdownResponse(makeContent(files.Express), 200);
+        case "fastapi":
+          return markdownResponse(makeContent(files.FastAPI), 200);
+        case "flask":
+          return markdownResponse(makeContent(files.Flask), 200);
+        case "spring-kotlin":
+          return markdownResponse(makeContent(files.Spring_Kotlin), 200);
+        default:
+          // 지원되지 않는 프레임워크에 대한 오류 반환 및 지원되는 옵션 목록 제공
+          return markdownResponse(
+            `지원되지 않는 framework: ${framework}. 지원하는 framework: express, fastapi, flask, spring-kotlin`,
+            400,
+          );
+      }
+    } catch (error) {
+      // 알려진 오류를 특정 오류 메시지로 처리
+      if (error instanceof Error) {
+        return markdownResponse(error.message, 400);
+      }
+      // 예상치 못한 오류를 일반 메시지로 처리
+      return markdownResponse("An unknown error occurred", 500);
+    }
+  })();
+
+  // 응답을 해결된 프로미스로 반환
+  return Promise.resolve(response);
+};

--- a/src/routes/(root)/opi/ko/quick-guide/payment/frontend-code.ts
+++ b/src/routes/(root)/opi/ko/quick-guide/payment/frontend-code.ts
@@ -1,0 +1,70 @@
+import type { APIHandler } from "@solidjs/start/server";
+
+import type { CodeExample } from "~/state/interactive-docs/index.jsx";
+
+import * as files from "./_preview/frontend";
+import { type Params, type Sections, validateParams } from "./_preview/type";
+import { formatCodeExample, markdownResponse } from "./_preview/utils";
+
+/**
+ * 프론트엔드 코드 예제를 위한 GET 핸들러
+ *
+ * 제공된 파라미터를 기반으로 결제 연동을 위한 프론트엔드 코드 예제를 생성합니다.
+ * 여러 프론트엔드 프레임워크(html, react)를 지원하며
+ * 입력 파라미터가 지원되는 결제 게이트웨이와 호환되는지 검증합니다.
+ *
+ * @param event - 서버로부터의 요청 이벤트
+ * @returns Promise<Response> - 코드 예제 또는 오류 메시지를 포함하는 마크다운 응답
+ */
+export const GET: APIHandler = (event): Promise<Response> => {
+  // 요청 URL에서 쿼리 파라미터 추출
+  const url = new URL(event.request.url);
+  const pg = url.searchParams.get("pg");
+  const payMethod = url.searchParams.get("payMethod");
+  const smartRouting = url.searchParams.get("smartRouting");
+  const framework = url.searchParams.get("framework");
+
+  const response = (() => {
+    try {
+      // 결제 파라미터 검증 및 정규화
+      // 파라미터가 지원되는 PG와 호환되는지 확인
+      const codeParams = validateParams({
+        pg,
+        payMethod,
+        smartRouting,
+      });
+
+      // 여러 코드 예제를 하나의 마크다운 문자열로 포맷팅하는 헬퍼 함수
+      const makeContent = (examples: CodeExample<Params, Sections>[]) => {
+        return examples
+          .map((example) => formatCodeExample(example, codeParams))
+          .join("\n");
+      };
+
+      // 요청된 프레임워크에 기반한 코드 예제 생성
+      // 대소문자 구분 없는 프레임워크 이름 매칭
+      switch (framework?.toLowerCase()) {
+        case "html":
+          return markdownResponse(makeContent(files.HTML), 200);
+        case "react":
+          return markdownResponse(makeContent(files.React), 200);
+        default:
+          // 지원되지 않는 프레임워크에 대한 오류 반환 및 지원되는 옵션 목록 제공
+          return markdownResponse(
+            `지원되지 않는 framework: ${framework}. 지원하는 framework: html, react`,
+            400,
+          );
+      }
+    } catch (error) {
+      // 알려진 오류를 특정 오류 메시지로 처리
+      if (error instanceof Error) {
+        return markdownResponse(error.message, 400);
+      }
+      // 예상치 못한 오류를 일반 메시지로 처리
+      return markdownResponse("An unknown error occurred", 500);
+    }
+  })();
+
+  // 응답을 해결된 프로미스로 반환
+  return Promise.resolve(response);
+};


### PR DESCRIPTION
`GET /opi/ko/quick-guide/payment/backend-code` `GET /opi/ko/quick-guide/payment/frontend-code`를 추가합니다.

해당 API는 https://github.com/portone-io/mcp-server 에서 활용하기 위한 용도로, pg, payMethod, framework에 따라 샘플 코드를 마크다운 형식으로 반환합니다.