### PR TITLE
docs: update checkout color schema descriptions

### DIFF
--- a/src/schema/v2.openapi.json
+++ b/src/schema/v2.openapi.json
@@ -36892,15 +36892,18 @@
         "properties": {
           "primary": {
             "type": "string",
-            "title": "주 색상"
+            "title": "주 색상",
+            "description": "CSS 색 문자열 형식"
           },
           "primaryHover": {
             "type": "string",
-            "title": "호버 주 색상"
+            "title": "호버 주 색상",
+            "description": "CSS 색 문자열 형식"
           },
           "primaryLight": {
             "type": "string",
-            "title": "밝은 주 색상"
+            "title": "밝은 주 색상",
+            "description": "CSS 색 문자열 형식"
           }
         },
         "x-portone-title": "체크아웃 페이지 색 설정"

--- a/src/schema/v2.openapi.yml
+++ b/src/schema/v2.openapi.yml
@@ -27513,12 +27513,15 @@ components:
         primary:
           type: string
           title: 주 색상
+          description: CSS 색 문자열 형식
         primaryHover:
           type: string
           title: 호버 주 색상
+          description: CSS 색 문자열 형식
         primaryLight:
           type: string
           title: 밝은 주 색상
+          description: CSS 색 문자열 형식
       x-portone-title: 체크아웃 페이지 색 설정
     PaymentSessionProduct:
       title: 결제 세션 주문 항목


### PR DESCRIPTION
## Summary
- Add CSS color string descriptions to checkout page color schema fields.
- Keep JSON and YAML OpenAPI schema files in sync.

## Validation
- git diff --check -- src/schema/v2.openapi.json src/schema/v2.openapi.yml