### PR TITLE
kcp 네이버페이 허브형 pay_method 추가

### DIFF
--- a/src/routes/(root)/opi/ko/integration/pg/v1/nhn-kcp/readme.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/nhn-kcp/readme.mdx
@@ -42,7 +42,8 @@ import Parameter from "~/components/parameter/Parameter";
     - 페이코 : `payco`
     - L페이 : `lpay`
     - 카카오페이 : `kakaopay`
-    - 네이버페이 : `naverpay`
+    - 네이버페이(카드결제 호출) : `naverpay`
+    - 네이버페이(카드, 포인트 선택창 호출) : `naverpay_bridge`
     - 애플페이 : `applepay`
     - 토스페이 : `tosspay`
 
@@ -148,7 +149,8 @@ KCP 기준으로 작성한 예시 코드는 아래와 같습니다.
     - `payco` (페이코)
     - `lpay` (L페이)
     - `kakaopay` (카카오페이)
-    - `naverpay` (네이버페이)
+    - `naverpay` (네이버페이 카드결제)
+    - `naverpay_bridge` (네이버페이 카드/포인트결제)
     - `samsung` (삼성페이)
     - `ssgpay` (SSG페이)
     - `applepay` (애플페이)


### PR DESCRIPTION
카드결제 호출과 카드/포인트 결제 선택창 호출 코드가 구분되어 있는데, 누락되어 있어서 추가