### PR TITLE
llms-txt-support.mdx: Open llms.txt in a new tab

### DIFF
--- a/src/routes/(root)/_components/ko/llms-txt-support.mdx
+++ b/src/routes/(root)/_components/ko/llms-txt-support.mdx
@@ -4,6 +4,7 @@ description: 포트원이 지원하는 llms.txt 표준에 대한 내용입니다
 targetVersions: ["v1", "v2"]
 ---
 import { prose } from "~/components/prose";
+
 포트원 개발자센터 웹사이트는 [llms.txt 표준](https://llmstxt.org)을 준수하며, LLM이 문서 정보를 쉽게 조회할 수 있도록 지원하고 있습니다.
 
 - <prose.a target="_blank" href="https://developers.portone.io/llms.txt">llms.txt</prose.a>: LLM을 위한 가이드 및 문서 목차를 포함합니다.

--- a/src/routes/(root)/_components/ko/llms-txt-support.mdx
+++ b/src/routes/(root)/_components/ko/llms-txt-support.mdx
@@ -3,7 +3,7 @@ title: llms.txt 표준 지원
 description: 포트원이 지원하는 llms.txt 표준에 대한 내용입니다.
 targetVersions: ["v1", "v2"]
 ---
-
+import { prose } from "~/components/prose";
 포트원 개발자센터 웹사이트는 [llms.txt 표준](https://llmstxt.org)을 준수하며, LLM이 문서 정보를 쉽게 조회할 수 있도록 지원하고 있습니다.
 
 - <prose.a target="_blank" href="https://developers.portone.io/llms.txt">llms.txt</prose.a>: LLM을 위한 가이드 및 문서 목차를 포함합니다.

--- a/src/routes/(root)/_components/ko/llms-txt-support.mdx
+++ b/src/routes/(root)/_components/ko/llms-txt-support.mdx
@@ -6,8 +6,8 @@ targetVersions: ["v1", "v2"]
 
 포트원 개발자센터 웹사이트는 [llms.txt 표준](https://llmstxt.org)을 준수하며, LLM이 문서 정보를 쉽게 조회할 수 있도록 지원하고 있습니다.
 
-- <a target="_blank" href="https://developers.portone.io/llms.txt">llms.txt</a>: LLM을 위한 가이드 및 문서 목차를 포함합니다.
-- <a target="_blank" href="https://developers.portone.io/llms-full.txt">llms-full.txt</a>: llms.txt에 더해 모든 문서 내용을 추가로 포함합니다.
-- <a target="_blank" href="https://developers.portone.io/llms-small.txt">llms-small.txt</a>: llms.txt에 더해 모든 문서의 메타 정보만 추가로 포함합니다.
+- <prose.a target="_blank" href="https://developers.portone.io/llms.txt">llms.txt</prose.a>: LLM을 위한 가이드 및 문서 목차를 포함합니다.
+- <prose.a target="_blank" href="https://developers.portone.io/llms-full.txt">llms-full.txt</prose.a>: llms.txt에 더해 모든 문서 내용을 추가로 포함합니다.
+- <prose.a target="_blank" href="https://developers.portone.io/llms-small.txt">llms-small.txt</prose.a>: llms.txt에 더해 모든 문서의 메타 정보만 추가로 포함합니다.
 
 llms.txt, llms-small.txt를 사용하는 AI 어시스턴트의 프롬프트에 포함하거나, llms-full.txt를 파일로 업로드해 질의하는 방식으로도 활용이 가능합니다.

--- a/src/routes/(root)/_components/ko/llms-txt-support.mdx
+++ b/src/routes/(root)/_components/ko/llms-txt-support.mdx
@@ -6,8 +6,8 @@ targetVersions: ["v1", "v2"]
 
 포트원 개발자센터 웹사이트는 [llms.txt 표준](https://llmstxt.org)을 준수하며, LLM이 문서 정보를 쉽게 조회할 수 있도록 지원하고 있습니다.
 
-- [llms.txt](https://developers.portone.io/llms.txt): LLM을 위한 가이드 및 문서 목차를 포함합니다.
-- [llms-full.txt](https://developers.portone.io/llms-full.txt): llms.txt에 더해 모든 문서 내용을 추가로 포함합니다.
-- [llms-small.txt](https://developers.portone.io/llms-small.txt): llms.txt에 더해 모든 문서의 메타 정보만 추가로 포함합니다.
+- <a target="_blank" href="https://developers.portone.io/llms.txt">llms.txt</a>: LLM을 위한 가이드 및 문서 목차를 포함합니다.
+- <a target="_blank" href="https://developers.portone.io/llms-full.txt">llms-full.txt</a>: llms.txt에 더해 모든 문서 내용을 추가로 포함합니다.
+- <a target="_blank" href="https://developers.portone.io/llms-small.txt">llms-small.txt</a>: llms.txt에 더해 모든 문서의 메타 정보만 추가로 포함합니다.
 
 llms.txt, llms-small.txt를 사용하는 AI 어시스턴트의 프롬프트에 포함하거나, llms-full.txt를 파일로 업로드해 질의하는 방식으로도 활용이 가능합니다.


### PR DESCRIPTION
llms.txt 가 solidjs/router에 포함되어있지 않아 저 링크를 누르면 404가 뜹니다. 새로고침을 하면 정상적으로 로딩이 되는데, 라우터가 저 파일들을 인식하는게 아주 자명하진 않아서 그냥 애초에 파일을 새 탭에서 켜게 만들었습니다.