### PR TITLE
nav.yaml에 kcp 본인인증 경로추가

### DIFF
--- a/src/routes/(root)/opi/ko/_nav.yaml
+++ b/src/routes/(root)/opi/ko/_nav.yaml
@@ -40,6 +40,7 @@
       items:
         - /ko/integration/pg/v2/danal-identity-verification
         - /ko/integration/pg/v2/inicis-unified-identity-verification
+        - /ko/integration/pg/v2/kcp-v2-identity-verification
     - /ko/extra/confirm-process/readme-v2
     - slug: /ko/extra/smart-routing/intro
       items:
@@ -148,6 +149,7 @@
             - /ko/extra/identity-verification/v1/credit-auth/2
             - /ko/extra/identity-verification/v1/credit-auth/3
             - /ko/extra/identity-verification/v1/credit-auth/4
+        - slug: /ko/integration/pg/v1/kcp-v2-identity-verification
     - /ko/extra/confirm-process/readme-v1
     - slug: /ko/extra/smart-routing/intro
       items:

--- a/src/routes/(root)/opi/ko/integration/pg/v1/kcp-v2-identity-verification.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/kcp-v2-identity-verification.mdx
@@ -2,6 +2,8 @@
 title: NHN KCP(신모듈) 본인인증 연동하기
 description: NHN KCP(신모듈) 본인인증 연동 방법을 안내합니다.
 targetVersions: ["v1"]
+versionVariants:
+  v2: /opi/ko/integration/pg/v2/kcp-v2-identity-verification
 ---
 
 import Tabs from "~/components/gitbook/Tabs";

--- a/src/routes/(root)/opi/ko/integration/pg/v2/kcp-v2-identity-verification.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v2/kcp-v2-identity-verification.mdx
@@ -2,6 +2,8 @@
 title: KCP 본인인증
 description: KCP 본인인증 연동 방법을 안내합니다.
 targetVersions: ["v2"]
+versionVariants:
+  v1: /opi/ko/integration/pg/v1/kcp-v2-identity-verification
 ---
 
 import Details from "~/components/gitbook/Details";


### PR DESCRIPTION
kcp 연동 가이드 추가 pr(https://github.com/portone-io/developers.portone.io/pull/848) 에서 경로추가가 누락되어 추가하였습니다.