### PR TITLE
docs:v1 카카오페이 부가세 지정 미지원 설명 유의사항 추가

### DIFF
--- a/src/routes/(root)/opi/ko/integration/pg/v1/kakaopay.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/kakaopay.mdx
@@ -7,6 +7,7 @@ versionVariants:
 ---
 
 import Figure from "~/components/Figure";
+import Details from "~/components/gitbook/Details";
 import Tabs from "~/components/gitbook/Tabs";
 import Hint from "~/components/Hint";
 import Parameter from "~/components/parameter/Parameter";
@@ -73,7 +74,7 @@ import Parameter from "~/components/parameter/Parameter";
           JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
         </Hint>
 
-      - pay_method?: string
+      - pay\_method?: string
 
         **결제수단 구분코드**
 
@@ -81,7 +82,7 @@ import Parameter from "~/components/parameter/Parameter";
 
         (호출 시 선택된 값은 무시되며 카카오페이 앱에서 신용카드와 카카오머니 중 선택한 옵션으로 설정됩니다.)
 
-      - merchant_uid: string
+      - merchant\_uid: string
 
         **주문번호**
 
@@ -154,7 +155,7 @@ import Parameter from "~/components/parameter/Parameter";
           JS SDK를 가장 최신 버전으로 업그레이드 후 `channelKey` 파라미터로 채널 설정(PG사 구분)을 대체해주세요.
         </Hint>
 
-      - customer_uid?: string
+      - customer\_uid?: string
 
         **카드 빌링키**
 
@@ -181,9 +182,20 @@ import Parameter from "~/components/parameter/Parameter";
   </Tabs.Tab>
 </Tabs>
 
-<Hint style="info">
-  ## 참고사항
+## 유의사항
 
+<Details>
+  <Details.Summary> 부가세 지정 미지원</Details.Summary>
+
+  <Details.Content>
+    - 카카오페이 결제 시 부가세 지정은 지원하지 않습니다.
+    - 카카오페이 결제 취소 시 부가세 지정은 지원하지 않습니다.
+  </Details.Content>
+</Details>
+
+## 참고사항
+
+<Hint style="info">
   - 카카오페이 결제버튼이 노출되는 것을 권장 합니다.
   - 카카오페이 고객사 사이니지 이미지를 [다운받아](http://biz.kakaopay.com/online/guide) 활용할 수 있습니다.
 
@@ -191,7 +203,7 @@ import Parameter from "~/components/parameter/Parameter";
 
   <Figure src="https://t1.daumcdn.net/kakaopay/biz-web-home/production/v1.0.0_1693458401577/static/media/img_online_guide_signage_ex.a406536b.png" />
 
-  - app_scheme 파라미터는 카카오페이 정책에 따라 iOS에서만 사용 가능합니다.
+  - app\_scheme 파라미터는 카카오페이 정책에 따라 iOS에서만 사용 가능합니다.
 </Hint>
 
 <Hint style="info">


### PR DESCRIPTION
<img width="824" height="229" alt="image" src="https://github.com/user-attachments/assets/cc56809d-532a-458e-9c05-aa84a5abd218" />


카카오페이 결제, 결제 취소 시 부가세 지정이 불가능함을 안내하는 내용 추가합니다.