### PR TITLE
페이먼트월 V1 문서에서 배송지등록 API 링크 및 설명 수정

### DIFF
--- a/src/routes/(root)/opi/ko/integration/pg/v1/paymentwall.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/paymentwall.mdx
@@ -266,9 +266,9 @@ import Parameter from "~/components/parameter/Parameter";
 <Hint style="danger">
   **배송정보 등록 API**
 
-  페이먼트월을 통한 이커머스(실물상품) 결제인 경우 아래 배송정보등록 API를 반드시 연동해야 합니다. 해당 API를 연동하지 않을 경우 정산 시 문제가 발생할 수 있습니다.
+  페이먼트월을 통한 이커머스(실물상품) 결제인 경우 아래 배송정보등록 API를 반드시 연동해야 합니다. 추후 차지백이 발생할 경우 해당 결제 건에 대해 고객사가 실물 상품 배송을 완료했다는 증빙 자료로 활용되어 차지백 대응에 활용됩니다.
 
-  [→ 페이먼트월 배송등록 API 바로가기](/api/rest-v1/pg.paymentwall)
+  [→ 페이먼트월 배송등록 API(Delivery Information Registration API) 바로가기](/api/rest-v1/pg.paymentwall?v=v1)
 </Hint>
 
 <Hint style="danger">


### PR DESCRIPTION
Updated the description and link for the Delivery Information Registration API in the Paymentwall integration documentation.