### PR TITLE
V1 네이버페이 지원 중단 파라미터 설명 제거

### DIFF
--- a/src/routes/(root)/opi/ko/integration/pg/v1/naver.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/naver.mdx
@@ -387,17 +387,6 @@ callback) 호출 후 **callback** 으로 수신 되며
         **리다이렉트 URL**
 
         리디렉션 방식으로 진행(`naverPopupMode`: **false**)할 경우 결제 완료 후 리디렉션 될 URL
-
-      - naverActionType?: string
-
-        **신규 등록/수단 변경 여부**
-
-        네이버페이를 통해 발급한 빌링키의 결제 수단을 변경하고자 하는 경우 포트원 빌링키인 `customer_uid`를 동일하게 입력하고, `naverActionType` 파라미터를 `CHANGE`로 입력하여 빌링키를 재발급해야 합니다.
-
-        `naverActionType` 파라미터를 이용하지 않고 동일한 고객의 정보로 추가 빌링키를 발급 시도하면 이전의 결제 수단 정보가 구매자의 네이버페이 계정에 그대로 남아있어 문제가 발생할 수 있습니다.
-
-        - `NEW`(default) : 신규 등록
-        - `CHANGE` 결제 수단 변경
     </Parameter>
 
     <br/>


### PR DESCRIPTION
지원 중단되는 V1 네이버페이 `naverActionType` 파라미터에 대한 설명을 삭제합니다.