### PR TITLE
ci: GitHub Actions 보안 취약점 수정 (zizmor)

### DIFF
--- a/.github/workflows/server-sdk.yml
+++ b/.github/workflows/server-sdk.yml
@@ -55,7 +55,7 @@ jobs:
         working-directory: sdk/codegen
 
       - name: Install Python
-        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: "3.9"
 


### PR DESCRIPTION
## 개요

[zizmor](https://github.com/woodruffw/zizmor)로 GitHub Actions 워크플로우 보안 감사를 수행하고 자동 수정 가능한 항목을 적용했습니다.

## 수정 내용

- **ref-version-mismatch**: `actions/setup-python` 액션의 버전 주석을 `v5`에서 `v5.4.0`으로 정확하게 수정