### PR TITLE
`Parameter.TypeDef` 에 leadingDescription 구현

### DIFF
--- a/packages/browser-sdk-mdx-codegen/src/parameter.ts
+++ b/packages/browser-sdk-mdx-codegen/src/parameter.ts
@@ -6,6 +6,7 @@ import { match, P } from "ts-pattern";
 
 import { TypescriptWriter } from "./common.ts";
 import { getResourceRef, type Parameter } from "./schema.ts";
+import { getComponentName } from "./utils.ts";
 
 function generateDescription({
   imports,
@@ -36,9 +37,6 @@ function generateDescription({
   );
   return { componentName };
 }
-
-const getComponentName = (ref: string) =>
-  pascalCase(getResourceRef(ref).replaceAll("/", "_"));
 
 function generateTypeDef({
   imports,

--- a/packages/browser-sdk-mdx-codegen/src/parameter.ts
+++ b/packages/browser-sdk-mdx-codegen/src/parameter.ts
@@ -37,6 +37,9 @@ function generateDescription({
   return { componentName };
 }
 
+const getComponentName = (ref: string) =>
+  pascalCase(getResourceRef(ref).replaceAll("/", "_"));
+
 function generateTypeDef({
   imports,
   basePath,
@@ -44,6 +47,7 @@ function generateTypeDef({
   parameter,
   ident,
   defaultExpanded,
+  leadingDescription,
 }: {
   imports: Set<string>;
   basePath: string;
@@ -51,14 +55,14 @@ function generateTypeDef({
   ident?: string;
   parameter: Parameter;
   defaultExpanded?: boolean;
+  leadingDescription?: string;
 }): string {
   const writer = TypescriptWriter();
 
   if (parameter.type === "resourceRef") {
-    const componentName = `${pascalCase(getResourceRef(parameter.$ref).replaceAll("/", "_"))}TypeDef`;
-    imports.add(
-      `import { TypeDef as ${componentName} } from "~/components/parameter/__generated__/${getResourceRef(parameter.$ref)}/index.ts";`,
-    );
+    const modulePath = `~/components/parameter/__generated__/${getResourceRef(parameter.$ref)}/index.ts`;
+    const componentName = `${getComponentName(parameter.$ref)}TypeDef`;
+    imports.add(`import { TypeDef as ${componentName} } from "${modulePath}";`);
 
     writer.writeLine(`<${componentName}`);
     writer.indent();
@@ -67,6 +71,18 @@ function generateTypeDef({
     }
     if (ident !== undefined) {
       writer.writeLine(`ident="${ident}"`);
+    }
+    if (leadingDescription !== undefined) {
+      const description = generateDescription({
+        imports,
+        basePath,
+        filePath: path.join(parameterPath, "Leading"),
+        description: leadingDescription,
+      });
+      writer.writeLine(`leadingDescription={<${description.componentName} />}`);
+    }
+    if (defaultExpanded === false) {
+      writer.writeLine("defaultExpanded={false}");
     }
     writer.outdent();
     writer.writeLine("/>");
@@ -84,9 +100,19 @@ function generateTypeDef({
   if (ident !== undefined) {
     writer.writeLine(`ident="${ident}"`);
   }
-  if (parameter.type === "enum" || defaultExpanded === false) {
-    writer.writeLine(`defaultExpanded={false}`);
-  }
+  match(parameter)
+    .with({ type: "enum" }, () => {
+      writer.writeLine(`defaultExpanded={false}`);
+    })
+    .with({ type: "array", items: { type: "enum" } }, () => {
+      writer.writeLine(`defaultExpanded={false}`);
+    })
+    .with(P._, () => {
+      if (defaultExpanded === false) {
+        writer.writeLine(`defaultExpanded={false}`);
+      }
+    })
+    .exhaustive();
   writer.outdent();
   writer.writeLine(">");
   writer.indent();
@@ -122,7 +148,7 @@ function generateTypeDef({
         items: { type: "resourceRef" },
       },
       (parameter) => {
-        const componentName = `${pascalCase(getResourceRef(parameter.items.$ref).replaceAll("/", "_"))}Description`;
+        const componentName = `${getComponentName(parameter.items.$ref)}Description`;
         imports.add(
           `import { Description as ${componentName} } from "~/components/parameter/__generated__/${getResourceRef(parameter.items.$ref)}/index.ts";`,
         );
@@ -194,10 +220,8 @@ function generateTypeDetails({
             ident,
             basePath,
             imports,
-            parameter: {
-              ...propValue,
-              description: `\`${parameter.discriminator}\`가 \`${discriminateValue}\`인 경우에만 허용됩니다.\n\n`,
-            },
+            parameter: propValue,
+            leadingDescription: `\`${parameter.discriminator}\`가 \`${discriminateValue}\`인 경우에만 허용됩니다.\n\n`,
             parameterPath: path.join(parameterPath, ident),
             defaultExpanded: false,
           }),
@@ -221,7 +245,7 @@ function generateTypeDetails({
           const description = generateDescription({
             imports,
             basePath,
-            filePath: path.join(parameterPath, variantValue),
+            filePath: path.join(parameterPath, `Variant${variantValue}`),
             description: variant.description,
           });
           writer.writeLine(`<${description.componentName} />`);
@@ -271,7 +295,7 @@ function generateTypeDetails({
       });
     })
     .with({ type: "resourceRef" }, (parameter) => {
-      const componentName = `${pascalCase(getResourceRef(parameter.$ref).replaceAll("/", "_"))}Details`;
+      const componentName = `${getComponentName(parameter.$ref)}Details`;
       imports.add(
         `import { Details as ${componentName} } from "~/components/parameter/__generated__/${getResourceRef(parameter.$ref)}/index.ts";`,
       );
@@ -407,7 +431,7 @@ function generateInlineType({
       writer.writeLine(`<span class="text-slate-5">&#125;</span>`);
     })
     .with({ type: "resourceRef" }, ({ $ref }) => {
-      const componentName = `${pascalCase(getResourceRef($ref).replaceAll("/", "_"))}Type`;
+      const componentName = `${getComponentName($ref)}Type`;
       imports.add(
         `import { Type as ${componentName} } from "~/components/parameter/__generated__/${getResourceRef($ref)}/index.ts";`,
       );
@@ -437,12 +461,15 @@ export function generateParameter({
   const imports = new Set<string>();
   const writer = TypescriptWriter();
 
+  imports.add('import { type JSXElement } from "solid-js";');
   imports.add('import Parameter from "~/components/parameter/Parameter.tsx";');
 
   writer.writeLine("interface TypeDefProps {");
   writer.indent();
   writer.writeLine("ident?: string;");
   writer.writeLine("optional?: boolean;");
+  writer.writeLine("leadingDescription?: JSXElement;");
+  writer.writeLine("defaultExpanded?: boolean;");
   writer.outdent();
   writer.writeLine("}");
   writer.writeLine("");
@@ -452,7 +479,7 @@ export function generateParameter({
   writer.writeLine("return (");
   writer.indent();
   if (parameter.type === "resourceRef") {
-    const componentName = `${pascalCase(getResourceRef(parameter.$ref).replaceAll("/", "_"))}TypeDef`;
+    const componentName = `${getComponentName(parameter.$ref)}TypeDef`;
     imports.add(
       `import { TypeDef as ${componentName} } from "~/components/parameter/__generated__/${getResourceRef(parameter.$ref)}/index.ts";`,
     );
@@ -468,7 +495,10 @@ export function generateParameter({
     writer.indent();
     writer.writeLine("type={<Type {...props} />}");
     writer.writeLine("{...props}");
-    if (parameter.type === "enum") {
+    if (
+      parameter.type === "enum" ||
+      (parameter.type === "array" && parameter.items.type === "enum")
+    ) {
       writer.writeLine("defaultExpanded={false}");
     }
     writer.outdent();

--- a/packages/browser-sdk-mdx-codegen/src/schema.ts
+++ b/packages/browser-sdk-mdx-codegen/src/schema.ts
@@ -40,6 +40,7 @@ export type ParameterType =
       type: "discriminatedUnion";
       types: Record<string, Parameter>;
       discriminator: string;
+      optional?: boolean;
     }
   | { type: "resourceRef"; $ref: string }
   | {

--- a/packages/browser-sdk-mdx-codegen/src/utils.ts
+++ b/packages/browser-sdk-mdx-codegen/src/utils.ts
@@ -1,0 +1,6 @@
+import { pascalCase } from "es-toolkit/string";
+
+import { getResourceRef } from "./schema.ts";
+
+export const getComponentName = (ref: string) =>
+  pascalCase(getResourceRef(ref).replaceAll("/", "_"));

--- a/src/components/parameter/Parameter.tsx
+++ b/src/components/parameter/Parameter.tsx
@@ -95,6 +95,7 @@ interface TypeDefProps {
   type: JSXElement;
   children?: JSXElement;
   defaultExpanded?: boolean;
+  leadingDescription?: JSXElement;
 }
 
 const TypeDefContext = createContext({
@@ -167,7 +168,10 @@ Parameter.TypeDef = function TypeDef(props: TypeDefProps) {
           type={others.type}
           optional={others.optional}
         />
-        <div class="overflow-x-auto">{children}</div>
+        <div class="overflow-x-auto">
+          {others.leadingDescription}
+          {children}
+        </div>
       </div>
       <Collapsible.Content
         as={Parameter}


### PR DESCRIPTION
https://github.com/portone-io/browser-sdk-generator/pull/2 로 바뀔 예정인 스키마에서 parameterRef 타입의 멤버를 가진 discriminatedUnion이 각 discriminator의 값에 따라 달라진다는 주석을 표시하지 못 하고 있어서 해당 부분을 수정했습니다.