### PR TITLE
세금계산서 취소 API Title에서 역발행 단어 제거

### DIFF
--- a/src/schema/v2.openapi.json
+++ b/src/schema/v2.openapi.json
@@ -1148,8 +1148,8 @@
     },
     "/b2b/tax-invoices/{taxInvoiceKey}/cancel-issuance": {
       "post": {
-        "summary": "세금계산서 역발행 취소 (공급자에 의한 취소)",
-        "description": "세금계산서 역발행 취소 (공급자에 의한 취소)\n\n발행 완료된 세금계산서를 공급자가 국세청 전송 전에 취소합니다.",
+        "summary": "세금계산서 취소 (공급자에 의한 취소)",
+        "description": "세금계산서 취소 (공급자에 의한 취소)\n\n발행 완료된 세금계산서를 공급자가 국세청 전송 전에 취소합니다.",
         "operationId": "cancelB2bTaxInvoiceIssuance",
         "parameters": [
           {
@@ -1277,7 +1277,7 @@
           }
         ],
         "x-portone-category": "b2b.taxInvoice",
-        "x-portone-title": "세금계산서 역발행 취소 (공급자에 의한 취소)",
+        "x-portone-title": "세금계산서 취소 (공급자에 의한 취소)",
         "x-portone-description": "발행 완료된 세금계산서를 공급자가 국세청 전송 전에 취소합니다.",
         "x-portone-error": {
           "$ref": "#/components/schemas/CancelB2bTaxInvoiceIssuanceError"
@@ -17230,8 +17230,8 @@
         "x-portone-status-code": 409
       },
       "CancelB2bTaxInvoiceIssuanceBody": {
-        "title": "세금계산서 역발행 취소 정보",
-        "description": "세금계산서 역발행 취소 정보",
+        "title": "세금계산서 취소 정보",
+        "description": "세금계산서 취소 정보",
         "type": "object",
         "properties": {
           "memo": {
@@ -17239,7 +17239,7 @@
             "title": "메모"
           }
         },
-        "x-portone-title": "세금계산서 역발행 취소 정보"
+        "x-portone-title": "세금계산서 취소 정보"
       },
       "CancelB2bTaxInvoiceIssuanceError": {
         "title": "CancelB2bTaxInvoiceIssuanceError",
@@ -17280,8 +17280,8 @@
         }
       },
       "CancelB2bTaxInvoiceIssuanceResponse": {
-        "title": "세금계산서 역발행 취소 응답",
-        "description": "세금계산서 역발행 취소 응답",
+        "title": "세금계산서 취소 응답",
+        "description": "세금계산서 취소 응답",
         "type": "object",
         "required": [
           "taxInvoice"
@@ -17291,7 +17291,7 @@
             "$ref": "#/components/schemas/B2bTaxInvoice"
           }
         },
-        "x-portone-title": "세금계산서 역발행 취소 응답"
+        "x-portone-title": "세금계산서 취소 응답"
       },
       "CancelB2bTaxInvoiceRequestBody": {
         "title": "세금계산서 역발행 요청 취소 정보",

--- a/src/schema/v2.openapi.yml
+++ b/src/schema/v2.openapi.yml
@@ -905,9 +905,9 @@ paths:
         $ref: '#/components/schemas/GetB2bTaxInvoiceAttachmentsError'
   '/b2b/tax-invoices/{taxInvoiceKey}/cancel-issuance':
     post:
-      summary: 세금계산서 역발행 취소 (공급자에 의한 취소)
+      summary: 세금계산서 취소 (공급자에 의한 취소)
       description: |-
-        세금계산서 역발행 취소 (공급자에 의한 취소)
+        세금계산서 취소 (공급자에 의한 취소)
 
         발행 완료된 세금계산서를 공급자가 국세청 전송 전에 취소합니다.
       operationId: cancelB2bTaxInvoiceIssuance
@@ -1004,7 +1004,7 @@ paths:
         - bearerJwt: []
         - portOne: []
       x-portone-category: b2b.taxInvoice
-      x-portone-title: 세금계산서 역발행 취소 (공급자에 의한 취소)
+      x-portone-title: 세금계산서 취소 (공급자에 의한 취소)
       x-portone-description: 발행 완료된 세금계산서를 공급자가 국세청 전송 전에 취소합니다.
       x-portone-error:
         $ref: '#/components/schemas/CancelB2bTaxInvoiceIssuanceError'
@@ -12512,14 +12512,14 @@ components:
       x-portone-title: 결제 취소 금액이 취소 가능 금액을 초과한 경우
       x-portone-status-code: 409
     CancelB2bTaxInvoiceIssuanceBody:
-      title: 세금계산서 역발행 취소 정보
-      description: 세금계산서 역발행 취소 정보
+      title: 세금계산서 취소 정보
+      description: 세금계산서 취소 정보
       type: object
       properties:
         memo:
           type: string
           title: 메모
-      x-portone-title: 세금계산서 역발행 취소 정보
+      x-portone-title: 세금계산서 취소 정보
     CancelB2bTaxInvoiceIssuanceError:
       title: CancelB2bTaxInvoiceIssuanceError
       oneOf:
@@ -12541,15 +12541,15 @@ components:
           INVALID_REQUEST: '#/components/schemas/InvalidRequestError'
           UNAUTHORIZED: '#/components/schemas/UnauthorizedError'
     CancelB2bTaxInvoiceIssuanceResponse:
-      title: 세금계산서 역발행 취소 응답
-      description: 세금계산서 역발행 취소 응답
+      title: 세금계산서 취소 응답
+      description: 세금계산서 취소 응답
       type: object
       required:
         - taxInvoice
       properties:
         taxInvoice:
           $ref: '#/components/schemas/B2bTaxInvoice'
-      x-portone-title: 세금계산서 역발행 취소 응답
+      x-portone-title: 세금계산서 취소 응답
     CancelB2bTaxInvoiceRequestBody:
       title: 세금계산서 역발행 요청 취소 정보
       description: 세금계산서 역발행 요청 취소 정보


### PR DESCRIPTION
[요약]
세금계산서 정발행 API 기능이 업데이트 되면서, 취소 API Title에서 역발행 단어를 제거합니다.