### PR TITLE
fix: 블로그 앵커를 solid-router A 기반 ProseAnchor로 통일

### DIFF
--- a/src/components/ProseAnchor.tsx
+++ b/src/components/ProseAnchor.tsx
@@ -1,0 +1,20 @@
+import { A } from "@solidjs/router";
+import { createMemo, type JSX, splitProps } from "solid-js";
+import { Dynamic } from "solid-js/web";
+
+export default function ProseAnchor(props: JSX.IntrinsicElements["a"]) {
+  const [local, others] = splitProps(props, ["children", "href"]);
+
+  const isExternalLink = createMemo(() => {
+    if (!local.href) return false;
+    return /^(mailto|tel):/i.test(local.href);
+  });
+
+  const component = createMemo(() => (isExternalLink() ? "a" : A));
+
+  return (
+    <Dynamic component={component()} {...others} href={local.href ?? "#"}>
+      {local.children}
+    </Dynamic>
+  );
+}

--- a/src/components/blog/prose.tsx
+++ b/src/components/blog/prose.tsx
@@ -1,6 +1,8 @@
 import { clsx } from "clsx";
 import { type JSX, splitProps } from "solid-js";
 
+import ProseAnchor from "~/components/ProseAnchor";
+
 export function h1(props: JSX.HTMLAttributes<HTMLHeadingElement>) {
   const [locals, others] = splitProps(props, ["class", "children"]);
   return (
@@ -100,15 +102,14 @@ export function p(props: JSX.HTMLAttributes<HTMLParagraphElement>) {
   );
 }
 
-export function a(props: JSX.HTMLAttributes<HTMLAnchorElement>) {
-  const [locals, others] = splitProps(props, ["class", "children"]);
+export function a(props: JSX.IntrinsicElements["a"]) {
+  const [locals, others] = splitProps(props, ["class"]);
+
   return (
-    <a
+    <ProseAnchor
       {...others}
       class={clsx("cursor-pointer underline hover:text-slate-9", locals.class)}
-    >
-      {locals.children}
-    </a>
+    />
   );
 }
 

--- a/src/components/prose.tsx
+++ b/src/components/prose.tsx
@@ -1,13 +1,7 @@
-import { A } from "@solidjs/router";
 import { clsx } from "clsx";
-import {
-  createContext,
-  createMemo,
-  type JSX,
-  splitProps,
-  useContext,
-} from "solid-js";
-import { Dynamic } from "solid-js/web";
+import { createContext, type JSX, splitProps, useContext } from "solid-js";
+
+import ProseAnchor from "~/components/ProseAnchor";
 
 export const ProseContext = createContext<{
   styles: Partial<
@@ -141,32 +135,17 @@ function p(props: JSX.IntrinsicElements["p"]) {
 
 function a(props: JSX.IntrinsicElements["a"]) {
   const { styles } = useContext(ProseContext);
-  const [local, others] = splitProps(props, ["children", "class", "href"]);
-
-  const cls = createMemo(() => {
-    return clsx(
-      "cursor-pointer text-orange-5 hover:text-orange-7 hover:underline",
-      local.class,
-    );
-  });
-
-  const isExternalLink = createMemo(() => {
-    if (!local.href) return false;
-    return /^(mailto|tel):/i.test(local.href);
-  });
-
-  const component = createMemo(() => (isExternalLink() ? "a" : A));
+  const [local, others] = splitProps(props, ["class"]);
 
   return (
-    <Dynamic
-      component={component()}
+    <ProseAnchor
       {...others}
-      href={local.href ?? "#"}
-      class={cls()}
+      class={clsx(
+        "cursor-pointer text-orange-5 hover:text-orange-7 hover:underline",
+        local.class,
+      )}
       style={styles.a}
-    >
-      {local.children}
-    </Dynamic>
+    />
   );
 }
 


### PR DESCRIPTION
#1095 와 같은 문제의 근본 원인 수정입니다.

블로그 prose의 `a`는 네이티브 `<a>`를 그대로 렌더링해 `../v2-zio` 같은 상대 링크가 브라우저 표준 해석으로 `/blog/posts/v2-zio`(404)가 됐습니다. 문서 쪽은 solid-router `<A>`를 사용해 정상 작동했습니다.

공통 로직을 `ProseAnchor` 컴포넌트로 추출하고 문서·블로그 `a`가 이를 사용하도록 통일했습니다. MDX 수정 없이 기존 `../v2-zio` 링크가 올바르게 해석되며, lint(`remark-lint-local-links-valid`)와 런타임의 해석도 일치하게 됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)