### PR TITLE
docs/v1: KCP 퀵페이 선불머니 제한 기능 목록 보완

### DIFF
--- a/src/routes/(root)/opi/ko/integration/pg/v1/nhn-kcp/kcp-quickpay.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/nhn-kcp/kcp-quickpay.mdx
@@ -462,6 +462,7 @@ KCP 퀵페이 기준으로 작성한 예시 코드는 아래와 같습니다.
             - PrepaidRefund: 선불머니 환급 요청 (사전 협의 필요)
             - PrepaidLimitRaise: 선불머니 보유한도 상향 요청 (사전 협의 필요)
             - PrepaidKYC: 선불머니 고객 확인 재이행 (사전 협의 필요)
+            - PrepaidAuth: 선불머니 결제 인증 (사전 협의 필요)
 
           - encryptedCI: string
 
@@ -628,10 +629,12 @@ KCP 퀵페이 기준으로 작성한 예시 코드는 아래와 같습니다.
     **제한 기능 목록:**
 
     - `SignUp`: 간편결제+선불머니 서비스 유저 등록
-    - `Leave`: 간편결제+선불머니 서비스 해지 (선불머니 환급 완료 후 진행 가능)
+    - `Leave`: 간편결제+선불머니 서비스 해지
     - `PrepaidRefundAccount`: 선불머니 환급계좌 등록 및 변경
     - `PrepaidRefund`: 선불머니 환급 요청
     - `PrepaidLimitRaise`: 선불머니 보유한도 상향 요청
+    - `PrepaidKYC`: 선불머니 고객 확인 재이행
+    - `PrepaidAuth`: 선불머니 결제 인증
   </Details.Content>
 </Details>
 
@@ -650,6 +653,7 @@ KCP 퀵페이 기준으로 작성한 예시 코드는 아래와 같습니다.
     - `PrepaidRefund`: 선불머니 환급 요청
     - `PrepaidLimitRaise`: 선불머니 보유한도 상향 요청
     - `PrepaidKYC`: 선불머니 고객 확인 재이행
+    - `PrepaidAuth`: 선불머니 결제 인증
 
     거래사전 등록 API를 호출하지 않은 상태에서 선불머니 기능을 요청하는 경우 에러가 발생할 수 있으니 유의하시기 바랍니다.
   </Details.Content>

--- a/src/schema/v1.openapi.json
+++ b/src/schema/v1.openapi.json
@@ -2081,6 +2081,30 @@
             "maxLength": 200,
             "x-portone-name": "요청자 검증 문자열",
             "x-portone-description": "요청자 검증을 위한 랜덤 문자열(code_verifier). 최대 200자"
