### PR TITLE
키움페이 할부개월수 파라미터(display.card_quota) 설명 수정

### DIFF
--- a/src/routes/(root)/opi/ko/integration/pg/v1/daou/readme.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v1/daou/readme.mdx
@@ -303,7 +303,7 @@ import Parameter from "~/components/parameter/Parameter";
     ```json
     {
       "display": {
-        "card_quota": [6] // 할부개월 6개월까지만 활성화
+        "card_quota": [0, 2, 3, 4, 5, 6] // 할부개월 6개월까지만 활성화
       }
     }
     ```
@@ -322,9 +322,9 @@ import Parameter from "~/components/parameter/Parameter";
 
             예시
 
-            - `[]`: 일시불만 결제 가능
-            - `2,3,4,5,6`: 일시불을 포함한 2, 3, 4, 5, 6개월까지 할부개월 선택 가능
-            - `3`: 일시불을 포함한 2,3개월까지 할부개월 선택 가능
+            - `[0]`: 일시불만 결제 가능
+            - `[0,2,3,4,5,6]`: 일시불을 포함한 2, 3, 4, 5, 6개월까지 할부개월 선택 가능
+            - `[0,2,3]`: 일시불을 포함한 2,3개월까지 할부개월 선택 가능
         </Parameter.Details>
     </Parameter>
 


### PR DESCRIPTION
V1 키움페이 연동 가이드 내 할부개월수 관련 파라미터(`display.card_quota`) 설명이 실제 동작과 상이하여
실제 동작 방식과 동일하게 설명 및 예시를 업데이트하였습니다.