### PR TITLE
docs: v1: 키움페이 애플페이 다이렉트 추가

### DIFF
--- a/src/routes/(root)/opi/ko/integration/pg/v1/daou/readme.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/daou/readme.mdx
@@ -135,8 +135,6 @@ import Parameter from "~/components/parameter/Parameter";
 
         'Y'로 입력하는 경우 키움페이 화면이 노출되지 않고 바로 카드사, 간편결제 결제창이 호출됩니다.
 
-        결제수단이 **applepay** 인 경우는 지원하지 않습니다.
-
       - app_scheme?: string
 
         **모바일 앱 URL Scheme**


### PR DESCRIPTION
키움페이 간편결제 애플페이에서도 bypass.daou.DIRECT_YN 파라미터를 지원하여 
미지원 안내문구를 제거합니다.