### PR TITLE
docs(v1): KCP 퀵페이 sdkVersion 순수 버전 토큰 계약으로 정정

### DIFF
--- a/src/routes/(root)/opi/ko/integration/pg/v1/nhn-kcp/kcp-quickpay.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/nhn-kcp/kcp-quickpay.mdx
@@ -566,9 +566,10 @@ KCP 퀵페이 기준으로 작성한 예시 코드는 아래와 같습니다.
 
             **퀵페이 SDK 버전 식별자**
 
-            로드할 KCP 퀵페이 SDK(`qpay_web.js`)의 버전을 지정합니다.
+            로드할 KCP 퀵페이 SDK의 버전을 지정합니다. KCP와 사전 협의하여 전달받은 버전 토큰(예: `v2`)만 입력합니다.
 
-            - 입력하지 않으면 채널에 설정된 기본 버전이 사용됩니다.
+            - 입력하지 않으면 기본 SDK가 로드됩니다.
+            - 버전 토큰만 입력하며, 앞에 `_` 등 구분자나 파일명을 붙이지 않습니다.
             - 영문자, 숫자, `_`, `-` 조합만 허용되며, 그 외 형식의 값을 입력하면 요청이 실패합니다.
 
           - prepaidOfflinePaymentInfoRequest?: object
@@ -735,8 +736,8 @@ KCP 퀵페이 기준으로 작성한 예시 코드는 아래와 같습니다.
   <Details.Summary>생체인증(FIDO) 및 SDK 버전 지정 안내</Details.Summary>
 
   <Details.Content>
-    생체인증(FIDO) 등록(actionType:`RegisterFido`)을 비롯한 일부 기능은 특정 버전의 퀵페이 SDK(`qpay_web.js`)에서만 동작합니다.
-    이 경우 KCP와 사전 협의 후 전달받은 SDK 버전 식별자를 `bypass.kcpQuick.sdkVersion`에 입력하여 해당 버전의 SDK를 로드할 수 있습니다.
+    생체인증(FIDO) 등록(actionType:`RegisterFido`)을 비롯한 일부 기능은 특정 버전의 퀵페이 SDK에서만 동작합니다.
+    이 경우 KCP와 사전 협의 후 전달받은 버전 토큰(예: `v2`)을 `bypass.kcpQuick.sdkVersion`에 입력하여 해당 버전의 SDK를 로드할 수 있습니다.
 
     ```ts
     IMP.request_pay(
@@ -749,7 +750,7 @@ KCP 퀵페이 기준으로 작성한 예시 코드는 아래와 같습니다.
             actionType: "RegisterFido",
             encryptedCI: "encrypted_ci",
             memberID: "use_your_unique_id",
-            sdkVersion: "kcp_provided_version", // KCP와 협의하여 전달받은 값
+            sdkVersion: "v2", // KCP와 협의하여 전달받은 버전 토큰
           },
         },
         m_redirect_url: "https://redirection.url",
@@ -760,7 +761,7 @@ KCP 퀵페이 기준으로 작성한 예시 코드는 아래와 같습니다.
     );
     ```
 
-    `sdkVersion`을 입력하지 않으면 채널에 설정된 기본 버전이 사용됩니다.
+    `sdkVersion`을 입력하지 않으면 기본 SDK가 로드됩니다. 버전 토큰만 입력하며, 앞에 `_` 등 구분자를 붙이지 않습니다.
     허용되지 않는 형식(영문자, 숫자, `_`, `-` 외)의 값을 입력하면 요청이 실패하니 유의하시기 바랍니다.
   </Details.Content>
 </Details>


### PR DESCRIPTION
## 작업 요약
KCP 가 최종 확정한 퀵페이 SDK URL 스킴(`qpay_web{_version}.js`)과 pay-iamport 백엔드 계약(portone-io/pay-iamport#1280)에 맞춰, 이미 배포된 `bypass.kcpQuick.sdkVersion` 안내를 정정합니다.

## 배경
`sdkVersion` 값 계약을 **순수 버전 토큰**(예: `v2`)으로 확정했습니다. 가맹점은 버전 토큰만 입력하고, KCP 파일명 구분자(`_`)는 백엔드가 부착합니다. 기존 문서는 값을 `kcp_provided_version`(불투명 값)으로, 기본값을 "채널에 설정된 기본 버전"으로 안내하고 있어 실제 동작과 어긋났습니다.

## 변경 내용
- `sdkVersion` 파라미터 설명: 버전 토큰(예: `v2`)만 입력, 구분자/파일명 미포함, 미입력 시 기본 SDK 로드로 정정
- 생체인증(FIDO)·SDK 버전 안내 섹션: 예시값 `kcp_provided_version` → `v2`, "채널 기본 버전" → "기본 SDK 로드"
- 내부 SDK 파일명(`qpay_web.js`) 직접 노출 문구 제거

## 리뷰 포인트
- 공개 문서 특성상 KCP 내부 파일 네이밍(`qpay_web_v2.js`, `_` 부착 로직)은 노출하지 않고 가맹점 입력값 관점으로만 기술했습니다.

관련: portone-io/pay-iamport#1280, OPI-1471