+          },
+          {
+            "name": "prepaid_auth_yn",
+            "in": "formData",
+            "description": "선불머니 인증 사용 여부. actionType이 결제(Pay), PIN확인(PinCheck), 선불머니 인증 요청(PrepaidAuth)에서 사용 가능하며, Pay/PinCheck에서는 옵셔널, PrepaidAuth에서는 필수입니다. 'Y'인 경우 prepaid_amount가 필수입니다.",
+            "required": false,
+            "type": "string",
+            "maxLength": 1,
+            "enum": [
+              "Y",
+              "N"
+            ],
+            "x-portone-name": "선불머니 인증 여부",
+            "x-portone-description": "선불머니 인증 사용 여부. actionType이 결제(Pay), PIN확인(PinCheck), 선불머니 인증 요청(PrepaidAuth)에서 사용 가능하며, Pay/PinCheck에서는 옵셔널, PrepaidAuth에서는 필수입니다. 'Y'인 경우 prepaid_amount가 필수입니다."
+          },
+          {
+            "name": "prepaid_amount",
+            "in": "formData",
+            "description": "선불머니 결제 금액(최대 9자리 정수). actionType이 결제(Pay), PIN확인(PinCheck), 선불머니 인증 요청(PrepaidAuth)에서 사용 가능하며, Pay/PinCheck에서는 옵셔널, PrepaidAuth에서는 필수입니다. prepaid_auth_yn이 'Y'인 경우 필수입니다.",
+            "required": false,
+            "type": "integer",
+            "maxLength": 9,
+            "x-portone-name": "선불머니 결제 금액",
+            "x-portone-description": "선불머니 결제 금액(최대 9자리 정수). actionType이 결제(Pay), PIN확인(PinCheck), 선불머니 인증 요청(PrepaidAuth)에서 사용 가능하며, Pay/PinCheck에서는 옵셔널, PrepaidAuth에서는 필수입니다. prepaid_auth_yn이 'Y'인 경우 필수입니다."
           }
         ],
         "responses": {
@@ -2155,6 +2179,30 @@
             "maxLength": 200,
             "x-portone-name": "요청자 검증 문자열",
             "x-portone-description": "요청자 검증을 위한 랜덤 문자열(code_verifier). 최대 200자"
+          },
+          {
+            "name": "prepaid_auth_yn",
+            "in": "formData",
+            "description": "선불머니 인증 사용 여부. actionType이 결제(Pay), PIN확인(PinCheck), 선불머니 인증 요청(PrepaidAuth)에서 사용 가능하며, Pay/PinCheck에서는 옵셔널, PrepaidAuth에서는 필수입니다. 'Y'인 경우 prepaid_amount가 필수입니다.",
+            "required": false,
+            "type": "string",
+            "maxLength": 1,
+            "enum": [
+              "Y",
+              "N"
+            ],
+            "x-portone-name": "선불머니 인증 여부",
+            "x-portone-description": "선불머니 인증 사용 여부. actionType이 결제(Pay), PIN확인(PinCheck), 선불머니 인증 요청(PrepaidAuth)에서 사용 가능하며, Pay/PinCheck에서는 옵셔널, PrepaidAuth에서는 필수입니다. 'Y'인 경우 prepaid_amount가 필수입니다."
+          },
+          {
+            "name": "prepaid_amount",
+            "in": "formData",
+            "description": "선불머니 결제 금액(최대 9자리 정수). actionType이 결제(Pay), PIN확인(PinCheck), 선불머니 인증 요청(PrepaidAuth)에서 사용 가능하며, Pay/PinCheck에서는 옵셔널, PrepaidAuth에서는 필수입니다. prepaid_auth_yn이 'Y'인 경우 필수입니다.",
+            "required": false,
+            "type": "integer",
+            "maxLength": 9,
+            "x-portone-name": "선불머니 결제 금액",
+            "x-portone-description": "선불머니 결제 금액(최대 9자리 정수). actionType이 결제(Pay), PIN확인(PinCheck), 선불머니 인증 요청(PrepaidAuth)에서 사용 가능하며, Pay/PinCheck에서는 옵셔널, PrepaidAuth에서는 필수입니다. prepaid_auth_yn이 'Y'인 경우 필수입니다."
           }
         ],
         "responses": {

--- a/src/schema/v1.openapi.yml
+++ b/src/schema/v1.openapi.yml
@@ -1809,6 +1809,37 @@ paths:
           maxLength: 200
           x-portone-name: 요청자 검증 문자열
           x-portone-description: 요청자 검증을 위한 랜덤 문자열(code_verifier). 최대 200자
+        - name: prepaid_auth_yn
+          in: formData
+          description: >-
+            선불머니 인증 사용 여부. actionType이 결제(Pay), PIN확인(PinCheck), 선불머니 인증
+            요청(PrepaidAuth)에서 사용 가능하며, Pay/PinCheck에서는 옵셔널, PrepaidAuth에서는
+            필수입니다. 'Y'인 경우 prepaid_amount가 필수입니다.
+          required: false
+          type: string
+          maxLength: 1
+          enum:
+            - 'Y'
+            - 'N'
+          x-portone-name: 선불머니 인증 여부
+          x-portone-description: >-
+            선불머니 인증 사용 여부. actionType이 결제(Pay), PIN확인(PinCheck), 선불머니 인증
+            요청(PrepaidAuth)에서 사용 가능하며, Pay/PinCheck에서는 옵셔널, PrepaidAuth에서는
+            필수입니다. 'Y'인 경우 prepaid_amount가 필수입니다.
+        - name: prepaid_amount
+          in: formData
+          description: >-
+            선불머니 결제 금액(최대 9자리 정수). actionType이 결제(Pay), PIN확인(PinCheck), 선불머니 인증
+            요청(PrepaidAuth)에서 사용 가능하며, Pay/PinCheck에서는 옵셔널, PrepaidAuth에서는
+            필수입니다. prepaid_auth_yn이 'Y'인 경우 필수입니다.
+          required: false
+          type: integer
+          maxLength: 9
+          x-portone-name: 선불머니 결제 금액
+          x-portone-description: >-
+            선불머니 결제 금액(최대 9자리 정수). actionType이 결제(Pay), PIN확인(PinCheck), 선불머니 인증
+            요청(PrepaidAuth)에서 사용 가능하며, Pay/PinCheck에서는 옵셔널, PrepaidAuth에서는
+            필수입니다. prepaid_auth_yn이 'Y'인 경우 필수입니다.
       responses:
         '200':
           description: 정상 수정
@@ -1864,6 +1895,37 @@ paths:
           maxLength: 200
           x-portone-name: 요청자 검증 문자열
           x-portone-description: 요청자 검증을 위한 랜덤 문자열(code_verifier). 최대 200자
+        - name: prepaid_auth_yn
+          in: formData
+          description: >-
+            선불머니 인증 사용 여부. actionType이 결제(Pay), PIN확인(PinCheck), 선불머니 인증
+            요청(PrepaidAuth)에서 사용 가능하며, Pay/PinCheck에서는 옵셔널, PrepaidAuth에서는
+            필수입니다. 'Y'인 경우 prepaid_amount가 필수입니다.
+          required: false
+          type: string
+          maxLength: 1
+          enum:
+            - 'Y'
+            - 'N'
+          x-portone-name: 선불머니 인증 여부
+          x-portone-description: >-
+            선불머니 인증 사용 여부. actionType이 결제(Pay), PIN확인(PinCheck), 선불머니 인증
+            요청(PrepaidAuth)에서 사용 가능하며, Pay/PinCheck에서는 옵셔널, PrepaidAuth에서는
+            필수입니다. 'Y'인 경우 prepaid_amount가 필수입니다.
+        - name: prepaid_amount
+          in: formData
+          description: >-
+            선불머니 결제 금액(최대 9자리 정수). actionType이 결제(Pay), PIN확인(PinCheck), 선불머니 인증
+            요청(PrepaidAuth)에서 사용 가능하며, Pay/PinCheck에서는 옵셔널, PrepaidAuth에서는
+            필수입니다. prepaid_auth_yn이 'Y'인 경우 필수입니다.
+          required: false
+          type: integer
+          maxLength: 9
+          x-portone-name: 선불머니 결제 금액
+          x-portone-description: >-
+            선불머니 결제 금액(최대 9자리 정수). actionType이 결제(Pay), PIN확인(PinCheck), 선불머니 인증
+            요청(PrepaidAuth)에서 사용 가능하며, Pay/PinCheck에서는 옵셔널, PrepaidAuth에서는
+            필수입니다. prepaid_auth_yn이 'Y'인 경우 필수입니다.
       responses:
         '200':
           description: 정상 등록


### PR DESCRIPTION
## Summary

- KCP 퀵페이 `actionType` 파라미터 문서에 `PrepaidAuth` (선불머니 결제 인증) 항목 추가
- 선불머니 서비스 이용 제한 안내의 제한 기능 목록에 `PrepaidLimitRaise`, `PrepaidKYC`, `PrepaidAuth` 항목 추가
- `Leave` 항목 설명 간소화

## Test plan

- [ ] 빌드 후 KCP 퀵페이 문서 페이지에서 actionType 목록 및 제한 기능 안내가 정상 렌더링되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)