### PR TITLE
fix: V2 빌링결제 리커버리 설명 warning, deprecated로 수정

### DIFF
--- a/src/routes/(root)/opi/ko/console/guide/billing-payments.mdx
+++ b/src/routes/(root)/opi/ko/console/guide/billing-payments.mdx
@@ -112,7 +112,12 @@ import Image4 from "../_assets/schedule.png";
 </VersionGate>
 
 <VersionGate v="v2">
-  빌링키 결제 API 및 결제 예약 API를 이용한 결제 건 중 결제 실패 상태인 거래 건에 한하여 리커버리 기능을 사용할 수 있습니다.
+  <Hint style="warning">
+    리커버리 기능은 종료 예정으로, 사용을 권장하지 않습니다.
+    결제 실패 건에 대한 재시도가 필요한 경우
+    [결제 예약 API](/api/rest-v2/payment.paymentSchedule?v=v2#post%20%2Fpayments%2F%7BpaymentId%7D%2Fschedule)를
+    통해 자체적으로 구현해 주시기 바랍니다.
+  </Hint>
 </VersionGate>
 
 ### 상태별 상세조회


### PR DESCRIPTION
빌링결제 내역 조회 페이지의 리커버리 섹션(V1, V2)에서 사용 조건 안내를 `<Hint style="warning">`으로 감싸 시각적으로 강조합니다.