### PR TITLE
docs:v1 본인인증 결과처리 가이드에서 생년월일 필드명이 잘못되어 수정합니다.

### DIFF
--- a/src/routes/(root)/opi/ko/extra/identity-verification/v1/all/3.mdx
+++ b/src/routes/(root)/opi/ko/extra/identity-verification/v1/all/3.mdx
@@ -93,7 +93,7 @@ app.post("/certifications", async (request, response) => {
 
 - `name`: 이름
 - `gender`: 성별
-- `birth`: 생년월일
+- `birthday`: 생년월일(YYYY-MM-DD)
 - `unique_key`: CI 값과 동일. 온라인 주민번호와 같은 개인고유식별키
 - `phone :`휴대폰 번호
 
@@ -107,9 +107,9 @@ app.post("/certifications", async (request, response) => {
     // imp_uid로 인증 정보 조회
     /* ...중략... */
     const certificationsInfo = getCertifications.data; // 조회한 인증 정보
-    const { name, birth } = certificationsInfo;
+    const { name, birthday } = certificationsInfo;
     // 연령 제한 로직
-    if (new Date(birth).getFullYear() <= 1999) {
+    if (new Date(birthday).getFullYear() <= 1999) {
       // 연령 만족
     } else {
       // 연령 미달

--- a/src/routes/(root)/opi/ko/extra/identity-verification/v1/credit-auth/4.mdx
+++ b/src/routes/(root)/opi/ko/extra/identity-verification/v1/credit-auth/4.mdx
@@ -83,7 +83,7 @@ app.post("/certifications", async (request, response) => {
 
 - `name`: 이름
 - `gender`: 성별
-- `birth`: 생년월일
+- `birthday`: 생년월일(YYYY-MM-DD)
 - `unique_key`: CI 값과 동일. 온라인 주민번호와 같은 개인고유식별키
 - `unique_in_site`: DI 값과 동일. 상점아이디(사이트)별로 할당되는 식별키
 
@@ -104,10 +104,10 @@ app.post("/certifications", async (request, response) => {
     /* ...중략... */
     const certificationsInfo = getCertifications.data; // 조회한 인증 정보
     // unique_key: 개인식별 고유 키, unique_in_site: 사이트 별 개인식별 고유 키
-    const { unique_key, unique_in_site, name, gender, birth } =
+    const { unique_key, unique_in_site, name, gender, birthday } =
       certificationsInfo;
     // 연령 제한 로직
-    if (new Date(birth).getFullYear() <= 1999) {
+    if (new Date(birthday).getFullYear() <= 1999) {
       // 연령 만족
     } else {
       // 연령 미달

--- a/src/routes/(root)/opi/ko/extra/identity-verification/v1/phone/4.mdx
+++ b/src/routes/(root)/opi/ko/extra/identity-verification/v1/phone/4.mdx
@@ -85,7 +85,7 @@ app.post("/certifications", async (request, response) => {
 
 - `name`: 이름
 - `gender`: 성별
-- `birth`: 생년월일
+- `birthday`: 생년월일(YYYY-MM-DD)
 - `unique_key`: CI 값과 동일. 온라인 주민번호와 같은 개인고유식별키
 - `unique_in_site`: DI 값과 동일. 상점아이디(사이트)별로 할당되는 식별키
 
@@ -119,10 +119,10 @@ app.post("/certifications", async (request, response) => {
     /* ...중략... */
     const certificationsInfo = getCertifications.data; // 조회한 인증 정보
     // unique_key: 개인식별 고유 키, unique_in_site: 사이트 별 개인식별 고유 키
-    const { unique_key, unique_in_site, name, gender, birth } =
+    const { unique_key, unique_in_site, name, gender, birthday } =
       certificationsInfo;
     // 연령 제한 로직
-    if (new Date(birth).getFullYear() <= 1999) {
+    if (new Date(birthday).getFullYear() <= 1999) {
       // 연령 만족
     } else {
       // 연령 미달


### PR DESCRIPTION
포트원 V1 본인인증 내역 조회 API의 응답에서 생년월일 필드명은 birthday입니다.
연동가이드에서 birth로 잘못 작성되어 있어 birthday로 수정합니다.