### PR TITLE
docs: KCP V2 SDK 본인인증 이용 시 유의사항 추가

### DIFF
--- a/src/routes/(root)/opi/ko/integration/pg/v2/kcp-v2-identity-verification.mdx
+++ b/src/routes/(root)/opi/ko/integration/pg/v2/kcp-v2-identity-verification.mdx
@@ -20,6 +20,14 @@ import Parameter from "~/components/parameter/Parameter";
 
 - [본인인증 연동하기](/opi/ko/extra/identity-verification/readme-v2) 페이지의 내용을 참고하여 연동을 진행합니다.
 
+<Hint style="warning">
+  SDK 방식으로 본인인증을 이용하기 위해서는 KCP 관리자 페이지에서 신규 연동방식(V2) 설정이 되어 있어야 합니다.
+
+  partner.kcp.co.kr > \[부가서비스] > \[휴대폰본인확인] > \[연동방식 설정] 에서 **신규 연동방식(V2) 사용여부**를 **사용**으로 설정해주세요.
+
+  설정하지 않을 경우 `requestIdentityVerification`의 응답으로 `pgCode`가 `CS24`, `pgMessage`가 `정보조회가 올바르지 않습니다.`와 같은 오류가 발생할 수 있습니다.
+</Hint>
+
 ## API 방식으로 본인인증하기
 
 - [본인인증 관련 API](/api/rest-v2/identityVerification) 페이지의 내용을 참고하여 연동을 진행합니다.


### PR DESCRIPTION
KCP V2 SDK방식의 본인인증 사용 시 PG사 에러코드 "CS24"와 함께 인증에 실패한다는 문의가 빈번하게 인입됩니다.
원인은 모두 KCP 파트너센터 설정이 되어있지 않아 발생하는 것으로 동일한 문의가 반복되어 인입되지 않도록
개발자센터에 안내 문구를 추가합니다.