### PR TITLE
V1 키움페이 상품권 결제수단 추가

### DIFF
--- a/src/routes/(root)/opi/ko/integration/pg/v1/daou/readme.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/daou/readme.mdx
@@ -93,6 +93,9 @@ import Parameter from "~/components/parameter/Parameter";
         - payco (페이코)
         - samsung (삼성페이)
         - applepay (애플페이)
+        - cultureland (문화상품권)
+        - smartculture (스마트문화상품권)
+        - booknlife (도서문화상품권)
 
       - merchant_uid: string
 

--- a/src/routes/(root)/opi/ko/integration/pg/v1/daou/undefined.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/daou/undefined.mdx
@@ -213,3 +213,11 @@ import Details from "~/components/gitbook/Details";
     초당 50건 이상의 비인증 결제 API가 호출될 경우 오류가 발생할 수 있습니다.
   </Details.Content>
 </Details>
+
+<Details>
+  <Details.Summary>도서문화상품권, 스마트문화상품권 거래는 부분취소 불가능</Details.Summary>
+
+  <Details.Content>
+    도서문화상품권, 스마트문화상품권 거래는 부분취소가 불가능하며 전체취소만 가능합니다.
+  </Details.Content>
+</Details>


### PR DESCRIPTION
포트원 V1 키움페이 상품권 결제 연동하여 관련 내용을 추가합니다.

250814 정기배포 후 머지해야합니다.