### PR TITLE
chore: v1 eximbay 지원하지 않는 통화 제거

### DIFF
--- a/src/routes/(root)/opi/ko/integration/pg/v1/eximbay.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/eximbay.mdx
@@ -119,20 +119,6 @@ import Parameter from "~/components/parameter/Parameter";
         - HKD
         - CAD
         - AUD
-        - CNY
-        - TWD
-        - MYR
-        - VND
-        - PHP
-        - MNT
-        - NZD
-        - AED
-        - MOP
-        - BRL
-        - KZT
-        - NOK
-        - SAR
-        - TRY
 
       - language?: string
 


### PR DESCRIPTION
엑심베이에서 지원하지 않는 통화코드가 결제 가능한 것으로 잘못 안내하고 있어
지원하지 않는 결제 통화는 제거합니다